### PR TITLE
PLC4X-193 Support for little endian fields

### DIFF
--- a/build-utils/language-java/src/main/java/org/apache/plc4x/language/java/JavaLanguageTemplateHelper.java
+++ b/build-utils/language-java/src/main/java/org/apache/plc4x/language/java/JavaLanguageTemplateHelper.java
@@ -242,33 +242,35 @@ public class JavaLanguageTemplateHelper implements FreemarkerLanguageTemplateHel
             }
             case UINT: {
                 IntegerTypeReference integerTypeReference = (IntegerTypeReference) simpleTypeReference;
+                String endianness = integerTypeReference.isLittleEndian() ? ", true" : "";
                 if (integerTypeReference.getSizeInBits() <= 4) {
                     return "io.readUnsignedByte(" + integerTypeReference.getSizeInBits() + ")";
                 }
                 if (integerTypeReference.getSizeInBits() <= 8) {
-                    return "io.readUnsignedShort(" + integerTypeReference.getSizeInBits() + ")";
+                    return "io.readUnsignedShort(" + integerTypeReference.getSizeInBits() + endianness + ")";
                 }
                 if (integerTypeReference.getSizeInBits() <= 16) {
-                    return "io.readUnsignedInt(" + integerTypeReference.getSizeInBits() + ")";
+                    return "io.readUnsignedInt(" + integerTypeReference.getSizeInBits() + endianness + ")";
                 }
                 if (integerTypeReference.getSizeInBits() <= 32) {
-                    return "io.readUnsignedLong(" + integerTypeReference.getSizeInBits() + ")";
+                    return "io.readUnsignedLong(" + integerTypeReference.getSizeInBits() + endianness + ")";
                 }
                 return "io.readUnsignedBigInteger(" + integerTypeReference.getSizeInBits() + ")";
             }
             case INT: {
                 IntegerTypeReference integerTypeReference = (IntegerTypeReference) simpleTypeReference;
+                String endianness = integerTypeReference.isLittleEndian() ? ", true" : "";
                 if (integerTypeReference.getSizeInBits() <= 8) {
                     return "io.readByte(" + integerTypeReference.getSizeInBits() + ")";
                 }
                 if (integerTypeReference.getSizeInBits() <= 16) {
-                    return "io.readShort(" + integerTypeReference.getSizeInBits() + ")";
+                    return "io.readShort(" + integerTypeReference.getSizeInBits() + endianness + ")";
                 }
                 if (integerTypeReference.getSizeInBits() <= 32) {
-                    return "io.readInt(" + integerTypeReference.getSizeInBits() + ")";
+                    return "io.readInt(" + integerTypeReference.getSizeInBits() + endianness + ")";
                 }
                 if (integerTypeReference.getSizeInBits() <= 64) {
-                    return "io.readLong(" + integerTypeReference.getSizeInBits() + ")";
+                    return "io.readLong(" + integerTypeReference.getSizeInBits() + endianness + ")";
                 }
                 return "io.readBigInteger(" + integerTypeReference.getSizeInBits() + ")";
             }
@@ -301,33 +303,35 @@ public class JavaLanguageTemplateHelper implements FreemarkerLanguageTemplateHel
             }
             case UINT: {
                 IntegerTypeReference integerTypeReference = (IntegerTypeReference) simpleTypeReference;
+                String endianness = integerTypeReference.isLittleEndian() ? ", true" : "";
                 if (integerTypeReference.getSizeInBits() <= 4) {
                     return "io.writeUnsignedByte(" + integerTypeReference.getSizeInBits() + ", ((Number) " + fieldName + ").byteValue())";
                 }
                 if (integerTypeReference.getSizeInBits() <= 8) {
-                    return "io.writeUnsignedShort(" + integerTypeReference.getSizeInBits() + ", ((Number) " + fieldName + ").shortValue())";
+                    return "io.writeUnsignedShort(" + integerTypeReference.getSizeInBits() + ", ((Number) " + fieldName + ").shortValue()" + endianness + ")";
                 }
                 if (integerTypeReference.getSizeInBits() <= 16) {
-                    return "io.writeUnsignedInt(" + integerTypeReference.getSizeInBits() + ", ((Number) " + fieldName + ").intValue())";
+                    return "io.writeUnsignedInt(" + integerTypeReference.getSizeInBits() + ", ((Number) " + fieldName + ").intValue()" + endianness + ")";
                 }
                 if (integerTypeReference.getSizeInBits() <= 32) {
-                    return "io.writeUnsignedLong(" + integerTypeReference.getSizeInBits() + ", ((Number) " + fieldName + ").longValue())";
+                    return "io.writeUnsignedLong(" + integerTypeReference.getSizeInBits() + ", ((Number) " + fieldName + ").longValue()" + endianness + ")";
                 }
                 return "io.writeUnsignedBigInteger(" + integerTypeReference.getSizeInBits() + ", (BigInteger) " + fieldName + ")";
             }
             case INT: {
                 IntegerTypeReference integerTypeReference = (IntegerTypeReference) simpleTypeReference;
+                String endianness = integerTypeReference.isLittleEndian() ? ", true" : "";
                 if (integerTypeReference.getSizeInBits() <= 8) {
                     return "io.writeByte(" + integerTypeReference.getSizeInBits() + ", ((Number) " + fieldName + ").byteValue())";
                 }
                 if (integerTypeReference.getSizeInBits() <= 16) {
-                    return "io.writeShort(" + integerTypeReference.getSizeInBits() + ", ((Number) " + fieldName + ").shortValue())";
+                    return "io.writeShort(" + integerTypeReference.getSizeInBits() + ", ((Number) " + fieldName + ").shortValue()" + endianness + ")";
                 }
                 if (integerTypeReference.getSizeInBits() <= 32) {
-                    return "io.writeInt(" + integerTypeReference.getSizeInBits() + ", ((Number) " + fieldName + ").intValue())";
+                    return "io.writeInt(" + integerTypeReference.getSizeInBits() + ", ((Number) " + fieldName + ").intValue()" + endianness + ")";
                 }
                 if (integerTypeReference.getSizeInBits() <= 64) {
-                    return "io.writeLong(" + integerTypeReference.getSizeInBits() + ", ((Number) " + fieldName + ").longValue())";
+                    return "io.writeLong(" + integerTypeReference.getSizeInBits() + ", ((Number) " + fieldName + ").longValue() " + endianness + ")";
                 }
                 return "io.writeBigInteger(" + integerTypeReference.getSizeInBits() + ", BigInteger.valueOf( " + fieldName + "))";
             }
@@ -359,6 +363,8 @@ public class JavaLanguageTemplateHelper implements FreemarkerLanguageTemplateHel
         languageTypeName = languageTypeName.substring(0, 1).toUpperCase() + languageTypeName.substring(1);
         if(simpleTypeReference.getBaseType().equals(SimpleTypeReference.SimpleBaseType.UINT)) {
             return "readUnsigned" + languageTypeName;
+        } else if(simpleTypeReference.getBaseType().equals(SimpleTypeReference.SimpleBaseType.UINT)) {
+            return "readUnsigned" + languageTypeName + "LE";
         } else {
             return "read" + languageTypeName;
         }

--- a/build-utils/language-java/src/main/resources/templates/java/data-io-template.ftlh
+++ b/build-utils/language-java/src/main/resources/templates/java/data-io-template.ftlh
@@ -60,6 +60,8 @@ import java.util.function.Supplier;
 
 public class ${typeName}IO {
 
+    // data-io
+
     private static final Logger LOGGER = LoggerFactory.getLogger(${typeName}IO.class);
 
     public static PlcValue staticParse(ReadBuffer io<#if type.parserArguments?has_content>, <#list type.parserArguments as parserArgument>${helper.getLanguageTypeName(parserArgument.type, false)} ${parserArgument.name}<#sep>, </#sep></#list></#if>) throws ParseException {

--- a/build-utils/language-java/src/main/resources/templates/java/io-template.ftlh
+++ b/build-utils/language-java/src/main/resources/templates/java/io-template.ftlh
@@ -58,7 +58,9 @@ import java.util.function.Supplier;
 
 public class ${typeName}IO implements <#if outputFlavor != "passive">MessageIO<${typeName}, ${typeName}><#else>MessageInput<${typeName}></#if> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(${typeName}IO.class);
+    // io template  ${type} little endian ${type.littleEndian?c}
+
+private static final Logger LOGGER = LoggerFactory.getLogger(${typeName}IO.class);
 
 <#if !helper.isDiscriminatedType(type)>
     @Override

--- a/build-utils/language-java/src/main/resources/templates/java/io-template.ftlh
+++ b/build-utils/language-java/src/main/resources/templates/java/io-template.ftlh
@@ -58,9 +58,7 @@ import java.util.function.Supplier;
 
 public class ${typeName}IO implements <#if outputFlavor != "passive">MessageIO<${typeName}, ${typeName}><#else>MessageInput<${typeName}></#if> {
 
-    // io template  ${type} little endian ${type.littleEndian?c}
-
-private static final Logger LOGGER = LoggerFactory.getLogger(${typeName}IO.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(${typeName}IO.class);
 
 <#if !helper.isDiscriminatedType(type)>
     @Override
@@ -114,7 +112,10 @@ private static final Logger LOGGER = LoggerFactory.getLogger(${typeName}IO.class
     public static ${typeName}<#if helper.isDiscriminatedType(type)>Builder</#if> staticParse(ReadBuffer io<#if type.parserArguments?has_content>, <#list type.parserArguments as parserArgument>${helper.getLanguageTypeName(parserArgument.type, false)} ${parserArgument.name}<#sep>, </#sep></#list></#if>) throws ParseException {
         int startPos = io.getPos();
         int curPos;
-<#list type.fields as field>
+
+        <#if type.littleEndian>// this type is declared as little endian, field order have been changed to match full bytes in big endian order.</#if>
+
+<#list type.fieldsInOrder as field>
 <#switch field.typeName>
     <#case "array">
 
@@ -352,7 +353,9 @@ private static final Logger LOGGER = LoggerFactory.getLogger(${typeName}IO.class
     public static void staticSerialize(WriteBuffer io, ${typeName} _value<#if helper.getSerializerArguments(type.parserArguments)?has_content>, <#list helper.getSerializerArguments(type.parserArguments) as parserArgument>${helper.getLanguageTypeName(parserArgument.type, false)} ${parserArgument.name}<#sep>, </#sep></#list></#if>) throws ParseException {
         int startPos = io.getPos();
 
-<#list type.fields as field>
+    <#if type.littleEndian>// this type is declared as little endian, field order have been changed to match full bytes in big endian order.</#if>
+
+<#list type.fieldsInOrder as field>
 <#switch field.typeName>
     <#case "array">
 

--- a/build-utils/protocol-base-mspec/src/main/antlr4/org/apache/plc4x/plugins/codegenerator/language/mspec/MSpec.g4
+++ b/build-utils/protocol-base-mspec/src/main/antlr4/org/apache/plc4x/plugins/codegenerator/language/mspec/MSpec.g4
@@ -27,10 +27,10 @@ complexTypeDefinition
  ;
 
 complexType
- : 'type' name=idExpression (LBRACKET params=argumentList RBRACKET)? fieldDefinition*
- | 'discriminatedType' name=idExpression (LBRACKET params=argumentList RBRACKET)? fieldDefinition+
- | 'enum' type=typeReference name=idExpression (LBRACKET params=argumentList RBRACKET)? enumValues=enumValueDefinition+
- | 'dataIo' name=idExpression (LBRACKET params=argumentList RBRACKET)? dataIoTypeSwitch=dataIoDefinition
+ : 'type' (endianness=ENDIANNESS_LITERAL)? name=idExpression (LBRACKET params=argumentList RBRACKET)? fieldDefinition*
+ | 'discriminatedType' (endianness=ENDIANNESS_LITERAL)? name=idExpression (LBRACKET params=argumentList RBRACKET)? fieldDefinition+
+ | 'enum' (endianness=ENDIANNESS_LITERAL)? type=typeReference name=idExpression (LBRACKET params=argumentList RBRACKET)? enumValues=enumValueDefinition+
+ | 'dataIo' (endianness=ENDIANNESS_LITERAL)? name=idExpression (LBRACKET params=argumentList RBRACKET)? dataIoTypeSwitch=dataIoDefinition
  ;
 
 fieldDefinition

--- a/build-utils/protocol-base-mspec/src/main/antlr4/org/apache/plc4x/plugins/codegenerator/language/mspec/MSpec.g4
+++ b/build-utils/protocol-base-mspec/src/main/antlr4/org/apache/plc4x/plugins/codegenerator/language/mspec/MSpec.g4
@@ -138,8 +138,8 @@ caseStatement
 
 dataType
  : base='bit'
- | base='int' size=INTEGER_LITERAL
- | base='uint' size=INTEGER_LITERAL
+ | base='int' size=INTEGER_LITERAL (endianness=ENDIANNESS_LITERAL)?
+ | base='uint' size=INTEGER_LITERAL (endianness=ENDIANNESS_LITERAL)?
  | base='float' exponent=INTEGER_LITERAL '.' mantissa=INTEGER_LITERAL
  | base='ufloat' exponent=INTEGER_LITERAL '.' mantissa=INTEGER_LITERAL
 /* For the following types the parsing/serialization has to be handled manually */
@@ -150,6 +150,10 @@ dataType
  | base='time'
  | base='date'
  | base='dateTime'
+ ;
+
+ENDIANNESS_LITERAL
+ : 'big endian' | 'little endian'
  ;
 
 argument

--- a/build-utils/protocol-base-mspec/src/main/java/org/apache/plc4x/plugins/codegenerator/language/mspec/model/definitions/DefaultDataIoTypeDefinition.java
+++ b/build-utils/protocol-base-mspec/src/main/java/org/apache/plc4x/plugins/codegenerator/language/mspec/model/definitions/DefaultDataIoTypeDefinition.java
@@ -26,8 +26,8 @@ public class DefaultDataIoTypeDefinition extends DefaultTypeDefinition implement
 
     private final SwitchField switchField;
 
-    public DefaultDataIoTypeDefinition(String name, Argument[] parserArguments, String[] tags, SwitchField switchField) {
-        super(name, parserArguments, tags);
+    public DefaultDataIoTypeDefinition(String name, Argument[] parserArguments, String[] tags, boolean littleEndian, SwitchField switchField) {
+        super(name, parserArguments, tags, littleEndian);
         this.switchField = switchField;
     }
 

--- a/build-utils/protocol-base-mspec/src/main/java/org/apache/plc4x/plugins/codegenerator/language/mspec/model/definitions/DefaultDiscriminatedComplexTypeDefinition.java
+++ b/build-utils/protocol-base-mspec/src/main/java/org/apache/plc4x/plugins/codegenerator/language/mspec/model/definitions/DefaultDiscriminatedComplexTypeDefinition.java
@@ -30,8 +30,8 @@ public class DefaultDiscriminatedComplexTypeDefinition extends DefaultComplexTyp
 
     private final String[] discriminatorValues;
 
-    public DefaultDiscriminatedComplexTypeDefinition(String name, Argument[] parserArguments, String[] tags, String[] discriminatorValues, List<Field> fields) {
-        super(name, parserArguments, tags, false, fields);
+    public DefaultDiscriminatedComplexTypeDefinition(String name, Argument[] parserArguments, String[] tags, boolean littleEndian, String[] discriminatorValues, List<Field> fields) {
+        super(name, parserArguments, tags, littleEndian, false, fields);
         this.discriminatorValues = discriminatorValues;
     }
 

--- a/build-utils/protocol-base-mspec/src/main/java/org/apache/plc4x/plugins/codegenerator/language/mspec/model/definitions/DefaultEnumTypeDefinition.java
+++ b/build-utils/protocol-base-mspec/src/main/java/org/apache/plc4x/plugins/codegenerator/language/mspec/model/definitions/DefaultEnumTypeDefinition.java
@@ -34,8 +34,8 @@ public class DefaultEnumTypeDefinition extends DefaultTypeDefinition implements 
     private final Map<String, TypeReference> constants;
 
     public DefaultEnumTypeDefinition(String name, TypeReference type, EnumValue[] enumValues,
-                                     Argument[] constants, String[] tags) {
-        super(name, constants, tags);
+                                     Argument[] constants, String[] tags, boolean littleEndian) {
+        super(name, constants, tags, littleEndian);
         this.type = type;
         this.enumValues = enumValues;
         this.constants = new HashMap<>();

--- a/build-utils/protocol-base-mspec/src/main/java/org/apache/plc4x/plugins/codegenerator/language/mspec/model/definitions/DefaultTypeDefinition.java
+++ b/build-utils/protocol-base-mspec/src/main/java/org/apache/plc4x/plugins/codegenerator/language/mspec/model/definitions/DefaultTypeDefinition.java
@@ -28,12 +28,14 @@ public abstract class DefaultTypeDefinition {
     private final String name;
     private final Argument[] parserArguments;
     private final String[] tags;
+    private final boolean littleEndian;
     private TypeDefinition parentType;
 
-    public DefaultTypeDefinition(String name, Argument[] parserArguments, String[] tags) {
+    public DefaultTypeDefinition(String name, Argument[] parserArguments, String[] tags, boolean littleEndian) {
         this.name = name;
         this.parserArguments = parserArguments;
         this.tags = tags;
+        this.littleEndian = littleEndian;
         this.parentType = null;
     }
 
@@ -51,6 +53,10 @@ public abstract class DefaultTypeDefinition {
 
     public TypeDefinition getParentType() {
         return parentType;
+    }
+
+    public boolean isLittleEndian() {
+        return littleEndian;
     }
 
     public void setParentType(TypeDefinition parentType) {

--- a/build-utils/protocol-base-mspec/src/main/java/org/apache/plc4x/plugins/codegenerator/language/mspec/model/references/DefaultIntegerTypeReference.java
+++ b/build-utils/protocol-base-mspec/src/main/java/org/apache/plc4x/plugins/codegenerator/language/mspec/model/references/DefaultIntegerTypeReference.java
@@ -23,8 +23,16 @@ import org.apache.plc4x.plugins.codegenerator.types.references.IntegerTypeRefere
 
 public class DefaultIntegerTypeReference extends DefaultSimpleTypeReference implements IntegerTypeReference {
 
-    public DefaultIntegerTypeReference(SimpleBaseType baseType, int sizeInBits) {
+    private final boolean littleEndian;
+
+    public DefaultIntegerTypeReference(SimpleBaseType baseType, int sizeInBits, boolean littleEndian) {
         super(baseType, sizeInBits);
+        this.littleEndian = littleEndian;
+    }
+
+    @Override
+    public boolean isLittleEndian() {
+        return littleEndian;
     }
 
 }

--- a/build-utils/protocol-base-mspec/src/main/java/org/apache/plc4x/plugins/codegenerator/language/mspec/model/references/DefaultSimpleVarLengthTypeReference.java
+++ b/build-utils/protocol-base-mspec/src/main/java/org/apache/plc4x/plugins/codegenerator/language/mspec/model/references/DefaultSimpleVarLengthTypeReference.java
@@ -24,7 +24,7 @@ import org.apache.plc4x.plugins.codegenerator.types.references.SimpleVarLengthTy
 public class DefaultSimpleVarLengthTypeReference extends DefaultIntegerTypeReference implements SimpleVarLengthTypeReference {
 
     public DefaultSimpleVarLengthTypeReference(SimpleBaseType baseType) {
-        super(baseType, -1);
+        super(baseType, -1, false);
     }
 
 }

--- a/build-utils/protocol-base-mspec/src/main/java/org/apache/plc4x/plugins/codegenerator/language/mspec/parser/MessageFormatListener.java
+++ b/build-utils/protocol-base-mspec/src/main/java/org/apache/plc4x/plugins/codegenerator/language/mspec/parser/MessageFormatListener.java
@@ -447,7 +447,8 @@ public class MessageFormatListener extends MSpecBaseListener {
         // If a size it specified its a simple integer length based type.
         if (ctx.size != null) {
             int size = Integer.parseInt(ctx.size.getText());
-            return new DefaultIntegerTypeReference(simpleBaseType, size);
+            boolean littleEndian = isLittleEndian(() -> ctx.endianness);
+            return new DefaultIntegerTypeReference(simpleBaseType, size, littleEndian);
         }
         // If exponent and mantissa are present, it's a floating point representation.
         else if((ctx.exponent != null) && (ctx.mantissa != null)) {
@@ -462,7 +463,7 @@ public class MessageFormatListener extends MSpecBaseListener {
         }
         // In all other cases (bit) it's just assume it's length it 1.
         else {
-            return new DefaultIntegerTypeReference(simpleBaseType, 1);
+            return new DefaultIntegerTypeReference(simpleBaseType, 1, false);
         }
     }
 
@@ -515,6 +516,11 @@ public class MessageFormatListener extends MSpecBaseListener {
             return quotedString.substring(1, quotedString.length() - 1);
         }
         return quotedString;
+    }
+
+    private boolean isLittleEndian(Supplier<Token> endianness) {
+        Token token = endianness.get();
+        return token != null && token.getText().equalsIgnoreCase("little endian");
     }
 
 }

--- a/build-utils/protocol-base-mspec/src/test/resources/mspec.example
+++ b/build-utils/protocol-base-mspec/src/test/resources/mspec.example
@@ -132,11 +132,11 @@
     // This is the AmsNetId of the station, for which the packet is intended. Remarks see below.
     [simple     AmsNetId        'targetAmsNetId'                            ]
     // This is the AmsPort of the station, for which the packet is intended.
-    [simple     uint        16  'targetAmsPort'                             ]
+    [simple     uint        16  little endian 'targetAmsPort'               ]
     // This contains the AmsNetId of the station, from which the packet was sent.
     [simple     AmsNetId        'sourceAmsNetId'                            ]
     // This contains the AmsPort of the station, from which the packet was sent.
-    [simple     uint        16  'sourceAmsPort'                             ]
+    [simple     uint        16  little endian 'sourceAmsPort'               ]
     // 2 bytes.
     [enum       CommandId       'commandId'                                 ]
     // 2 bytes.

--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/configuration/ConfigurationParameterConverter.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/configuration/ConfigurationParameterConverter.java
@@ -1,0 +1,44 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+package org.apache.plc4x.java.spi.configuration;
+
+/**
+ * Interface which allows to convert parameter from URI into its complex form.
+ */
+public interface ConfigurationParameterConverter<T> {
+
+    /**
+     * Type of supported configuration parameter.
+     *
+     * Returned value determines Java type to which this converter is able to turn string representation. Only if field
+     * type is assignable to returned type conversion attempt will be made.
+     *
+     * @return Java type constructed by converter.
+     */
+    Class<T> getType();
+
+    /**
+     * Executes conversion of parameter textual representation into java object.
+     *
+     * @param value Parameter value.
+     * @return Object representing passed string value.
+     */
+    T convert(String value);
+
+}

--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/configuration/annotations/ParameterConverter.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/configuration/annotations/ParameterConverter.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.plc4x.java.spi.configuration.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.apache.plc4x.java.spi.configuration.ConfigurationParameterConverter;
+
+/**
+ * Helper annotation to customize handling of configuration parameter conversion.
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ParameterConverter {
+
+    /**
+     * Type which should be used for conversion of text value to object representation.
+     *
+     * @return Class implementing necessary conversion logic.
+     */
+    Class<? extends ConfigurationParameterConverter<?>> value();
+
+}

--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/generation/ReadBuffer.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/generation/ReadBuffer.java
@@ -118,6 +118,10 @@ public class ReadBuffer {
     }
 
     public int readUnsignedInt(int bitLength) throws ParseException {
+        return readUnsignedInt(bitLength, littleEndian);
+    }
+
+    public int readUnsignedInt(int bitLength, boolean littleEndian) throws ParseException {
         if (bitLength <= 0) {
             throw new ParseException("unsigned int must contain at least 1 bit");
         }
@@ -135,6 +139,10 @@ public class ReadBuffer {
     }
 
     public long readUnsignedLong(int bitLength) throws ParseException {
+        return readUnsignedLong(bitLength, littleEndian);
+    }
+
+    public long readUnsignedLong(int bitLength, boolean littleEndian) throws ParseException {
         if (bitLength <= 0) {
             throw new ParseException("unsigned long must contain at least 1 bit");
         }
@@ -170,6 +178,10 @@ public class ReadBuffer {
     }
 
     public short readShort(int bitLength) throws ParseException {
+        return readShort(bitLength, littleEndian);
+    }
+
+    public short readShort(int bitLength, boolean littleEndian) throws ParseException {
         if (bitLength <= 0) {
             throw new ParseException("short must contain at least 1 bit");
         }
@@ -187,6 +199,10 @@ public class ReadBuffer {
     }
 
     public int readInt(int bitLength) throws ParseException {
+        return readInt(bitLength, littleEndian);
+    }
+
+    public int readInt(int bitLength, boolean littleEndian) throws ParseException {
         if (bitLength <= 0) {
             throw new ParseException("int must contain at least 1 bit");
         }
@@ -204,6 +220,10 @@ public class ReadBuffer {
     }
 
     public long readLong(int bitLength) throws ParseException {
+        return readLong(bitLength, littleEndian);
+    }
+
+    public long readLong(int bitLength, boolean littleEndian) throws ParseException {
         if (bitLength <= 0) {
             throw new ParseException("long must contain at least 1 bit");
         }

--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/generation/WriteBuffer.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/generation/WriteBuffer.java
@@ -84,6 +84,10 @@ public class WriteBuffer {
     }
 
     public void writeUnsignedShort(int bitLength, short value) throws ParseException {
+        writeUnsignedShort(bitLength, value, littleEndian);
+    }
+
+    public void writeUnsignedShort(int bitLength, short value, boolean littleEndian) throws ParseException {
         if(bitLength <= 0) {
             throw new ParseException("unsigned short must contain at least 1 bit");
         }
@@ -91,6 +95,9 @@ public class WriteBuffer {
             throw new ParseException("unsigned short can only contain max 8 bits");
         }
         try {
+            if (littleEndian) {
+                value = Short.reverseBytes(value);
+            }
             bo.writeShort(true, bitLength, value);
         } catch (IOException e) {
             throw new ParseException("Error reading", e);
@@ -98,6 +105,10 @@ public class WriteBuffer {
     }
 
     public void writeUnsignedInt(int bitLength, int value) throws ParseException {
+        writeUnsignedInt(bitLength, value, littleEndian);
+    }
+
+    public void writeUnsignedInt(int bitLength, int value, boolean littleEndian) throws ParseException {
         if(bitLength <= 0) {
             throw new ParseException("unsigned int must contain at least 1 bit");
         }
@@ -105,7 +116,7 @@ public class WriteBuffer {
             throw new ParseException("unsigned int can only contain max 16 bits");
         }
         try {
-            if(littleEndian) {
+            if (littleEndian) {
                 value = Integer.reverseBytes(value) >> 16;
             }
             bo.writeInt(true, bitLength, value);
@@ -115,6 +126,10 @@ public class WriteBuffer {
     }
 
     public void writeUnsignedLong(int bitLength, long value) throws ParseException {
+        writeUnsignedLong(bitLength, value, littleEndian);
+    }
+
+    public void writeUnsignedLong(int bitLength, long value, boolean littleEndian) throws ParseException {
         if(bitLength <= 0) {
             throw new ParseException("unsigned long must contain at least 1 bit");
         }
@@ -122,7 +137,7 @@ public class WriteBuffer {
             throw new ParseException("unsigned long can only contain max 32 bits");
         }
         try {
-            if(littleEndian) {
+            if (littleEndian) {
                 value = Long.reverseBytes(value) >> 32;
             }
             bo.writeLong(true, bitLength, value);
@@ -150,6 +165,10 @@ public class WriteBuffer {
     }
 
     public void writeShort(int bitLength, short value) throws ParseException {
+        writeShort(bitLength, value, littleEndian);
+    }
+
+    public void writeShort(int bitLength, short value, boolean littleEndian) throws ParseException {
         if(bitLength <= 0) {
             throw new ParseException("short must contain at least 1 bit");
         }
@@ -157,7 +176,7 @@ public class WriteBuffer {
             throw new ParseException("short can only contain max 16 bits");
         }
         try {
-            if(littleEndian) {
+            if (littleEndian) {
                 value = Short.reverseBytes(value);
             }
             bo.writeShort(false, bitLength, value);
@@ -167,6 +186,10 @@ public class WriteBuffer {
     }
 
     public void writeInt(int bitLength, int value) throws ParseException {
+        writeInt(bitLength, value, littleEndian);
+    }
+
+    public void writeInt(int bitLength, int value, boolean littleEndian) throws ParseException {
         if(bitLength <= 0) {
             throw new ParseException("int must contain at least 1 bit");
         }
@@ -184,6 +207,10 @@ public class WriteBuffer {
     }
 
     public void writeLong(int bitLength, long value) throws ParseException {
+        writeLong(bitLength, value, littleEndian);
+    }
+
+    public void writeLong(int bitLength, long value, boolean littleEndian) throws ParseException {
         if(bitLength <= 0) {
             throw new ParseException("long must contain at least 1 bit");
         }
@@ -191,7 +218,7 @@ public class WriteBuffer {
             throw new ParseException("long can only contain max 64 bits");
         }
         try {
-            if(littleEndian) {
+            if (littleEndian) {
                 value = Long.reverseBytes(value);
             }
             bo.writeLong(false, bitLength, value);

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <!-- Exclude all generated code -->
     <sonar.exclusions>**/generated-sources</sonar.exclusions>
 
-    <plc4x-code-generation.version>1.2.0</plc4x-code-generation.version>
+    <plc4x-code-generation.version>1.3.0-SNAPSHOT</plc4x-code-generation.version>
 
     <antlr.version>4.7.2</antlr.version>
     <apiguardian.version>1.1.0</apiguardian.version>

--- a/protocols/amsads/src/main/resources/protocols/amsads/amsads.mspec
+++ b/protocols/amsads/src/main/resources/protocols/amsads/amsads.mspec
@@ -126,17 +126,17 @@
     // This is the AmsNetId of the station, for which the packet is intended. Remarks see below.
     [simple     AmsNetId        'targetAmsNetId'                            ]
     // This is the AmsPort of the station, for which the packet is intended.
-    [simple     uint        16  'targetAmsPort'                             ]
+    [simple     uint        16  little endian 'targetAmsPort'               ]
     // This contains the AmsNetId of the station, from which the packet was sent.
     [simple     AmsNetId        'sourceAmsNetId'                            ]
     // This contains the AmsPort of the station, from which the packet was sent.
-    [simple     uint        16  'sourceAmsPort'                             ]
+    [simple     uint        16  little endian 'sourceAmsPort'               ]
     // 2 bytes.
     [enum       CommandId       'commandId'                                 ]
     // 2 bytes.
     [simple     State           'state'                                     ]
     // 4 bytes	Size of the data range. The unit is byte.
-    [simple     uint        32  'length'                                ]
+    [simple     uint        32  little endian 'length'                      ]
     // 4 bytes	AMS error number. See ADS Return Codes.
     [simple     uint        32  'errorCode'                                 ]
     // free usable field of 4 bytes
@@ -144,7 +144,7 @@
     [simple      uint        32  'invokeId'                                 ]
 ]
 
-[enum uint 16 'CommandId'
+[enum uint 16 little endian 'CommandId'
     ['0x00' INVALID]
     ['0x01' ADS_READ_DEVICE_INFO]
     ['0x02' ADS_READ]

--- a/protocols/amsads/src/main/resources/protocols/amsads/amsads.mspec
+++ b/protocols/amsads/src/main/resources/protocols/amsads/amsads.mspec
@@ -141,7 +141,7 @@
     [simple     uint        32  'errorCode'                                 ]
     // free usable field of 4 bytes
     // 4 bytes	Free usable 32 bit array. Usually this array serves to send an Id. This Id makes is possible to assign a received response to a request, which was sent before.
-    [simple      uint        32  'invokeId'                                 ]
+    [simple      uint        32  little endian 'invokeId'                   ]
 ]
 
 [enum uint 16 little endian 'CommandId'
@@ -157,7 +157,7 @@
     ['0x09' ADS_READ_WRITE]
 ]
 
-[type 'State'
+[type little endian 'State'
     [simple     bit 'broadcast'             ]
     [reserved   int 7 '0x0'                 ]
     [simple     bit 'initCommand'           ]
@@ -225,11 +225,11 @@
         ]
         ['CommandId.ADS_READ', 'false' AdsReadRequest
             // 4 bytes	Index Group of the data which should be read.
-            [simple uint 32 'indexGroup']
+            [simple uint 32 little endian 'indexGroup']
             // 4 bytes	Index Offset of the data which should be read.
-            [simple uint 32 'indexOffset']
+            [simple uint 32 little endian 'indexOffset']
             // 4 bytes	Length of the data (in bytes) which should be read.
-            [simple uint 32 'length']
+            [simple uint 32 little endian 'length']
         ]
         ['CommandId.ADS_WRITE', 'true' AdsWriteResponse
             // 4 bytes	ADS error number

--- a/sandbox/test-java-amsads-driver/src/main/java/org/apache/plc4x/java/amsads/configuration/AdsConfiguration.java
+++ b/sandbox/test-java-amsads-driver/src/main/java/org/apache/plc4x/java/amsads/configuration/AdsConfiguration.java
@@ -21,17 +21,31 @@ package org.apache.plc4x.java.amsads.configuration;
 import org.apache.plc4x.java.amsads.AMSADSPlcDriver;
 import org.apache.plc4x.java.amsads.readwrite.AmsNetId;
 import org.apache.plc4x.java.spi.configuration.Configuration;
+import org.apache.plc4x.java.spi.configuration.ConfigurationParameterConverter;
+import org.apache.plc4x.java.spi.configuration.annotations.ConfigurationParameter;
+import org.apache.plc4x.java.spi.configuration.annotations.ParameterConverter;
+import org.apache.plc4x.java.spi.configuration.annotations.Required;
 import org.apache.plc4x.java.transport.serial.SerialTransportConfiguration;
 import org.apache.plc4x.java.transport.tcp.TcpTransportConfiguration;
 
 public class AdsConfiguration implements Configuration, TcpTransportConfiguration, SerialTransportConfiguration {
 
+    @Required
+    @ConfigurationParameter
+    @ParameterConverter(AmsNetIdConverter.class)
     protected AmsNetId targetAmsNetId;
 
+    @Required
+    @ConfigurationParameter
     protected int targetAmsPort;
 
+    @Required
+    @ConfigurationParameter
+    @ParameterConverter(AmsNetIdConverter.class)
     protected AmsNetId sourceAmsNetId;
 
+    @Required
+    @ConfigurationParameter
     protected int sourceAmsPort;
 
     public AmsNetId getTargetAmsNetId() {
@@ -71,4 +85,16 @@ public class AdsConfiguration implements Configuration, TcpTransportConfiguratio
         return AMSADSPlcDriver.TCP_PORT;
     }
 
+    public static class AmsNetIdConverter implements ConfigurationParameterConverter<AmsNetId> {
+
+        @Override
+        public Class<AmsNetId> getType() {
+            return AmsNetId.class;
+        }
+
+        @Override
+        public AmsNetId convert(String value) {
+            return AMSADSPlcDriver.AmsNetIdOf(value);
+        }
+    }
 }

--- a/sandbox/test-java-amsads-driver/src/test/java/org/apache/plc4x/protocol/amsads/AmsHeaderSerializerParserTest.java
+++ b/sandbox/test-java-amsads-driver/src/test/java/org/apache/plc4x/protocol/amsads/AmsHeaderSerializerParserTest.java
@@ -1,0 +1,33 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+*/
+
+package org.apache.plc4x.protocol.amsads;
+
+import org.apache.plc4x.test.parserserializer.ParserSerializerTestsuiteRunner;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+public class AmsHeaderSerializerParserTest extends ParserSerializerTestsuiteRunner {
+
+    public AmsHeaderSerializerParserTest() {
+        super("/testsuite/AmsHeaderParserSerializerTest.xml");
+    }
+
+}

--- a/sandbox/test-java-amsads-driver/src/test/java/org/apache/plc4x/protocol/amsads/AmsNetIdSerializerParserTest.java
+++ b/sandbox/test-java-amsads-driver/src/test/java/org/apache/plc4x/protocol/amsads/AmsNetIdSerializerParserTest.java
@@ -19,11 +19,12 @@
 
 package org.apache.plc4x.protocol.amsads;
 
+import org.apache.plc4x.test.parserserializer.ParserSerializerTestsuiteRunner;
 
-public class AmsAdsSerializerParserTest /*extends ProtocolTestsuiteRunner*/ {
+public class AmsNetIdSerializerParserTest extends ParserSerializerTestsuiteRunner {
 
-    public AmsAdsSerializerParserTest() {
-        //super("/testsuite/Df1Testsuite.xml");
+    public AmsNetIdSerializerParserTest() {
+        super("/testsuite/AmsNetIdParserSerializerTest.xml");
     }
 
 }

--- a/sandbox/test-java-amsads-driver/src/test/java/org/apache/plc4x/protocol/amsads/StateSerializerParserTest.java
+++ b/sandbox/test-java-amsads-driver/src/test/java/org/apache/plc4x/protocol/amsads/StateSerializerParserTest.java
@@ -1,0 +1,30 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+*/
+
+package org.apache.plc4x.protocol.amsads;
+
+import org.apache.plc4x.test.parserserializer.ParserSerializerTestsuiteRunner;
+
+public class StateSerializerParserTest extends ParserSerializerTestsuiteRunner {
+
+    public StateSerializerParserTest() {
+        super("/testsuite/StateParserSerializerTest.xml");
+    }
+
+}

--- a/sandbox/test-java-amsads-driver/src/test/resources/testsuite/AmsHeaderParserSerializerTest.xml
+++ b/sandbox/test-java-amsads-driver/src/test/resources/testsuite/AmsHeaderParserSerializerTest.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+<test:testsuite xmlns:test="https://plc4x.apache.org/schemas/parser-serializer-testsuite.xsd" bigEndian="true">
+
+  <name>AmsHeader</name>
+
+  <testcase>
+    <name>Header 0.0.0.0.1.1/10000, 0.0.0.0.1.1/32769, read state</name>
+    <raw>0000000001011027000000000101018004000400000000000000000009000000</raw>
+    <root-type>AmsHeader</root-type>
+    <xml>
+      <AmsHeader className="org.apache.plc4x.java.amsads.readwrite.AmsHeader">
+        <targetAmsNetId className="org.apache.plc4x.java.amsads.readwrite.AmsNetId">
+          <octet1>0</octet1>
+          <octet2>0</octet2>
+          <octet3>0</octet3>
+          <octet4>0</octet4>
+          <octet5>1</octet5>
+          <octet6>1</octet6>
+        </targetAmsNetId>
+        <targetAmsPort>10000</targetAmsPort>
+        <sourceAmsNetId className="org.apache.plc4x.java.amsads.readwrite.AmsNetId">
+          <octet1>0</octet1>
+          <octet2>0</octet2>
+          <octet3>0</octet3>
+          <octet4>0</octet4>
+          <octet5>1</octet5>
+          <octet6>1</octet6>
+        </sourceAmsNetId>
+        <sourceAmsPort>32769</sourceAmsPort>
+        <commandId>ADS_READ_STATE</commandId>
+        <state className="org.apache.plc4x.java.amsads.readwrite.State">
+          <broadcast>false</broadcast>
+          <initCommand>false</initCommand>
+          <updCommand>false</updCommand>
+          <timestampAdded>false</timestampAdded>
+          <highPriorityCommand>false</highPriorityCommand>
+          <systemCommand>false</systemCommand>
+          <adsCommand>true</adsCommand>
+          <noReturn>false</noReturn>
+          <response>false</response>
+        </state>
+        <length>0</length>
+        <errorCode>0</errorCode>
+        <invokeId>9</invokeId>
+      </AmsHeader>
+    </xml>
+  </testcase>
+
+</test:testsuite>

--- a/sandbox/test-java-amsads-driver/src/test/resources/testsuite/AmsNetIdParserSerializerTest.xml
+++ b/sandbox/test-java-amsads-driver/src/test/resources/testsuite/AmsNetIdParserSerializerTest.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+<test:testsuite xmlns:test="https://plc4x.apache.org/schemas/parser-serializer-testsuite.xsd" bigEndian="true">
+
+  <name>AmsNetId</name>
+
+  <testcase>
+    <name>Test parsing of ams id 0.0.0.0.1.1</name>
+    <raw>000000000101</raw>
+    <root-type>AmsNetId</root-type>
+    <xml>
+      <AmsNetId className="org.apache.plc4x.java.amsads.readwrite.AmsNetId">
+        <octet1>0</octet1>
+        <octet2>0</octet2>
+        <octet3>0</octet3>
+        <octet4>0</octet4>
+        <octet5>1</octet5>
+        <octet6>1</octet6>
+      </AmsNetId>
+    </xml>
+  </testcase>
+
+  <testcase>
+    <name>Test parsing of ams id 10.10.2.232.1.1</name>
+    <raw>0a0a02e80101</raw>
+    <root-type>AmsNetId</root-type>
+    <xml>
+      <AmsNetId className="org.apache.plc4x.java.amsads.readwrite.AmsNetId">
+        <octet1>10</octet1>
+        <octet2>10</octet2>
+        <octet3>2</octet3>
+        <octet4>232</octet4>
+        <octet5>1</octet5>
+        <octet6>1</octet6>
+      </AmsNetId>
+    </xml>
+  </testcase>
+
+  <testcase>
+    <name>Test parsing of ams id 10.10.10.10.10.10</name>
+    <raw>0a0a0a0a0a0a</raw>
+    <root-type>AmsNetId</root-type>
+    <xml>
+      <AmsNetId className="org.apache.plc4x.java.amsads.readwrite.AmsNetId">
+        <octet1>10</octet1>
+        <octet2>10</octet2>
+        <octet3>10</octet3>
+        <octet4>10</octet4>
+        <octet5>10</octet5>
+        <octet6>10</octet6>
+      </AmsNetId>
+    </xml>
+  </testcase>
+
+</test:testsuite>

--- a/sandbox/test-java-amsads-driver/src/test/resources/testsuite/StateParserSerializerTest.xml
+++ b/sandbox/test-java-amsads-driver/src/test/resources/testsuite/StateParserSerializerTest.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+<test:testsuite xmlns:test="https://plc4x.apache.org/schemas/parser-serializer-testsuite.xsd" bigEndian="true">
+
+  <name>State</name>
+
+  <testcase>
+    <name>State ADS_COMMAND</name>
+    <raw>0400</raw>
+    <root-type>State</root-type>
+    <xml>
+      <State className="org.apache.plc4x.java.amsads.readwrite.State">
+        <broadcast>false</broadcast>
+        <initCommand>false</initCommand>
+        <updCommand>false</updCommand>
+        <timestampAdded>false</timestampAdded>
+        <highPriorityCommand>false</highPriorityCommand>
+        <systemCommand>false</systemCommand>
+        <adsCommand>true</adsCommand>
+        <noReturn>false</noReturn>
+        <response>false</response>
+      </State>
+    </xml>
+  </testcase>
+
+  <testcase>
+    <name>State ADS_COMMAND RESPONSE</name>
+    <raw>0500</raw>
+    <root-type>State</root-type>
+    <xml>
+      <State className="org.apache.plc4x.java.amsads.readwrite.State">
+        <broadcast>false</broadcast>
+        <initCommand>false</initCommand>
+        <updCommand>false</updCommand>
+        <timestampAdded>false</timestampAdded>
+        <highPriorityCommand>false</highPriorityCommand>
+        <systemCommand>false</systemCommand>
+        <adsCommand>true</adsCommand>
+        <noReturn>false</noReturn>
+        <response>true</response>
+      </State>
+    </xml>
+  </testcase>
+
+</test:testsuite>


### PR DESCRIPTION
This is work in progress to support little endian numbers in the operations. Not sure what to do with byte sequences and reserved fields. Theoretically they should work.