### PR TITLE
remove Bnd-LastModified header that is not reproducible

### DIFF
--- a/protocols/pom.xml
+++ b/protocols/pom.xml
@@ -163,6 +163,11 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <instructions>
+            <_removeheaders>Bnd-LastModified</_removeheaders>
+          </instructions>
+        </configuration>
       </plugin>
 
       <!--


### PR DESCRIPTION
as proposed by JB Onofre https://www.mail-archive.com/dev@felix.apache.org/msg49127.html

testing with
```
mvn clean deploy -DskipTests -DaltDeploymentRepository=local::default::file:../stage buildinfo:buildinfo
mvn clean verify -DskipTests -Dreference.repo=file:../stage buildinfo:buildinfo
```

after the change:
```
[WARNING] size mismatch plc4j-driver-s7-0.7.0-SNAPSHOT.kar: diffoscope target/reference/plc4j-driver-s7-0.7.0-SNAPSHOT.kar plc4j/drivers/s7/target/plc4j-driver-s7-0.7.0-SNAPSHOT.kar
[WARNING] sha512 mismatch plc4j-hello-webapp-webapp-0.7.0-SNAPSHOT.war: diffoscope target/reference/plc4j-hello-webapp-webapp-0.7.0-SNAPSHOT.war plc4j/examples/hello-webapp/webapp/target/plc4j-hello-webapp-webapp-0.7.0-SNAPSHOT.war
[WARNING] size mismatch plc4j-nifi-plc4x-nar-0.7.0-SNAPSHOT.nar: diffoscope target/reference/plc4j-nifi-plc4x-nar-0.7.0-SNAPSHOT.nar plc4j/integrations/apache-nifi/nifi-plc4x-nar/target/plc4j-nifi-plc4x-nar-0.7.0-SNAPSHOT.nar
[WARNING] size mismatch plc4j-apache-camel-0.7.0-SNAPSHOT.jar: diffoscope target/reference/plc4j-apache-camel-0.7.0-SNAPSHOT.jar plc4j/integrations/apache-camel/target/plc4j-apache-camel-0.7.0-SNAPSHOT.jar
[WARNING] sha512 mismatch plc4j-hello-webapp-client-0.7.0-SNAPSHOT.war: diffoscope target/reference/plc4j-hello-webapp-client-0.7.0-SNAPSHOT.war plc4j/examples/hello-webapp/client/target/plc4j-hello-webapp-client-0.7.0-SNAPSHOT.war
[WARNING] Reproducible Build output summary: 55 files ok, 5 different, 0 missing
```