### PR TITLE
Fixes in ADS protocol

### DIFF
--- a/plc4j/protocols/ads/src/main/java/org/apache/plc4x/java/ads/protocol/Payload2TcpProtocol.java
+++ b/plc4j/protocols/ads/src/main/java/org/apache/plc4x/java/ads/protocol/Payload2TcpProtocol.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 public class Payload2TcpProtocol extends MessageToMessageCodec<ByteBuf, ByteBuf> {
+    private ByteBuf retainingBuf = Unpooled.EMPTY_BUFFER;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Payload2TcpProtocol.class);
 
@@ -49,21 +50,24 @@ public class Payload2TcpProtocol extends MessageToMessageCodec<ByteBuf, ByteBuf>
             return;
         }
         LOGGER.trace("(-->IN): {}, {}, {}", channelHandlerContext, byteBuf, out);
-        if (byteBuf.readableBytes() < AmsTcpHeader.Reserved.NUM_BYTES + TcpLength.NUM_BYTES) {
-            // wait till we can read the length header
-            return;
-        }
-        if (byteBuf.readableBytes() < byteBuf.getUnsignedIntLE(AmsTcpHeader.Reserved.NUM_BYTES)) {
-            // wait till we have a complete ADS packet
-            return;
-        }
-        // Reserved
-        byteBuf.skipBytes(AmsTcpHeader.Reserved.NUM_BYTES);
-        TcpLength packetLength = TcpLength.of(byteBuf);
-        AmsTcpHeader amsTcpHeader = AmsTcpHeader.of(packetLength);
-        LOGGER.debug("AMS TCP Header {}", amsTcpHeader);
 
-        out.add(byteBuf.readBytes((int) packetLength.getAsLong()));
+        retainingBuf = Unpooled.wrappedBuffer(retainingBuf, byteBuf.retain());
+
+        while (retainingBuf.readableBytes() >= AmsTcpHeader.Reserved.NUM_BYTES + TcpLength.NUM_BYTES
+                && retainingBuf.readableBytes() >= retainingBuf.getUnsignedIntLE(retainingBuf.readerIndex()
+                        + AmsTcpHeader.Reserved.NUM_BYTES) + AmsTcpHeader.Reserved.NUM_BYTES + TcpLength.NUM_BYTES) {
+            // Reserved
+            retainingBuf.skipBytes(AmsTcpHeader.Reserved.NUM_BYTES);
+            TcpLength packetLength = TcpLength.of(retainingBuf);
+            AmsTcpHeader amsTcpHeader = AmsTcpHeader.of(packetLength);
+            LOGGER.debug("AMS TCP Header {}", amsTcpHeader);
+
+            out.add(retainingBuf.readBytes((int) packetLength.getAsLong()));
+        }
+        if (retainingBuf.readableBytes() == 0) {
+            retainingBuf.release();
+            retainingBuf = Unpooled.EMPTY_BUFFER;
+        }
     }
 
 }

--- a/plc4j/protocols/ads/src/test/java/org/apache/plc4x/java/ads/protocol/Payload2TcpProtocolTest.java
+++ b/plc4j/protocols/ads/src/test/java/org/apache/plc4x/java/ads/protocol/Payload2TcpProtocolTest.java
@@ -94,6 +94,26 @@ public class Payload2TcpProtocolTest extends AbstractProtocolTest {
     }
 
     @Test
+    public void fragmentedDecode() throws Exception {
+        ArrayList<Object> out = new ArrayList<>();
+        ByteBuf byteBuf = amsTCPPacket.getByteBuf();
+        SUT.decode(channelHandlerContextMock, byteBuf.readBytes(byteBuf.readableBytes() - 2), out);
+        assertThat(out, hasSize(0));
+        SUT.decode(channelHandlerContextMock, byteBuf, out);
+        assertThat(out, hasSize(1));
+        byteBuf.release();
+    }
+
+    @Test
+    public void multipleMessagesDecode() throws Exception {
+        ArrayList<Object> out = new ArrayList<>();
+        ByteBuf byteBuf = Unpooled.wrappedBuffer(amsTCPPacket.getByteBuf(), amsTCPPacket.getByteBuf());
+        SUT.decode(channelHandlerContextMock, byteBuf, out);
+        assertThat(out, hasSize(2));
+        byteBuf.release();
+    }
+
+    @Test
     public void roundTrip() throws Exception {
         ArrayList<Object> outbound = new ArrayList<>();
         SUT.encode(channelHandlerContextMock, Unpooled.wrappedBuffer(amsPacketBytes), outbound);


### PR DESCRIPTION
Fixed the following issue:

- The Payload2TcpProtocol did not retain the incomming ByteBuf in case a message entered fragmented and stopped parsing after one payload was parsed.
- The length check missed the header size.
- ByteBuf created in Ads2PayloadProtocol were not released.