### PR TITLE
Activate analysis on SonarCloud

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -156,6 +156,19 @@ pipeline {
             }
         }
 
+        stage('Code Quality on SonarCloud') {
+            when {
+                branch 'develop'
+            }
+            steps {
+                echo 'Checking Code Quality on SonarCloud'
+                def sonarcloudParams="-Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache_plc4x -Dsonar.branch.name=develop"
+                withCredentials([string(credentialsId: 'chris-sonarcloud-token', variable: 'SONAR_TOKEN')]) {
+                    sh 'mvn -P${JENKINS_PROFILE},with-java,with-dotnet,with-python,with-proxies sonar:sonar ${sonarcloudParams}'
+                }
+            }
+        }
+        
         stage('Deploy') {
             when {
                 branch 'develop'


### PR DESCRIPTION
Adding a new stage to activate code analysis on SonarCloud:
* Restrict the analysis for the `develop` branch.
  * It's easy to activate analysis for other branches: set the `sonar.branch.name` parameter to `${BRANCH_NAME}` and get rid of the `when ... steps ...` part
* Specifies the 3 mandatory properties for SonarCloud (`sonar.host.url`, `sonar.organization`, `sonar.projectKey`)
  * These can be set in the pom.xml file at a later stage, when the `ASF Sonar Analysis` stage is removed to stop pushing analyses on the ASF SonarQube instance
* @chrisdutz needs to set his SonarCloud token as a `chris-sonarcloud-token` credential, available for the build definition

If the analysis fails, you may need to remove the `with-dotnet` profile because SonarCloud can analyze C# code only using the Scanner for MSBuild (we'll see that later).

Once a first analysis is successful on SonarCloud, the `ASF Sonar Analysis` stage can be dropped, and we can go further with C# and C++.