### PR TITLE
Use existing base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 # This is the image we'll use to execute the build (and give it the name 'build').
 # (This image is based on Ubuntu)
 # Fixed version of this in order to have a fixed JDK version
-FROM azul/zulu-openjdk:8.42.0.21 as build
+FROM azul/zulu-openjdk:8 as build
 
 # Install some stuff we need to run the build
 RUN apt update -y


### PR DESCRIPTION
```
➜ docker build -t plc4x .
Sending build context to Docker daemon  20.12MB
Step 1/35 : FROM azul/zulu-openjdk:8.42.0.21 as build
manifest for azul/zulu-openjdk:8.42.0.21 not found: manifest unknown: manifest unknown
```