### PR TITLE
Ab eth station address parameter

### DIFF
--- a/plc4j/drivers/ab-eth/src/main/java/org/apache/plc4x/java/abeth/AbEthDriver.java
+++ b/plc4j/drivers/ab-eth/src/main/java/org/apache/plc4x/java/abeth/AbEthDriver.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
 
 public class AbEthDriver implements PlcDriver {
 
-    private static final Pattern ABETH_URI_PATTERN = Pattern.compile("^ab-eth://(?<host>.*)(?<params>\\?.*)?");
+    private static final Pattern ABETH_URI_PATTERN = Pattern.compile("^ab-eth://(?<host>.*)/(?<station>\\d{1,2})(?<params>\\?.*)?");
 
     @Override
     public String getProtocolCode() {
@@ -48,15 +48,15 @@ public class AbEthDriver implements PlcDriver {
         Matcher matcher = ABETH_URI_PATTERN.matcher(url);
         if (!matcher.matches()) {
             throw new PlcConnectionException(
-                "Connection url doesn't match the format 'ab-eth://{host|ip}'");
+                "Connection url doesn't match the format 'ab-eth://{host|ip}/{station}'");
         }
+        int station = Integer.parseInt(matcher.group("station"));
         String host = matcher.group("host");
-
         String params = matcher.group("params") != null ? matcher.group("params").substring(1) : null;
 
         try {
             InetAddress serverInetAddress = InetAddress.getByName(host);
-            return new AbEthPlcConnection(serverInetAddress, params);
+            return new AbEthPlcConnection(serverInetAddress, station, params);
         } catch (UnknownHostException e) {
             throw new PlcConnectionException("Error parsing address", e);
         } catch (Exception e) {

--- a/plc4j/drivers/ab-eth/src/main/java/org/apache/plc4x/java/abeth/connection/AbEthPlcConnection.java
+++ b/plc4j/drivers/ab-eth/src/main/java/org/apache/plc4x/java/abeth/connection/AbEthPlcConnection.java
@@ -29,7 +29,6 @@ import org.apache.plc4x.java.api.messages.PlcReadResponse;
 import org.apache.plc4x.java.api.model.PlcField;
 import org.apache.plc4x.java.base.connection.ChannelFactory;
 import org.apache.plc4x.java.base.connection.NettyPlcConnection;
-import org.apache.plc4x.java.tcp.connection.TcpSocketChannelFactory;
 import org.apache.plc4x.java.base.events.ConnectEvent;
 import org.apache.plc4x.java.base.events.ConnectedEvent;
 import org.apache.plc4x.java.base.messages.*;
@@ -45,13 +44,17 @@ public class AbEthPlcConnection extends NettyPlcConnection implements PlcReader 
     private static final int AB_ETH_PORT = 2222;
     private static final Logger logger = LoggerFactory.getLogger(AbEthPlcConnection.class);
 
-    public AbEthPlcConnection(InetAddress address, String params) {
-        this(new TcpSocketChannelFactory(address, AB_ETH_PORT), params);
+    private final int station;
+
+
+    public AbEthPlcConnection(InetAddress address, int station, String params) {
+        this(new TcpSocketChannelFactory(address, AB_ETH_PORT), station, params);
         logger.info("Setting up AB-ETH Connection with: host-name {}", address.getHostAddress());
     }
 
-    public AbEthPlcConnection(ChannelFactory channelFactory, String params) {
+    public AbEthPlcConnection(ChannelFactory channelFactory, int station, String params) {
         super(channelFactory, true);
+        this.station = station;
 
         if (!StringUtils.isEmpty(params)) {
             for (String param : params.split("&")) {
@@ -100,7 +103,7 @@ public class AbEthPlcConnection extends NettyPlcConnection implements PlcReader 
                     }
                 });
                 pipeline.addLast(new AbEthProtocol());
-                pipeline.addLast(new Plc4xAbEthProtocol());
+                pipeline.addLast(new Plc4xAbEthProtocol(station));
             }
         };
     }
@@ -113,6 +116,29 @@ public class AbEthPlcConnection extends NettyPlcConnection implements PlcReader 
     @Override
     public PlcReadRequest.Builder readRequestBuilder() {
         return new DefaultPlcReadRequest.Builder(this, new AbEthFieldHandler());
+    }
+
+    @Override
+    public void close() {
+        logger.debug("Closing PlcConnection...");
+        // Close the channel gracefully
+        if ((channel != null) && channel.isOpen()) {
+            logger.debug("Channel is still connected, Closing channel...");
+            // Close the channel
+            channel.close();
+
+            // Do some additional cleanup operations ...
+            // In normal operation, the channels event loop has a parent, however when running with
+            // the embedded channel for unit tests, parent is null.
+            if (channel.eventLoop().parent() != null) {
+                logger.trace("Shutting down EventLoop gracefully...");
+                channel.eventLoop().parent().shutdownGracefully();
+                logger.trace("Eventloop is shutted down");
+            }
+        }
+        // Dereference
+        channel = null;
+        connected = false;
     }
 
     @Override
@@ -129,5 +155,4 @@ public class AbEthPlcConnection extends NettyPlcConnection implements PlcReader 
         return future
             .thenApply(PlcReadResponse.class::cast);
     }
-
 }

--- a/plc4j/drivers/ab-eth/src/main/java/org/apache/plc4x/java/abeth/model/AbEthField.java
+++ b/plc4j/drivers/ab-eth/src/main/java/org/apache/plc4x/java/abeth/model/AbEthField.java
@@ -84,23 +84,22 @@ public class AbEthField implements PlcField {
             short elementNumber = Short.parseShort(matcher.group(ELEMENT_NUMBER));
             short bitNumber = (matcher.group(BIT_NUMBER) != null) ? Short.parseShort(matcher.group(BIT_NUMBER)) : 0;  //Short.parseShort(matcher.group(BIT_NUMBER));
             FileType fileType = FileType.valueOf(matcher.group(DATA_TYPE).toUpperCase());
+
             short byteSize;
             switch (fileType) {
                 case WORD:
+                case SINGLEBIT:
                     byteSize = 2;
                     break;
                 case DWORD:
                     byteSize = 4;
-                    break;
-                case SINGLEBIT:
-                    byteSize = 2;
                     break;
                 default:
                     byteSize = Short.parseShort(matcher.group(SIZE));
             }
             return new AbEthField(byteSize, fileNumber, fileType, elementNumber, bitNumber);
         }
-        throw new PlcInvalidFieldException("Unable to parse address: " + fieldString);
+        throw new PlcInvalidFieldException("Unable to parse field address: " + fieldString);
     }
 
 }

--- a/plc4j/drivers/ab-eth/src/main/java/org/apache/plc4x/java/abeth/protocol/Plc4xAbEthProtocol.java
+++ b/plc4j/drivers/ab-eth/src/main/java/org/apache/plc4x/java/abeth/protocol/Plc4xAbEthProtocol.java
@@ -58,10 +58,12 @@ public class Plc4xAbEthProtocol extends PlcMessageToMessageCodec<CIPEncapsulatio
 
     private long sessionHandle;
     private Map<Integer, PlcRequestContainer> requests;
+    private int station;
 
-    public Plc4xAbEthProtocol() {
+    public Plc4xAbEthProtocol(int station) {
         logger.trace("Created new instance of PLC4X-AB-ETH Protocol");
         this.requests = new HashMap<>();
+        this.station = station;
     }
 
     @Override
@@ -103,9 +105,9 @@ public class Plc4xAbEthProtocol extends PlcMessageToMessageCodec<CIPEncapsulatio
                 DF1RequestProtectedTypedLogicalRead logicalRead = new DF1RequestProtectedTypedLogicalRead(
                     abEthField.getByteSize(), abEthField.getFileNumber(), abEthField.getFileType().getTypeCode(),
                     abEthField.getElementNumber(), (short) 0); // Subelementnumber default to zero
-                // TODO: make target and origin address changeable
+                // origin/sender: constant = 5
                 DF1RequestMessage requestMessage = new DF1CommandRequestMessage(
-                    (short) 8, (short) 5, (short) 0, transactionCounterGenerator.incrementAndGet(), logicalRead);
+                    (short) station, (short) 5, (short) 0, transactionCounterGenerator.incrementAndGet(), logicalRead);
                 CIPEncapsulationReadRequest read = new CIPEncapsulationReadRequest(
                     sessionHandle, 0, emptySenderContext, 0, requestMessage);
 

--- a/plc4j/examples/hello-world-plc4x/pom.xml
+++ b/plc4j/examples/hello-world-plc4x/pom.xml
@@ -64,6 +64,12 @@
     <!-- Required driver implementation -->
     <dependency>
       <groupId>org.apache.plc4x</groupId>
+      <artifactId>plc4j-driver-ab-eth</artifactId>
+      <version>0.6.0-SNAPSHOT</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.plc4x</groupId>
       <artifactId>plc4j-driver-ads</artifactId>
       <version>0.6.0-SNAPSHOT</version>
       <scope>runtime</scope>
@@ -107,6 +113,7 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <usedDependencies combine.children="append">
+            <usedDependency>org.apache.plc4x:plc4j-driver-ab-eth</usedDependency>
             <usedDependency>org.apache.plc4x:plc4j-driver-ads</usedDependency>
             <usedDependency>org.apache.plc4x:plc4j-driver-ethernet-ip</usedDependency>
             <usedDependency>org.apache.plc4x:plc4j-driver-modbus</usedDependency>

--- a/src/site/asciidoc/protocols/ab-eth/index.adoc
+++ b/src/site/asciidoc/protocols/ab-eth/index.adoc
@@ -22,7 +22,7 @@ supports the protected typed logical read with a limited number of data types.
 
 === Connection
 
-The connection string looks as follows: `ab-eth://<ip-address>`
+The connection string looks as follows: `ab-eth://<ip-address>/<station>`
 
 The field address: `N<file>:<offset></bitnumber>:<datatype>[<numberofbytes>]`. The following data types are available
 at the moment: SINBLEBIT (requires bitnumber to be set), WORD (2 byte integer), DWORD (4 byte integer), INTEGER (returns

--- a/src/site/asciidoc/protocols/features.adoc
+++ b/src/site/asciidoc/protocols/features.adoc
@@ -23,6 +23,14 @@ The following table contains a list of operations and the protocols that support
 |===
 |Protocol |Read Single Address Value |Read Multiple Address Values |Write Single Address Value |Write Multiple Address Value|Subscribe to Value changes |Subscribe to PLC Events/Alarms
 
+|AB-Ethernet
+|icon:check[role="green"]
+|icon:check[role="red"]
+|icon:check[role="red"]
+|icon:check[role="red"]
+|icon:check[role="red"]
+|icon:question[role="red"]
+
 |ADS
 |icon:check[role="green"]
 |icon:check[role="green"]

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -126,6 +126,7 @@
     </menu>
     <menu name="Protocols">
       <item name="Features" href="protocols/features.html"/>
+      <item name="AB-Ethernet" href="protocols/ab-eth/index.html"/>
       <item name="ADS" href="protocols/ads/index.html"/>
       <item name="DeltaV" href="protocols/delta-v/index.html"/>
       <item name="EtherNet/IP" href="protocols/ethernet-ip/index.html"/>


### PR DESCRIPTION
Until now the station parameter, which is part of the DF1 block within the AB-ETH frame was defaulted to 8. It is now part of the connection string.