### PR TITLE
[fixed] OPC UA Subscription item name is null

### DIFF
--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/protocol/OpcuaSubsriptionHandle.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/protocol/OpcuaSubsriptionHandle.java
@@ -53,6 +53,7 @@ public class OpcuaSubsriptionHandle implements PlcSubscriptionHandle {
 
     public  OpcuaSubsriptionHandle(String fieldName, UInteger clientHandle){
         this.clientHandle = clientHandle;
+        this.fieldName = fieldName;
     }
     @Override
     public PlcConsumerRegistration register(Consumer<PlcSubscriptionEvent> consumer) {


### PR DESCRIPTION
The use of the subscription mechanic was not possible because the item was inaccessible due to the unset name.