### PR TITLE
PLC4X-160: Fix css to make links to Apache events and ASF homepage work again

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -73,8 +73,6 @@ under the License.
 h2[id]:before {
     display: block;
     content: "";
-    height: 360px;
-    margin: -360px 0 0;
 }
 
 /* Set where the focus will be set when using anchor links */

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -76,7 +76,7 @@
     <name>Apache Software Foundation</name>
     <src>https://plc4x.apache.org/images/apache_logo.png</src>
     <!--src>./images/apache_logo.png</src-->
-    <href>http://www.apache.org/</href>
+    <href>https://www.apache.org/</href>
   </bannerRight>
 
   <body>


### PR DESCRIPTION
I removed two lines in site.css (the height and margin elements), which created a layer with an invisible margin over the Apache images preventing click events to work properly.