### PR TITLE
Update S7PlcConnection.java

### DIFF
--- a/plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7/connection/S7PlcConnection.java
+++ b/plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7/connection/S7PlcConnection.java
@@ -170,8 +170,8 @@ public class S7PlcConnection extends NettyPlcConnection implements PlcReader, Pl
 
     @Override
     protected ChannelHandler getChannelHandler(CompletableFuture<Void> sessionSetupCompleteFuture) {
-        short calledTsapId = S7TsapIdEncoder.encodeS7TsapId(DeviceGroup.OS, 0, 0);
-        short callingTsapId = S7TsapIdEncoder.encodeS7TsapId(DeviceGroup.PG_OR_PC, rack, slot);
+        short calledTsapId = S7TsapIdEncoder.encodeS7TsapId(DeviceGroup.OS, rack, slot);
+        short callingTsapId = S7TsapIdEncoder.encodeS7TsapId(DeviceGroup.PG_OR_PC, 0, 0);
 
         return new ChannelInitializer() {
             @Override


### PR DESCRIPTION
From my experience with the connection to a S7 the calledTsapId must contain rack and slot while the callingTsapId must not. 

This PR is refering to https://issues.apache.org/jira/projects/PLC4X/issues/PLC4X-134?filter=allopenissues