### PR TITLE
Update the Thrift version to the just released 0.13.0 to make it compatible with Boost again (Also bumped the Boost version to the latest 1.71.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,8 +108,8 @@
     <asm.version>5.0.4</asm.version>
     <assertj.version>3.11.1</assertj.version>
     <bouncycastle.version>1.60</bouncycastle.version>
-    <boost.version>1.70.0</boost.version>
-    <boost.version.underline-short>1_70</boost.version.underline-short>
+    <boost.version>1.71.0</boost.version>
+    <boost.version.underline-short>1_71</boost.version.underline-short>
     <boost.version.underline>${boost.version.underline-short}_0</boost.version.underline>
     <byte-buddy.version>1.9.10</byte-buddy.version>
     <cmake-version>3.14.5</cmake-version>
@@ -157,7 +157,7 @@
     <spock-reports.version>1.6.1</spock-reports.version>
     <spock.version>1.2-groovy-2.5</spock.version>
     <t-digest.version>3.2</t-digest.version>
-    <thrift.version>0.12.0</thrift.version>
+    <thrift.version>0.13.0</thrift.version>
     <xmlunit.version>2.6.3</xmlunit.version>
 
     <!-- Site properties -->

--- a/tools/thrift/pom.xml
+++ b/tools/thrift/pom.xml
@@ -248,12 +248,6 @@
                 <option>-DBUILD_JAVA=OFF</option>
                 <option>-DBUILD_PYTHON=${thrift.with.python}</option>
                 <option>-DBUILD_HASKELL=OFF</option>
-                <!--
-                  Forcefully disable Boost detection as we don't need it and
-                  having Boost 1.70 available breaks the Thrift build.
-                  Boost would be needed, if we were planning on running tests.
-                -->
-                <option>-DBoost_NO_BOOST_CMAKE=ON</option>
               </options>
             </configuration>
           </execution>


### PR DESCRIPTION
Up to now we couldn't build Thrift with Boost support as Thrift had Boost-Incompatibility issues, these were fixed in 0.13.0:
- Bumped the Boost version to the latest 1.71.0
- Bumped the Thrift version to the latest 0.13.0
- Removed the disabling of Boost support in the Thrift build