### PR TITLE
[Fixed] DefaultPlcWriteRequest wrong return item for DefaultPlcWriteRequest.Builder addItem on Type Byte[]

### DIFF
--- a/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/messages/DefaultPlcWriteRequest.java
+++ b/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/messages/DefaultPlcWriteRequest.java
@@ -209,12 +209,12 @@ public class DefaultPlcWriteRequest implements InternalPlcWriteRequest, Internal
 
         @Override
         public Builder addItem(String name, String fieldQuery, byte[]... values) {
-            return addItem(name, fieldQuery, values, fieldHandler::encodeDateTime);
+            return addItem(name, fieldQuery, values, fieldHandler::encodeByteArray);
         }
 
         @Override
         public Builder addItem(String name, String fieldQuery, Byte[]... values) {
-            return addItem(name, fieldQuery, values, fieldHandler::encodeDateTime);
+            return addItem(name, fieldQuery, values, fieldHandler::encodeByteArray);
         }
 
         @Override


### PR DESCRIPTION
[Fixed] DefaultPlcWriteRequest returns for the types Byte[] and byte[] the wrong handle function "encodeDateTime" it become changed to "encodeByteArray"