### PR TITLE
PLC4X-176 resolve issues round running on linux platforms

### DIFF
--- a/tools/check_sigs.sh
+++ b/tools/check_sigs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 ################################################################################
 ##
@@ -26,7 +26,7 @@ set -e
 
 . `dirname $0`/common.sh
 
-setUsage "`basename $0` [bundle-directory]"
+setUsage "$(basename "$0") [bundle-directory]"
 handleHelp "$@"
 
 if [ $# -ge 1 ]
@@ -36,15 +36,15 @@ fi
 
 noExtraArgs "$@"
 
-[ -d ${BUNDLE_DIR} ] || die "Bundle directory \"${BUNDLE_DIR}\" does not exist"
+[ -d "${BUNDLE_DIR}" ] || die "Bundle directory \"${BUNDLE_DIR}\" does not exist"
 
 function checkFile() {
     FILE="$1"
     echo
     echo "Checking $FILE..."
 
-    HASH=`shasum -a 512 "${FILE}" | awk '{print$1}'`
-    CHECK=`cat "${FILE}.sha512"`
+    HASH=$(shasum -a 512 "${FILE}" | awk '{print$1}')
+    CHECK=$(cat "${FILE}.sha512")
 
     if [ "$HASH" != "$CHECK" ]
     then
@@ -58,9 +58,9 @@ function checkFile() {
 
 }
 
-for bundle in ${BUNDLE_DIR}/*.zip
+for bundle in "${BUNDLE_DIR}"/*.zip
 do
-    checkFile ${bundle}
+    checkFile "${bundle}"
 done
 
 echo

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 ################################################################################
 ##
@@ -19,7 +19,7 @@
 ##
 ################################################################################
 
-BUILDTOOLS_DIR=`dirname $0`
+BUILDTOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 
 PLC4X_ROOT_DIR=.
 # BUNDLE_DIR is results of maven release:perform's creation of release candidate
@@ -51,7 +51,7 @@ function usage() {  #  [$*: msgs]
 }
 
 function handleHelp() { # usage: handleHelp "$@"
-  if [ "$1" == "-?" -o "$1" == "--help" ]; then
+  if [ "$1" == "-?" ] ||  [ "$1" == "--help" ]; then
     usage
   fi
 }
@@ -67,17 +67,18 @@ function noExtraArgs() { # usage: noExtraArgs "$@"
 }
 
 function getAbsPath() { # $1: rel-or-abs-path 
-    echo "$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
+    echo "$(cd "$(dirname "$1")" >> /dev/null || exit $?; pwd)/$(basename "$1")"
 }
 
+# shellcheck disable=SC2046
 function confirm () {  # [$1: question]
   while true; do
     # call with a prompt string or use a default                                                                                                                                                   
     /bin/echo -n "${1:-Are you sure?}"
     read -r -p " [y/n] " response
     case $response in
-      [yY]) return `true` ;;
-      [nN]) return `false` ;;
+      [yY]) return $(true) ;;
+      [nN]) return $(false) ;;
       *) echo "illegal response '$response'" ;;
     esac
   done
@@ -92,9 +93,9 @@ function checkPLC4XSourceRootGitDie { # no args; dies if !ok
 }
 
 function checkUsingMgmtCloneWarn() { # no args; warns if plc4x root isn't a mgmt clone
-  CLONE_DIR=`cd ${PLC4X_ROOT_DIR}; pwd`
-  CLONE_DIRNAME=`basename $CLONE_DIR`
-  if [ ! `echo $CLONE_DIRNAME | grep -o -E '^mgmt-plc4x'` ]; then
+  CLONE_DIR="$(cd ${PLC4X_ROOT_DIR} > /dev/null || exit $?; pwd)"
+  CLONE_DIRNAME="$(basename "${CLONE_DIR}")"
+  if [ ! "$(echo ${CLONE_DIRNAME} | grep -o -E '^mgmt-plc4x')" ]; then
     echo "Warning: the PLC4X root dir \"${PLC4X_ROOT_DIR}\" is not a release mgmt clone!"
     return 1
   else
@@ -111,79 +112,69 @@ function checkBundleDir() { # no args  returns true/false (0/1)
 }
 
 function checkVerNum() {  #  $1: X.Y.Z  returns true/false (0/1)
-  if [ `echo $1 | grep -o -E '^\d+\.\d+\.\d+$'` ]; then
-    return 0
-  else
-    return 1
-  fi
+ [[ $1 =~ ^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}$ ]] && return 0
+ return 1
 }
 
 function checkVerNumDie() { #  $1: X.Y.Z  dies if not ok
-  checkVerNum $1 || die "Not a X.Y.Z version number \"$1\""
+  checkVerNum "$1" || die "Not a X.Y.Z version number \"$1\""
 }
 
 function checkRcNum() {  # $1: rc-num   returns true/false (0/1)
-  if [ `echo $1 | grep -o -E '^\d+$'` ] && [ $1 != 0 ]; then
-    return 0
-  else
-    return 1
-  fi
+ [[ $1 =~ ^[0-9]{1,2}$ ]] && return 0
+ return 1
 }
 
 function checkRcNumDie() {  # $1: rc-num dies if not ok
-  checkRcNum $1 || die "Not a release candidate number \"$1\""
+  checkRcNum "$1" || die "Not a release candidate number \"$1\""
 }
 
 function createReleaseProperties { # X.Y.Z
   VER="$1"
-  checkVerNumDie ${VER}
+  checkVerNumDie "${VER}"
   echo "releaseNum=${VER}" > ${RELEASE_PROP_FILE}
 }
 
 function getReleaseProperty {  # <property-name>
   PN=$1
-  PNVAL=`grep ${PN} ${RELEASE_PROP_FILE}`
-  VAL=`echo ${PNVAL} | sed -e "s/^${PN}=//"`
-  echo ${VAL}
+  PNVAL=$(grep "${PN}" ${RELEASE_PROP_FILE})
+  VAL=$(echo "${PNVAL}" | sed -e "s/^${PN}=//")
+  echo "${VAL}"
 }
 
 function getPLC4XVer() {  # [$1 == "bundle"]
   MSG="getPLC4XVer(): unknown mode \"$1\""
   VER=""
   if [ "$1" == "" ]; then
-    VER=`getReleaseProperty releaseNum`
+    VER=$(getReleaseProperty releaseNum)
     MSG="Unable to identify the release version id from ${RELEASE_PROP_FILE}"
-  elif [ $1 == "gradle" ]; then
+  elif [ "$1" == "gradle" ]; then
     die "'getPLC4XVer() gradle' is no longer supported"
-    # Get the X.Y.Z version from gradle build info
-    PROPS=${PLC4X_ROOT_DIR}/gradle.properties
-    VER=`grep build_version ${PROPS} | grep -o -E '\d+\.\d+\.\d+'`
-    MSG="Unable to identify the version id from ${PROPS}"
-  elif [ $1 == "bundle" ]; then
+  elif [ "$1" == "bundle" ]; then
     # Get the X.Y.Z version from a build generated bundle's name
-    BUNDLE=`echo ${BUNDLE_DIR}/apache-plc4x-*-source-release.tar.gz`
-    VER=`echo ${BUNDLE} | grep -o -E '\d+\.\d+\.\d+'`
+    BUNDLE=$(echo "${BUNDLE_DIR}"/apache-plc4x-*-source-release.tar.gz)
+    VER=$(echo "${BUNDLE}" | grep -o -E '\d+\.\d+\.\d+')
     MSG="Unable to identify the version id from bundle ${BUNDLE}"
   fi
   [ "${VER}" ] || die "${MSG}"
-  echo $VER
+  echo "$VER"
 }
 
 function getMajMinVerNum() {  #  $1: X.Y.Z  returns X.Y
   VER=$1; shift
-  checkVerNumDie ${VER}
-  MAJ_MIN_VER=`echo ${VER} | sed -e 's/\.[0-9][0-9]*$//'`
-  echo ${MAJ_MIN_VER}
+  checkVerNumDie "${VER}"
+  MAJ_MIN_VER=$(echo "${VER}" | sed -e 's/\.[0-9][0-9]*$//')
+  echo "${MAJ_MIN_VER}"
 }
 
 function getReleaseBranch() { # $1: X.Y.Z version
-  MAJ_MIN_NUM=`getMajMinVerNum $1`
+  MAJ_MIN_NUM=$(getMajMinVerNum "$1")
   echo "release/${MAJ_MIN_NUM}"
 }
 
 function getReleaseTag() {  # $1: X.Y.Z  [$2: rc-num]
   VER=$1; shift
-  checkVerNumDie ${VER}
+  checkVerNumDie "${VER}"
   RC_SFX=""
   if [ $# -gt 0 ] && [ "$1" != "" ]; then
     RC_SFX="-RC$1"
@@ -193,7 +184,7 @@ function getReleaseTag() {  # $1: X.Y.Z  [$2: rc-num]
 
 function getReleaseTagComment() {  # $1: X.Y.Z  [$2: rc-num]
   VER=$1; shift
-  checkVerNumDie ${VER}
+  checkVerNumDie "${VER}"
   RC_SFX=""
   if [ $# -gt 0 ] && [ "$1" != "" ]; then
     RC_SFX=" RC$1"

--- a/tools/download_staged_release.sh
+++ b/tools/download_staged_release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 ################################################################################
 ##
@@ -21,6 +21,7 @@
 
 set -e
 
+
 # Download the collection of files associated with an Apache PLC4X
 # Release or Release Candidate from the Apache Distribution area:
 # https://dist.apache.org/repos/dist/release/plc4x
@@ -36,10 +37,9 @@ set -e
 
 
 
-setUsage "`basename $0` [--nquery] [--validate|--nvalidate] <version> [<rc-num>]"
+setUsage "$(basename $0) [--nquery] [--validate|--nvalidate] <version> [<rc-num>]"
 handleHelp "$@"
 
-BUILDTOOLS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 NQUERY=
 if [ "$1" == "--nquery" ]; then
@@ -55,19 +55,19 @@ fi
 
 requireArg "$@"
 VER=$1; shift
-checkVerNum $VER || usage "Not a X.Y.Z version number \"$VER\""
+checkVerNum "$VER" || usage "Not a X.Y.Z version number \"$VER\""
 
 RC_NUM=
 if [ $# -gt 0 ]; then
   RC_NUM=$1; shift
-  checkRcNum ${RC_NUM} || usage "Not a release candidate number \"${RC_NUM}\""
+  checkRcNum "${RC_NUM}" || usage "Not a release candidate number \"${RC_NUM}\""
 fi
 
 noExtraArgs "$@"
 
 # Release or Release Candidate mode
 IS_RC=
-if [ ${RC_NUM} ]; then
+if [ "${RC_NUM}" ]; then
   IS_RC=1
 fi
 
@@ -82,28 +82,28 @@ if [ ${IS_RC} ]; then
 fi
 
 DST_BASE_DIR=downloaded-plc4x-${VER}${RC_SFX}
-[ -d ${DST_BASE_DIR} ] && die "${DST_BASE_DIR} already exists"
+[ -d "${DST_BASE_DIR}" ] && die "${DST_BASE_DIR} already exists"
 
 [ ${NQUERY} ] || confirm "Proceed to download to ${DST_BASE_DIR} from ${BASE_URL}?" || exit
 
-echo Downloading to ${DST_BASE_DIR} ...
+echo Downloading to "${DST_BASE_DIR}" ...
 
 function mywget() {
   # OSX lacks wget by default
-  (set -x; curl -f -O $1)
+  (set -x; curl -f -O "$1")
 }
 
 function getSignedBundle() {
-  mywget ${1}
-  mywget ${1}.asc
-  mywget ${1}.sha512
+  mywget "${1}"
+  mywget "${1}".asc
+  mywget "${1}".sha512
 }
 
-mkdir -p ${DST_BASE_DIR}
-cd ${DST_BASE_DIR}
-ABS_BASE_DIR=`pwd`
+mkdir -p "${DST_BASE_DIR}"
+cd "${DST_BASE_DIR}"
+ABS_BASE_DIR=$(pwd)
 URL=${BASE_URL}
-mywget ${URL}/KEYS
+mywget "${URL}"/KEYS
 
 DST_VER_DIR=${VER}
 URL=${BASE_URL}/${VER}
@@ -112,19 +112,19 @@ if [ ${IS_RC} ]; then
   URL=${URL}/${RC_SFX}
 fi
 
-mkdir -p ${DST_VER_DIR}
-cd ${DST_VER_DIR}
-mywget ${URL}/README.md
-mywget ${URL}/RELEASE_NOTES
-getSignedBundle ${URL}/apache-plc4x-${VER}-source-release.zip
+mkdir -p "${DST_VER_DIR}"
+cd "${DST_VER_DIR}"
+mywget "${URL}"/README.md
+mywget "${URL}"/RELEASE_NOTES
+getSignedBundle "${URL}"/apache-plc4x-"${VER}"-source-release.zip
 
 echo
-echo Done Downloading to ${DST_BASE_DIR}
+echo Done Downloading to "${DST_BASE_DIR}"
 
 [ ${VALIDATE} == 0 ] && exit
 [ ${VALIDATE} == 1 ] || [ ${NQUERY} ] || confirm "Do you want to check the bundle signatures and compare source bundles?" || exit
 
-cd ${ABS_BASE_DIR}
+cd "${ABS_BASE_DIR}"
 
 echo
 echo "If the following bundle gpg signature checks fail, you may need to"
@@ -134,4 +134,4 @@ echo "    $ gpg --import ${DST_BASE_DIR}/KEYS"
 
 echo
 echo "Verifying the source bundle signatures..."
-(set -x; $BUILDTOOLS_DIR/check_sigs.sh ${DST_VER_DIR})
+(set -x; "$BUILDTOOLS_DIR"/check_sigs.sh "${DST_VER_DIR}")


### PR DESCRIPTION
This pr resolves issues that were keeping the tools scripts from running on any other platform than macOS.

The fixes involved resolving warnings set by shellcheck, changing to be `bash` scripts, and using bash expression matching.

These fixes have been verified in docker containers as such: 
```bash
>  docker run -it -v `(pwd)`:/root/code ubuntu:bionic bash
>  docker run -it -v `(pwd)`:/root/code ubuntu:disco bash
>  docker run -it -v `(pwd)`:/root/code centos:7 bash
>  docker run -it -v `(pwd)`:/root/code centos:8 bash
```
and locally on macOS 10.15.3 with 
bash -> 3.2.57
bash -> 5.0.16
With 0.6.0 2

Note, that these containers do not have all the packages required to run the scripts to completion, nor the local keys, but when those packages are present the script runs without error.  If the keys are present it runs to completion.

The packages that may be missing are curl, perl-Digest-SHA.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/plc4x/121)
<!-- Reviewable:end -->
