### PR TITLE
add iotdb integration example. for just saving one field for a PLC.

### DIFF
--- a/plc4j/examples/hello-integration-iotdb/pom.xml
+++ b/plc4j/examples/hello-integration-iotdb/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.plc4x.examples</groupId>
+    <artifactId>plc4j-examples</artifactId>
+    <version>0.6.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>plc4j-hello-integration-iotdb</artifactId>
+  <name>PLC4J: Examples: IoTDB</name>
+  <description>Application using Edgent to output PLC data to the IoTDB.</description>
+
+  <properties>
+    <app.main.class>org.apache.plc4x.java.examples.integration.iotdb.PlcLogger</app.main.class>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.plc4x</groupId>
+      <artifactId>plc4j-apache-edgent</artifactId>
+      <version>0.6.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.edgent</groupId>
+      <artifactId>edgent-api-function</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.edgent</groupId>
+      <artifactId>edgent-api-topology</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.edgent</groupId>
+      <artifactId>edgent-providers-direct</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>1.4</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+
+    <!-- Required driver implementation -->
+    <dependency>
+      <groupId>org.apache.plc4x</groupId>
+      <artifactId>plc4j-driver-ads</artifactId>
+      <version>0.6.0-SNAPSHOT</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.plc4x</groupId>
+      <artifactId>plc4j-driver-ethernet-ip</artifactId>
+      <version>0.6.0-SNAPSHOT</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.plc4x</groupId>
+      <artifactId>plc4j-driver-modbus</artifactId>
+      <version>0.6.0-SNAPSHOT</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.plc4x</groupId>
+      <artifactId>plc4j-driver-opcua</artifactId>
+      <version>0.6.0-SNAPSHOT</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.plc4x</groupId>
+      <artifactId>plc4j-driver-s7</artifactId>
+      <version>0.6.0-SNAPSHOT</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.plc4x</groupId>
+      <artifactId>plc4j-driver-simulated</artifactId>
+      <version>0.6.0-SNAPSHOT</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <!-- iotdb -->
+    <dependency>
+      <groupId>org.apache.iotdb</groupId>
+      <artifactId>iotdb-jdbc</artifactId>
+      <version>0.8.1</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <usedDependency>org.apache.plc4x:plc4j-driver-ads</usedDependency>
+            <usedDependency>org.apache.plc4x:plc4j-driver-ethernet-ip</usedDependency>
+            <usedDependency>org.apache.plc4x:plc4j-driver-modbus</usedDependency>
+            <usedDependency>org.apache.plc4x:plc4j-driver-opcua</usedDependency>
+            <usedDependency>org.apache.plc4x:plc4j-driver-s7</usedDependency>
+            <usedDependency>org.apache.plc4x:plc4j-driver-simulated</usedDependency>
+          </usedDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/plc4j/examples/hello-integration-iotdb/src/main/java/org/apache/plc4x/java/examples/integration/iotdb/CliOptions.java
+++ b/plc4j/examples/hello-integration-iotdb/src/main/java/org/apache/plc4x/java/examples/integration/iotdb/CliOptions.java
@@ -1,0 +1,188 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+package org.apache.plc4x.java.examples.integration.iotdb;
+
+import org.apache.commons.cli.*;
+
+public class CliOptions {
+
+    private static Options options;
+
+    private final String connectionString;
+    private final String fieldAddress;
+    private final int pollingInterval;
+    private final String iotdbIpPort;
+    private final String user;
+    private final String password;
+    private final String storageGroup;
+    private final String device;
+    private final String datatype;
+
+    public static CliOptions fromArgs(String[] args) {
+        options = new Options();
+        // Required arguments
+        options.addOption(
+            Option.builder()
+                .type(String.class)
+                .longOpt("connection-string")
+                .hasArg()
+                .desc("Connection String")
+                .required()
+                .build());
+        options.addOption(
+            Option.builder()
+                .type(String.class)
+                .longOpt("field-address")
+                .hasArg()
+                .desc("Field Address.")
+                .required()
+                .build());
+        options.addOption(
+            Option.builder()
+                .type(Integer.class)
+                .longOpt("polling-interval")
+                .hasArg()
+                .desc("Polling Interval (milliseconds).")
+                .required()
+                .build());
+        options.addOption(
+            Option.builder()
+                .type(Integer.class)
+                .longOpt("iotdb-address")
+                .hasArg()
+                .desc("The address and port of IoTDB server. format: ip:port")
+                .required()
+                .build());
+        options.addOption(
+            Option.builder()
+                .type(Integer.class)
+                .longOpt("iotdb-user-name")
+                .hasArg()
+                .desc("The connection user that has privilege to write data into IoTDB")
+                .required()
+                .build());
+        options.addOption(
+            Option.builder()
+                .type(Integer.class)
+                .longOpt("iotdb-user-password")
+                .hasArg()
+                .desc("The connection user password that has privilege to write data into IoTDB")
+                .required()
+                .build());
+        options.addOption(
+            Option.builder()
+                .type(Integer.class)
+                .longOpt("iotdb-sg")
+                .hasArg()
+                .desc("The Storage group name, e.g., testapp")
+                .required()
+                .build());
+        options.addOption(
+            Option.builder()
+                .type(Integer.class)
+                .longOpt("iotdb-device")
+                .hasArg()
+                .desc("The device name, e.g., mitsubishi.D58501")
+                .required()
+                .build());
+        options.addOption(
+            Option.builder()
+                .type(Integer.class)
+                .longOpt("iotdb-datatype")
+                .hasArg()
+                .desc("The data type of the field")
+                .required()
+                .build());
+
+        CommandLineParser parser = new DefaultParser();
+        CommandLine commandLine;
+        try {
+            commandLine = parser.parse(options, args);
+
+            String connectionString = commandLine.getOptionValue("connection-string");
+            String fieldAddress = commandLine.getOptionValue("field-address");
+            int pollingInterval = Integer.parseInt(commandLine.getOptionValue("polling-interval"));
+            String iotdbIpPort = commandLine.getOptionValue("iotdb-address");
+            String user = commandLine.getOptionValue("iotdb-user-name");
+            String password = commandLine.getOptionValue("iotdb-user-password");
+            String storageGroup = commandLine.getOptionValue("iotdb-sg");
+            String device = commandLine.getOptionValue("iotdb-device");
+            String datatype = commandLine.getOptionValue("iotdb-datatype");
+
+            return new CliOptions(connectionString, fieldAddress, pollingInterval, iotdbIpPort, user, password, storageGroup, device, datatype);
+        } catch (ParseException e) {
+            System.err.println(e.getMessage());
+            return null;
+        }
+    }
+
+    public static void printHelp() {
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.printHelp("PlcLogger", options);
+    }
+
+    public CliOptions(String connectionString, String fieldAddress, int pollingInterval, String iotdbIpPort, String user, String password, String storageGroup, String device, String datatype) {
+        this.connectionString = connectionString;
+        this.fieldAddress = fieldAddress;
+        this.pollingInterval = pollingInterval;
+        this.iotdbIpPort = iotdbIpPort;
+        this.user = user;
+        this.password = password;
+        this.storageGroup = storageGroup;
+        this.device = device;
+        this.datatype = datatype;
+    }
+
+    public String getConnectionString() {
+        return connectionString;
+    }
+
+    public String getFieldAddress() {
+        return fieldAddress;
+    }
+
+    public int getPollingInterval() {
+        return pollingInterval;
+    }
+
+    public String getIotdbIpPort() {
+        return iotdbIpPort;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getStorageGroup() {
+        return storageGroup;
+    }
+
+    public String getDevice() {
+        return device;
+    }
+
+    public String getDatatype() {
+        return datatype;
+    }
+}

--- a/plc4j/examples/hello-integration-iotdb/src/main/java/org/apache/plc4x/java/examples/integration/iotdb/PlcLogger.java
+++ b/plc4j/examples/hello-integration-iotdb/src/main/java/org/apache/plc4x/java/examples/integration/iotdb/PlcLogger.java
@@ -1,0 +1,139 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+package org.apache.plc4x.java.examples.integration.iotdb;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.apache.edgent.function.Supplier;
+import org.apache.edgent.providers.direct.DirectProvider;
+import org.apache.edgent.topology.TStream;
+import org.apache.edgent.topology.Topology;
+import org.apache.iotdb.jdbc.IoTDBSQLException;
+import org.apache.plc4x.edgent.PlcConnectionAdapter;
+import org.apache.plc4x.edgent.PlcFunctions;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * using this example, you can store data one by one into IoTDB.
+ *
+ * modified according to hello-integration-edgent
+ *
+ * arguments example:
+ * --connection-string test://127.0.0.1 --field-address RANDOM/foo:BYTE  --polling-interval 1000
+ * --iotdb-address 127.0.0.1:6667 --iotdb-user-name root --iotdb-user-password root --iotdb-sg mi
+ * --iotdb-device d1 --iotdb-datatype INT32
+ */
+public class PlcLogger {
+
+    //IoTDB JDBC connection
+    static Connection connection;
+
+    //IoTDB JDBC Statement
+    static Statement statement;
+
+    //Time series ID
+    static String timeSeries;
+
+    //device ID
+    static String deviceId;
+
+    //sensor ID
+    static String sensor;
+
+    public static void main(String[] args) throws Exception {
+        CliOptions options = CliOptions.fromArgs(args);
+        if (options == null) {
+            CliOptions.printHelp();
+            // Could not parse.
+            System.exit(1);
+        }
+
+        deviceId = String.format("root.%s.%s", options.getStorageGroup(), options.getDevice());
+        sensor = options.getFieldAddress().replace("/", "_").replace(":", "_");
+        timeSeries = String.format("%s.%s", deviceId, sensor);
+
+        // Get IoTDB connection
+        Class.forName("org.apache.iotdb.jdbc.IoTDBDriver");
+        connection = DriverManager.getConnection("jdbc:iotdb://" + options.getIotdbIpPort()+"/",
+            options.getUser(), options.getPassword());
+        statement = connection.createStatement();
+
+        //as we do not know whether the storage group is created or not, we can init the storage
+        // group in force.
+        try {
+            statement.execute("SET STORAGE GROUP TO root." + options.getStorageGroup());
+        } catch (IoTDBSQLException e) {
+            //from v0.9.0, you can use the error code to check whether the sg exists.
+            System.err.println(e.getMessage());
+        }
+
+        //before IoTDB v0.9, we have to create timeseries manually
+        try {
+            statement.execute(String.format("CREATE TIMESERIES %s WITH DATATYPE=%s, ENCODING=RLE",
+                timeSeries, options.getDatatype()));
+        } catch (IoTDBSQLException e) {
+            //from v0.9.0, you can use the error code to check whether the time series exists.
+            System.err.println(e.getMessage());
+        }
+
+        // Get a plc connection.
+        try (PlcConnectionAdapter plcAdapter = new PlcConnectionAdapter(options.getConnectionString())) {
+            // Initialize the Edgent core.
+            DirectProvider dp = new DirectProvider();
+            Topology top = dp.newTopology();
+
+            // Define the event stream.
+            // 1) PLC4X source generating a stream of bytes.
+            Supplier<Byte> plcSupplier = PlcFunctions.byteSupplier(plcAdapter,
+                options.getFieldAddress());
+            // 2) Use polling to get an item from the byte-stream in regular intervals.
+            TStream<Byte> source = top.poll(plcSupplier, options.getPollingInterval(),
+                TimeUnit.MILLISECONDS);
+            // 3) Output the events in the stream to IoTDB.
+            source.peek(x->storeData(x));
+
+            // Submit the topology and hereby start the event streams.
+            dp.submit(top);
+        }
+        //close IoTDB client.
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            public void run() {
+                try {
+                    connection.close();
+                } catch (SQLException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+    }
+
+    private static void storeData(Byte x) {
+        try {
+            statement.execute(String.format("insert into %s  (timestamp, %s) values (%d, %s)",
+                deviceId, sensor, System.currentTimeMillis(), x.byteValue()+""));
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/plc4j/examples/hello-integration-iotdb/src/main/resources/logback.xml
+++ b/plc4j/examples/hello-integration-iotdb/src/main/resources/logback.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<configuration xmlns="http://ch.qos.logback/xml/ns/logback"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://ch.qos.logback/xml/ns/logback https://raw.githubusercontent.com/enricopulatzo/logback-XSD/master/src/main/xsd/logback.xsd">
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>

--- a/plc4j/examples/pom.xml
+++ b/plc4j/examples/pom.xml
@@ -49,6 +49,7 @@
     <module>hello-storage-elasticsearch</module>
     <module>hello-webapp</module>
     <module>hello-world-plc4x</module>
+    <module>hello-integration-iotdb</module>
   </modules>
 
   <build>


### PR DESCRIPTION
Hi, I finished a simple example to using plc4j and edgent to collect data and then storing the data into iotdb.

It is a simple example, but just for showing how to use IoTDB and Plc4j together.

Latter, I think I can do some integration with plc4j-opm with IoTDB. e.g., add a method in OPM entity called `createIoTDBSchema()` to create the schema in IoTDB according to the attributes of the entity. Then an example about using OPM and iotdb will be easy to be implemented.