### PR TITLE
PLC4X-86 - Fix and re-enable tests that were disabled for Java 11 support

### DIFF
--- a/plc4j/drivers/ads/src/test/java/org/apache/plc4x/java/ads/connection/AdsAbstractPlcConnectionTest.java
+++ b/plc4j/drivers/ads/src/test/java/org/apache/plc4x/java/ads/connection/AdsAbstractPlcConnectionTest.java
@@ -55,8 +55,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
@@ -273,11 +275,12 @@ class AdsAbstractPlcConnectionTest implements WithAssertions {
             assertNotNull(amsPort);
         }
 
-        // TODO: Commented out as it was causing problems with Java 11
-        /*@Test
+
+        @Test
         void getFromFuture() throws Exception {
             runInThread(() -> {
                 CompletableFuture completableFuture = mock(CompletableFuture.class, RETURNS_DEEP_STUBS);
+                when(completableFuture.get(any(long.class), any(TimeUnit.class))).thenReturn(new Object());
                 Object fromFuture = SUT.getFromFuture(completableFuture, 1);
                 assertNotNull(fromFuture);
             });
@@ -297,7 +300,7 @@ class AdsAbstractPlcConnectionTest implements WithAssertions {
                 assertThrows(PlcRuntimeException.class, () -> SUT.getFromFuture(completableFuture, 1));
             });
             assertFalse("The current Thread should not be interrupted", Thread.currentThread().isInterrupted());
-        }*/
+        }
 
         /**
          * Runs tests steps in a dedicated {@link Thread} so a possible {@link InterruptedException} doesn't lead to a

--- a/plc4j/drivers/ads/src/test/java/org/apache/plc4x/java/ads/connection/AdsTcpPlcConnectionTests.java
+++ b/plc4j/drivers/ads/src/test/java/org/apache/plc4x/java/ads/connection/AdsTcpPlcConnectionTests.java
@@ -21,18 +21,30 @@ package org.apache.plc4x.java.ads.connection;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.plc4x.java.ads.api.commands.AdsAddDeviceNotificationResponse;
 import org.apache.plc4x.java.ads.api.commands.AdsDeleteDeviceNotificationResponse;
+import org.apache.plc4x.java.ads.api.commands.AdsDeviceNotificationRequest;
+import org.apache.plc4x.java.ads.api.commands.types.AdsNotificationSample;
+import org.apache.plc4x.java.ads.api.commands.types.AdsStampHeader;
+import org.apache.plc4x.java.ads.api.commands.types.Data;
+import org.apache.plc4x.java.ads.api.commands.types.Length;
 import org.apache.plc4x.java.ads.api.commands.types.NotificationHandle;
 import org.apache.plc4x.java.ads.api.commands.types.Result;
+import org.apache.plc4x.java.ads.api.commands.types.Stamps;
+import org.apache.plc4x.java.ads.api.commands.types.TimeStamp;
+import org.apache.plc4x.java.ads.api.generic.AmsHeader;
 import org.apache.plc4x.java.ads.api.generic.types.AmsNetId;
 import org.apache.plc4x.java.ads.api.generic.types.AmsPort;
 import org.apache.plc4x.java.ads.model.AdsDataType;
 import org.apache.plc4x.java.ads.model.AdsSubscriptionHandle;
 import org.apache.plc4x.java.ads.model.DirectAdsField;
+import org.apache.plc4x.java.ads.protocol.Plc4x2AdsProtocol;
+import org.apache.plc4x.java.api.messages.PlcSubscriptionEvent;
 import org.apache.plc4x.java.api.types.PlcSubscriptionType;
 import org.apache.plc4x.java.base.messages.*;
+import org.apache.plc4x.java.base.model.InternalPlcConsumerRegistration;
 import org.apache.plc4x.java.base.model.SubscriptionPlcField;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.AfterEach;
@@ -40,6 +52,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -51,6 +65,9 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -135,17 +152,16 @@ class AdsTcpPlcConnectionTests implements WithAssertions {
         }
     }
 
-    // TODO: Commented out as it was causing problems with Java 11
-    /*@Nested
+    @Nested
     class Registration {
         @Captor
         ArgumentCaptor<Consumer<AdsDeviceNotificationRequest>> consumerArgumentCaptor;
 
         @Test
-        @Disabled("This test seems to be causing problems in Java 11")
         void register() throws Exception {
             Plc4x2AdsProtocol plc4x2AdsProtocol = mock(Plc4x2AdsProtocol.class);
-            when(channelMock.pipeline().get(Plc4x2AdsProtocol.class)).thenReturn(plc4x2AdsProtocol);
+            // (Class<ChannelHandler>) (Object) -> https://bugs.eclipse.org/bugs/show_bug.cgi?id=535853
+            when(channelMock.pipeline().get((Class<ChannelHandler>) (Object) Plc4x2AdsProtocol.class)).thenReturn(plc4x2AdsProtocol);
 
             AtomicReference<PlcSubscriptionEvent> plcSubscriptionEventAtomicReference = new AtomicReference<>();
             SUT.register(plcSubscriptionEventAtomicReference::set);
@@ -160,7 +176,7 @@ class AdsTcpPlcConnectionTests implements WithAssertions {
         void unregister() {
             SUT.unregister(mock(InternalPlcConsumerRegistration.class));
         }
-    }*/
+    }
 
     @Nested
     class Misc {

--- a/plc4j/integrations/apache-camel/pom.xml
+++ b/plc4j/integrations/apache-camel/pom.xml
@@ -93,12 +93,13 @@
       <version>0.5.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
-    <!--dependency>
+    <dependency>
+      <!-- avoids java.lang.NoClassDefFoundError: javax/activation/DataHandler in Plc4XProducerTest on Java 11-->
       <groupId>javax.activation</groupId>
       <artifactId>javax.activation-api</artifactId>
       <version>1.2.0</version>
       <scope>test</scope>
-    </dependency-->
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/plc4j/integrations/apache-camel/src/test/java/org/apache/plc4x/camel/Plc4XProducerTest.java
+++ b/plc4j/integrations/apache-camel/src/test/java/org/apache/plc4x/camel/Plc4XProducerTest.java
@@ -53,15 +53,14 @@ public class Plc4XProducerTest {
         when(endpointMock.getPlcDriverManager()).thenReturn(plcDriverManagerMock);
         SUT = new Plc4XProducer(endpointMock);
         testExchange = mock(Exchange.class, RETURNS_DEEP_STUBS);
-        // TODO: Commented out as it was causing problems with Java 11
-/*        when(testExchange.getIn().getHeader(eq(Constants.FIELD_NAME_HEADER), eq(String.class)))
+
+        when(testExchange.getIn().getHeader(eq(Constants.FIELD_NAME_HEADER), eq(String.class)))
             .thenReturn("Hurz");
         when(testExchange.getIn().getHeader(eq(Constants.FIELD_QUERY_HEADER), eq(String.class)))
-            .thenReturn("PlcField.class");*/
+            .thenReturn("PlcField.class");
     }
 
-    // TODO: Commented out as it was causing problems with Java 11
-    //@Test
+    @Test
     public void process() throws Exception {
         when(testExchange.getPattern()).thenReturn(ExchangePattern.InOnly);
         SUT.process(testExchange);


### PR DESCRIPTION
Some of the previously uncommented tests now pass with Java 8 and Java 11.
The fixes mostly consist of workarounds around Mockito quirks.

Mockitos RETURNS_DEEP_STUBS stubbing mode seems to be broken for
methods with generic return types, see:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=535853
https://github.com/mockito/mockito/issues/357