### PR TITLE
Fix future chain for InternalPlcWriteRequest

### DIFF
--- a/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/protocol/SingleItemToSingleRequestProtocol.java
+++ b/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/protocol/SingleItemToSingleRequestProtocol.java
@@ -325,7 +325,9 @@ public class SingleItemToSingleRequestProtocol extends ChannelDuplexHandler {
                         ChannelPromise subPromise = new DefaultChannelPromise(promise.channel());
 
                         Integer tdpu = correlationIdGenerator.getAndIncrement();
-                        CompletableFuture<InternalPlcResponse> correlatedCompletableFuture = new CompletableFuture<>()
+                        CompletableFuture<InternalPlcResponse> correlatedCompletableFuture = new CompletableFuture<>();
+                        // Important: don't chain to above as we want the above to be completed not the result of when complete
+                        correlatedCompletableFuture
                             .thenApply(InternalPlcResponse.class::cast)
                             .whenComplete((internalPlcResponse, throwable) -> {
                                 if (throwable != null) {


### PR DESCRIPTION
Fix the future chain of the InternalPlcWriteRequest using the same code as used for: InternalPlcReadRequest (L303), InternalPlcSubscriptionRequest (L353) and InternalPlcUnsubscriptionRequest (L381).