### PR TITLE
Simplifying inheritance of shade plugin configurations

### DIFF
--- a/plc4j/examples/pom.xml
+++ b/plc4j/examples/pom.xml
@@ -74,8 +74,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              <transformers combine.children="append">
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>${app.main.class}</mainClass>
                 </transformer>


### PR DESCRIPTION
It seems that a slightly simpler version of achieving the same behavior as is currently in place is to rely on default Maven inheritance mechanisms to get `transformer implementation=...` configured.

This, of course, requires `combine.children="append"` to be added back at the examples pom.

Or to put it another way, this tries to be a simpler version of:
    https://github.com/apache/plc4x/commit/97e1eacfa912dbc106c955867b57041b58c34ae2
