### PR TITLE
complex object members should not leak to external entities, add apis…

### DIFF
--- a/sandbox/plc4c/.clang-format
+++ b/sandbox/plc4c/.clang-format
@@ -1,0 +1,168 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/sandbox/plc4c/api/include/plc4c/connection.h
+++ b/sandbox/plc4c/api/include/plc4c/connection.h
@@ -23,8 +23,91 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+
 #include "types.h"
 #include "utils/list.h"
+
+/**
+ * Initializes the connection members to their defaults.
+ * @param connection plc4c_connection
+ */
+void plc4c_connection_initialize(plc4c_connection *connection);
+
+/**
+ * Returns the connection string for a given connection
+ * @param connection plc4c_connection
+ * @return connection string
+ */
+char *plc4c_connection_get_connection_string(plc4c_connection *connection);
+
+/**
+ * Set the connection string
+ * @param connection plc4c_connection
+ * @param connection_string
+ */
+void plc4c_connection_set_connection_string(plc4c_connection *connection,
+                                            char *connection_string);
+
+/**
+ * Returns the protocol code for the given connection
+ * @param connection plc4c_connection
+ * @return protocol code
+ */
+char *plc4c_connection_get_protocol_code(plc4c_connection *connection);
+
+/**
+ * Set the protocol code
+ * @param connection plc4c_connection
+ * @param protocol_code
+ */
+void plc4c_connection_set_protocol_code(plc4c_connection *connection,
+                                        char *protocol_code);
+
+/**
+ * Returns the transport code for the given connection
+ * @param connection
+ * @return transport code
+ */
+char *plc4c_connection_get_transport_code(plc4c_connection *connection);
+
+/**
+ * Set the transport code
+ * @param connection plc4c_connection
+ * @param transport_code
+ */
+void plc4c_connection_set_transport_code(plc4c_connection *connection,
+                                         char *transport_code);
+
+/**
+ * Returns the transport connection information for a given connection
+ * @param connection plc4c_connection
+ * @return transport connection information
+ */
+char *plc4c_connection_get_transport_connect_information(
+    plc4c_connection *connection);
+
+/**
+ * Set the transport connect information
+ * @param connection plc4c_connection
+ * @param transport_connect_information
+ */
+void plc4c_connection_set_transport_connect_information(
+    plc4c_connection *connection, char *transport_connect_information);
+
+/**
+ * Returns the parameters for a given connection
+ * @param connection plc4c_connection
+ * @return parameters
+ */
+char *plc4c_connection_get_parameters(plc4c_connection *connection);
+
+/**
+ * Set the parameters
+ * @param connection plc4c_connection
+ * @param parameters
+ */
+void plc4c_connection_set_parameters(plc4c_connection *connection,
+                                     char *parameters);
 
 /**
  * Check if the connection is established successfully.
@@ -33,6 +116,44 @@ extern "C" {
  * @return true if the connection is established.
  */
 bool plc4c_connection_is_connected(plc4c_connection *connection);
+
+/**
+ * Sets the connected status of a given connection
+ * @param connection plc4c_connection
+ * @param connected bool is connected
+ */
+void plc4c_connection_set_connected(plc4c_connection *connection,
+                                    bool connected);
+
+/**
+ * Returns the status of the disconnect flag for a given connection
+ * @param connection plc4c_connection
+ * @return if the flag is set
+ */
+bool plc4c_connection_disconnect_is_set(plc4c_connection *connection);
+
+/**
+ * Sets the status of the disconnect flag for a given connection
+ * @param connection plc4c_connection
+ * @param disconnect the new flag status
+ */
+void plc4c_connection_disconnect_set(plc4c_connection *connection,
+                                     bool disconnect);
+
+/**
+ * Returns the system associated with a given connection
+ * @param connection plc4c_connection
+ * @return plc4c_system
+ */
+plc4c_system *plc4c_connection_get_system(plc4c_connection *connection);
+
+/**
+ * Sets a plc4c_system for a given connnection
+ * @param connection plc4c_connection
+ * @param system plc4c_system
+ */
+void plc4c_connection_set_system(plc4c_connection *connection,
+                                 plc4c_system *system);
 
 /**
  * Check if an error occurred while connecting.
@@ -79,10 +200,9 @@ bool plc4c_connection_supports_reading(plc4c_connection *connection);
  * @param read_request pointer to the read-request
  * @param plc4c_return_code
  */
-plc4c_return_code plc4c_connection_create_read_request(plc4c_connection *connection,
-                                                       plc4c_list *addresses,
-                                                       plc4c_read_request **read_request);
-
+plc4c_return_code plc4c_connection_create_read_request(
+    plc4c_connection *connection, plc4c_list *addresses,
+    plc4c_read_request **read_request);
 
 /**
  * Destroys a given read_response
@@ -108,16 +228,16 @@ bool plc4c_connection_supports_writing(plc4c_connection *connection);
  * @param write_request pointer to the write-request
  * @param plc4c_return_code
  */
-plc4c_return_code plc4c_connection_create_write_request(plc4c_connection *connection,
-                                                        plc4c_list *addresses,
-                                                        plc4c_list *values,
-                                                        plc4c_write_request **write_request);
+plc4c_return_code plc4c_connection_create_write_request(
+    plc4c_connection *connection, plc4c_list *addresses, plc4c_list *values,
+    plc4c_write_request **write_request);
 
 /**
  * Destroys a given write_response
  * @param write_response the write_response
  */
-void plc4c_connection_write_response_destroy(plc4c_write_response *write_response);
+void plc4c_connection_write_response_destroy(
+    plc4c_write_response *write_response);
 
 /**
  * Check if the current connection supports subscriptions.
@@ -127,7 +247,34 @@ void plc4c_connection_write_response_destroy(plc4c_write_response *write_respons
  */
 bool plc4c_connection_supports_subscriptions(plc4c_connection *connection);
 
+/**
+ * Returns the current number of running tasks for this connection
+ * @param connection plc4c_connection
+ * @return the count of running tasks
+ */
+int plc4c_connection_running_tasks_count(plc4c_connection *connection);
+
+/**
+ *
+ * @param connection
+ */
+void plc4c_connection_running_tasks_clear(plc4c_connection *connection);
+
+/**
+ * Signals the plc4c_connection that a task has been added
+ * @param connection plc4c_connection
+ * @return the number of tasks after this operation
+ */
+int plc4c_connection_task_added(plc4c_connection *connection);
+
+/**
+ * Signals the plc4c_connection that a task has been completed and removed
+ * @param connection plc4c_connection
+ * @return the number of tasks after this operation
+ */
+int plc4c_connection_task_removed(plc4c_connection *connection);
+
 #ifdef __cplusplus
 }
 #endif
-#endif //PLC4C_CONNECTION_H_
+#endif  // PLC4C_CONNECTION_H_

--- a/sandbox/plc4c/api/include/plc4c/read.h
+++ b/sandbox/plc4c/api/include/plc4c/read.h
@@ -25,14 +25,32 @@ extern "C" {
 #include "plc4c/types.h"
 
 /**
+ * Returns the plc4c_connection for a give read request
+ * @param read_request plc4c_read_request
+ * @return plc4c_connection
+ */
+plc4c_connection *plc4c_read_request_get_connection(
+    plc4c_read_request *read_request);
+
+/**
+ * Sets the plc4c_connection for a given read request
+ * @param read_request plc4c_read_request
+ * @param connection plc4c_connection
+ */
+void plc4c_read_request_set_connection(plc4c_read_request *read_request,
+                                       plc4c_connection *connection);
+
+/**
  * Actually executes the read-request.
  * @param connection connection this read-request will be executed on.
  * @param read_request the read-request object.
- * @param read_request_execution pointer to a data-structure handling one execution of the read-request.
+ * @param read_request_execution pointer to a data-structure handling one
+ * execution of the read-request.
  * @return plc4c_return_code
  */
-plc4c_return_code plc4c_read_request_execute(plc4c_read_request *read_request,
-                                             plc4c_read_request_execution **read_request_execution);
+plc4c_return_code plc4c_read_request_execute(
+    plc4c_read_request *read_request,
+    plc4c_read_request_execution **read_request_execution);
 
 /**
  * Check if the read-request is completed successfully.
@@ -40,7 +58,8 @@ plc4c_return_code plc4c_read_request_execute(plc4c_read_request *read_request,
  * @param read_request_execution the read-request execution.
  * @return true if the read-request is completed successfully.
  */
-bool plc4c_read_request_finished_successfully(plc4c_read_request_execution *read_request_execution);
+bool plc4c_read_request_finished_successfully(
+    plc4c_read_request_execution *read_request_execution);
 
 /**
  * Check if the read-request is completed unsuccessfully.
@@ -48,7 +67,8 @@ bool plc4c_read_request_finished_successfully(plc4c_read_request_execution *read
  * @param read_request_execution the read-request execution.
  * @return true if the read-request is completed with an error.
  */
-bool plc4c_read_request_has_error(plc4c_read_request_execution *read_request_execution);
+bool plc4c_read_request_has_error(
+    plc4c_read_request_execution *read_request_execution);
 
 /**
  * Retrieve the read-response from a given read-request execution.
@@ -56,7 +76,8 @@ bool plc4c_read_request_has_error(plc4c_read_request_execution *read_request_exe
  * @param read_request_execution the read-request execution.
  * @return the read-response.
  */
-plc4c_read_response *plc4c_read_request_get_response(plc4c_read_request_execution *read_request_execution);
+plc4c_read_response *plc4c_read_request_get_response(
+    plc4c_read_request_execution *read_request_execution);
 
 /**
  * Destroys a given read-request.
@@ -65,15 +86,15 @@ plc4c_read_response *plc4c_read_request_get_response(plc4c_read_request_executio
  */
 void plc4c_read_request_destroy(plc4c_read_request *read_request);
 
-
 /**
  * Destroys a given read-request execution.
  *
  * @param read_request_execution the read-request execution.
  */
-void plc4c_read_request_execution_destroy(plc4c_read_request_execution *read_request_execution);
+void plc4c_read_request_execution_destroy(
+    plc4c_read_request_execution *read_request_execution);
 
 #ifdef __cplusplus
 }
 #endif
-#endif //PLC4C_READ_H_
+#endif  // PLC4C_READ_H_

--- a/sandbox/plc4c/api/include/plc4c/system.h
+++ b/sandbox/plc4c/api/include/plc4c/system.h
@@ -22,7 +22,9 @@
 extern "C" {
 #endif
 
+#include <plc4c/utils/list.h>
 #include <stdbool.h>
+
 #include "types.h"
 
 /**
@@ -35,17 +37,20 @@ extern "C" {
  *
  * @param driver
  */
-typedef void (*plc4c_system_on_driver_load_success_callback)(plc4c_driver *driver);
+typedef void (*plc4c_system_on_driver_load_success_callback)(
+    plc4c_driver *driver);
 
 /**
  * Function pointer for a callback called when loading a driver fails.
  * Set in plc4c_system @see plc4c_system_set_on_driver_load_failure_callback
- * NOTE: driver_name could be a pointer to the configuration for the driver instead....
+ * NOTE: driver_name could be a pointer to the configuration for the driver
+ * instead....
  *
  * @param driver_name
  * @param error_code
  */
-typedef void (*plc4c_system_on_driver_load_failure_callback)(char *driver_name, plc4c_return_code error);
+typedef void (*plc4c_system_on_driver_load_failure_callback)(
+    char *driver_name, plc4c_return_code error);
 
 /**
  * Function pointer for a callback called when is successfully made
@@ -53,7 +58,8 @@ typedef void (*plc4c_system_on_driver_load_failure_callback)(char *driver_name, 
  *
  * @param connection
  */
-typedef void (*plc4c_system_on_connect_success_callback)(plc4c_connection *connection);
+typedef void (*plc4c_system_on_connect_success_callback)(
+    plc4c_connection *connection);
 
 /**
  * Function pointer for a callback called when connecting fails.
@@ -62,7 +68,8 @@ typedef void (*plc4c_system_on_connect_success_callback)(plc4c_connection *conne
  * @param connection_string
  * @param error_code
  */
-typedef void (*plc4c_system_on_connect_failure_callback)(char *connection_string, plc4c_return_code error);
+typedef void (*plc4c_system_on_connect_failure_callback)(
+    char *connection_string, plc4c_return_code error);
 
 /**
  * Function pointer for a callback called when is successfully made
@@ -70,7 +77,8 @@ typedef void (*plc4c_system_on_connect_failure_callback)(char *connection_string
  *
  * @param connection
  */
-typedef void (*plc4c_system_on_disconnect_success_callback)(plc4c_connection *connection);
+typedef void (*plc4c_system_on_disconnect_success_callback)(
+    plc4c_connection *connection);
 
 /**
  * Function pointer for a callback called when connecting fails.
@@ -79,7 +87,8 @@ typedef void (*plc4c_system_on_disconnect_success_callback)(plc4c_connection *co
  * @param connection
  * @param error_code
  */
-typedef void (*plc4c_system_on_disconnect_failure_callback)(plc4c_connection *connection, plc4c_return_code error);
+typedef void (*plc4c_system_on_disconnect_failure_callback)(
+    plc4c_connection *connection, plc4c_return_code error);
 
 /**
  * Function pointer for a callback called when a driver returns an error.
@@ -89,14 +98,13 @@ typedef void (*plc4c_system_on_disconnect_failure_callback)(plc4c_connection *co
  * @param connection
  * @param error_code
  */
-typedef void(*plc4c_system_on_loop_failure_callback)
-        (plc4c_driver *driver, plc4c_connection *connection, plc4c_return_code error);
-
+typedef void (*plc4c_system_on_loop_failure_callback)(
+    plc4c_driver *driver, plc4c_connection *connection,
+    plc4c_return_code error);
 
 /**
  * OTHER FUNCTION DEFS FOR SYSTEM
  */
-
 
 /**
  * SYSTEM FUNCTIONS
@@ -119,13 +127,30 @@ plc4c_return_code plc4c_system_create(plc4c_system **system);
 void plc4c_system_destroy(plc4c_system *system);
 
 /**
+ * Returns the plc4c_list for tasks for a given system
+ * @param system plc4c_system
+ * @return plc4c_list
+ */
+plc4c_list *plc4c_system_get_task_list(plc4c_system *system);
+
+/**
+ * Sets the plc4c_list for tasks for a given system
+ * @param system plc4c_system
+ * @param task_list plc4c_list
+ */
+void plc4c_system_set_task_list(plc4c_system *system, plc4c_list *task_list);
+
+void plc4c_system_remove_connection(plc4c_system *system, plc4c_connection *connection);
+
+/**
  * Function to set the on_driver_loaded callback for the plc4c system.
  *
  * @param system
  * @param callback plc4c_system_callback_on_driver
  */
-void plc4c_system_set_on_driver_load_success_callback(plc4c_system *system,
-                                                      plc4c_system_on_driver_load_success_callback callback);
+void plc4c_system_set_on_driver_load_success_callback(
+    plc4c_system *system,
+    plc4c_system_on_driver_load_success_callback callback);
 
 /**
  * Function to set the error callback for loading drivers for the plc4c system.
@@ -133,8 +158,9 @@ void plc4c_system_set_on_driver_load_success_callback(plc4c_system *system,
  * @param system
  * @param callback plc4c_system_callback_driver_load_error
  */
-void plc4c_system_set_on_driver_load_failure_callback(plc4c_system *system,
-                                                      plc4c_system_on_driver_load_failure_callback callback);
+void plc4c_system_set_on_driver_load_failure_callback(
+    plc4c_system *system,
+    plc4c_system_on_driver_load_failure_callback callback);
 
 /**
  * Function to set the on_connection callback for the plc4c system.
@@ -142,17 +168,18 @@ void plc4c_system_set_on_driver_load_failure_callback(plc4c_system *system,
  * @param system
  * @param callback plc4c_system_callback_on_connection
  */
-void plc4c_system_set_on_connect_success_callback(plc4c_system *system,
-                                                  plc4c_system_on_connect_success_callback callback);
+void plc4c_system_set_on_connect_success_callback(
+    plc4c_system *system, plc4c_system_on_connect_success_callback callback);
 
 /**
- * Function to set the error callback for making connections for the plc4c system.
+ * Function to set the error callback for making connections for the plc4c
+ * system.
  *
  * @param system
  * @param callback plc4c_system_on_connect_failure_callback
  */
-void plc4c_system_set_on_connect_failure_callback(plc4c_system *system,
-                                                  plc4c_system_on_connect_failure_callback callback);
+void plc4c_system_set_on_connect_failure_callback(
+    plc4c_system *system, plc4c_system_on_connect_failure_callback callback);
 
 /**
  * Function to set the on_disconnection callback for the plc4c system.
@@ -160,17 +187,18 @@ void plc4c_system_set_on_connect_failure_callback(plc4c_system *system,
  * @param system
  * @param callback plc4c_system_callback_on_disconnection
  */
-void plc4c_system_set_on_disconnect_success_callback(plc4c_system *system,
-                                                     plc4c_system_on_disconnect_success_callback callback);
+void plc4c_system_set_on_disconnect_success_callback(
+    plc4c_system *system, plc4c_system_on_disconnect_success_callback callback);
 
 /**
- * Function to set the error callback for shutting down connections for the plc4c system.
+ * Function to set the error callback for shutting down connections for the
+ * plc4c system.
  *
  * @param system
  * @param callback
  */
-void plc4c_system_set_on_disconnect_failure_callback(plc4c_system *system,
-                                                     plc4c_system_on_disconnect_failure_callback callback);
+void plc4c_system_set_on_disconnect_failure_callback(
+    plc4c_system *system, plc4c_system_on_disconnect_failure_callback callback);
 
 /**
  * Function to set the error callback loops.
@@ -178,8 +206,8 @@ void plc4c_system_set_on_disconnect_failure_callback(plc4c_system *system,
  * @param system
  * @param callback plc4c_system_callback_loop_error
  */
-void plc4c_system_set_on_loop_failure_callback(plc4c_system *system,
-                                               plc4c_system_on_loop_failure_callback callback);
+void plc4c_system_set_on_loop_failure_callback(
+    plc4c_system *system, plc4c_system_on_loop_failure_callback callback);
 
 /**
  * Function to manually add a driver to the system.
@@ -202,7 +230,8 @@ plc4c_return_code plc4c_system_add_transport(plc4c_system *system,
                                              plc4c_transport *transport);
 
 /**
- * Function to initialize the PLC4C system (Initialize the driver manager and the list of enabled drivers)
+ * Function to initialize the PLC4C system (Initialize the driver manager and
+ * the list of enabled drivers)
  *
  * @param system
  * @return plc4c_return_code
@@ -210,15 +239,16 @@ plc4c_return_code plc4c_system_add_transport(plc4c_system *system,
 plc4c_return_code plc4c_system_init(plc4c_system *system);
 
 /**
- * Function to clean up the PLC4C system (Free any still used resources, terminate live connections, ...)
+ * Function to clean up the PLC4C system (Free any still used resources,
+ * terminate live connections, ...)
  *
  * @param system
  */
 void plc4c_system_shutdown(plc4c_system *system);
 
 /**
- * Function to initialize a connection to a PLC by parsing the given connection string
- * and setting the passed connection system
+ * Function to initialize a connection to a PLC by parsing the given connection
+ * string and setting the passed connection system
  *
  * @param system
  * @param connection_string
@@ -242,4 +272,4 @@ plc4c_return_code plc4c_system_loop(plc4c_system *system);
 #ifdef __cplusplus
 }
 #endif
-#endif //PLC4C_SYSTEM_H_
+#endif  // PLC4C_SYSTEM_H_

--- a/sandbox/plc4c/api/include/plc4c/utils/list.h
+++ b/sandbox/plc4c/api/include/plc4c/utils/list.h
@@ -31,14 +31,14 @@ typedef struct plc4c_list_element plc4c_list_element;
 typedef void (*plc4c_list_delete_element_callback)(plc4c_list_element *element);
 
 struct plc4c_list {
-    plc4c_list_element *head;
-    plc4c_list_element *tail;
+  plc4c_list_element *head;
+  plc4c_list_element *tail;
 };
 
 struct plc4c_list_element {
-    plc4c_list_element *next;
-    plc4c_list_element *previous;
-    void *value;
+  plc4c_list_element *next;
+  plc4c_list_element *previous;
+  void *value;
 };
 
 void plc4c_utils_list_create(plc4c_list **list);
@@ -49,11 +49,13 @@ bool plc4c_utils_list_empty(plc4c_list *list);
 
 bool plc4c_utils_list_contains(plc4c_list *list, plc4c_list_element *element);
 
-void plc4c_utils_list_insert_head(plc4c_list *list, plc4c_list_element *element);
+void plc4c_utils_list_insert_head(plc4c_list *list,
+                                  plc4c_list_element *element);
 
 void plc4c_utils_list_insert_head_value(plc4c_list *list, void *value);
 
-void plc4c_utils_list_insert_tail(plc4c_list *list, plc4c_list_element *element);
+void plc4c_utils_list_insert_tail(plc4c_list *list,
+                                  plc4c_list_element *element);
 
 void plc4c_utils_list_insert_tail_value(plc4c_list *list, void *value);
 
@@ -67,10 +69,13 @@ plc4c_list_element *plc4c_utils_list_head(plc4c_list *list);
 
 plc4c_list_element *plc4c_utils_list_tail(plc4c_list *list);
 
-void plc4c_utils_list_delete_elements(plc4c_list *list, plc4c_list_delete_element_callback);
+void plc4c_utils_list_delete_elements(plc4c_list *list,
+                                      plc4c_list_delete_element_callback);
 
+plc4c_list_element *plc4c_utils_list_find_element_by_item(plc4c_list *list,
+                                                          void *item);
 
 #ifdef __cplusplus
 }
 #endif
-#endif //PLC4C_UTILS_LIST_H_
+#endif  // PLC4C_UTILS_LIST_H_

--- a/sandbox/plc4c/api/include/plc4c/write.h
+++ b/sandbox/plc4c/api/include/plc4c/write.h
@@ -25,14 +25,32 @@ extern "C" {
 #include "plc4c/types.h"
 
 /**
+ * Returns the plc4c_connection for a give write request
+ * @param write_request plc4c_write_request
+ * @return plc4c_connection
+ */
+plc4c_connection *plc4c_write_request_get_connection(
+    plc4c_write_request *write_request);
+
+/**
+ * Sets the plc4c_connection for a given write request
+ * @param write_request plc4c_write_request
+ * @param connection plc4c_connection
+ */
+void plc4c_write_request_set_connection(plc4c_write_request *write_request,
+                                        plc4c_connection *connection);
+
+/**
  * Actually executes the write-request.
  *
  * @param write_request the write-request object.
- * @param write_request_execution pointer to a data-structure handling one execution of the write-request.
+ * @param write_request_execution pointer to a data-structure handling one
+ * execution of the write-request.
  * @return plc4c_return_code
  */
-plc4c_return_code plc4c_write_request_execute(plc4c_write_request *write_reques,
-                                              plc4c_write_request_execution **write_request_execution);
+plc4c_return_code plc4c_write_request_execute(
+    plc4c_write_request *write_reques,
+    plc4c_write_request_execution **write_request_execution);
 
 /**
  * Check if the write-request is completed successfully.
@@ -40,7 +58,8 @@ plc4c_return_code plc4c_write_request_execute(plc4c_write_request *write_reques,
  * @param write_request_execution the write-request execution.
  * @return true if the write-request is completed successfully.
  */
-bool plc4c_write_request_finished_successfully(plc4c_write_request_execution *write_request_execution);
+bool plc4c_write_request_finished_successfully(
+    plc4c_write_request_execution *write_request_execution);
 
 /**
  * Check if the write-request is completed unsuccessfully.
@@ -48,7 +67,8 @@ bool plc4c_write_request_finished_successfully(plc4c_write_request_execution *wr
  * @param write_request_execution the write-request execution.
  * @return true if the write-request is completed with an error.
  */
-bool plc4c_write_request_has_error(plc4c_write_request_execution *write_request_execution);
+bool plc4c_write_request_has_error(
+    plc4c_write_request_execution *write_request_execution);
 
 /**
  * Retrieve the write-response from a given write-request execution.
@@ -56,7 +76,8 @@ bool plc4c_write_request_has_error(plc4c_write_request_execution *write_request_
  * @param write_request_execution the write-request execution.
  * @return the write-response.
  */
-plc4c_write_response *plc4c_write_request_get_response(plc4c_write_request_execution *write_request_execution);
+plc4c_write_response *plc4c_write_request_get_response(
+    plc4c_write_request_execution *write_request_execution);
 
 /**
  * Destroys a given write-request.
@@ -70,9 +91,10 @@ void plc4c_write_request_destroy(plc4c_write_request *write_request);
  *
  * @param write_request_execution the write-request execution.
  */
-void plc4c_write_request_execution_destroy(plc4c_write_request_execution *write_request_execution);
+void plc4c_write_request_execution_destroy(
+    plc4c_write_request_execution *write_request_execution);
 
 #ifdef __cplusplus
 }
 #endif
-#endif //PLC4C_WRITE_H_
+#endif  // PLC4C_WRITE_H_

--- a/sandbox/plc4c/drivers/simulated/src/driver_simulated.c
+++ b/sandbox/plc4c/drivers/simulated/src/driver_simulated.c
@@ -17,377 +17,400 @@
   under the License.
 */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <plc4c/spi/types_private.h>
 #include <plc4c/driver_simulated.h>
+#include <plc4c/plc4c.h>
+#include <plc4c/spi/types_private.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-enum plc4c_driver_simulated_field_type_t {
-    RANDOM,
-    STATE,
-    STDOUT
-};
-typedef enum plc4c_driver_simulated_field_type_t plc4c_driver_simulated_field_type;
+enum plc4c_driver_simulated_field_type_t { RANDOM, STATE, STDOUT };
+typedef enum plc4c_driver_simulated_field_type_t
+    plc4c_driver_simulated_field_type;
 
-typedef enum plc4c_driver_simulated_field_datatype_t plc4c_driver_simulated_field_datatype;
+typedef enum plc4c_driver_simulated_field_datatype_t
+    plc4c_driver_simulated_field_datatype;
 
 // State definitions
 enum plc4c_driver_simulated_disconnect_states {
-    PLC4C_DRIVER_SIMULATED_DISCONNECT_INIT,
-    PLC4C_DRIVER_SIMULATED_DISCONNECT_WAIT_TASKS_FINISHED,
-    PLC4C_DRIVER_SIMULATED_DISCONNECT_FINISHED
+  PLC4C_DRIVER_SIMULATED_DISCONNECT_INIT,
+  PLC4C_DRIVER_SIMULATED_DISCONNECT_WAIT_TASKS_FINISHED,
+  PLC4C_DRIVER_SIMULATED_DISCONNECT_FINISHED
 };
 
 enum read_states {
-    PLC4C_DRIVER_SIMULATED_READ_INIT,
-    PLC4C_DRIVER_SIMULATED_READ_FINISHED
+  PLC4C_DRIVER_SIMULATED_READ_INIT,
+  PLC4C_DRIVER_SIMULATED_READ_FINISHED
 };
 
 enum write_states {
-    PLC4C_DRIVER_SIMULATED_WRITE_INIT,
-    PLC4C_DRIVER_SIMULATED_WRITE_FINISHED
+  PLC4C_DRIVER_SIMULATED_WRITE_INIT,
+  PLC4C_DRIVER_SIMULATED_WRITE_FINISHED
 };
 
 struct plc4c_driver_simulated_item_t {
-    char *name;
-    plc4c_driver_simulated_field_type type;
-    plc4c_data_type data_type;
-    int num_elements;
+  char *name;
+  plc4c_driver_simulated_field_type type;
+  plc4c_data_type data_type;
+  int num_elements;
 };
 typedef struct plc4c_driver_simulated_item_t plc4c_driver_simulated_item;
 
-plc4c_return_code plc4c_driver_simulated_connect_machine_function(plc4c_system_task *task) {
-    plc4c_connection *connection = task->context;
-    if (connection == NULL) {
-        return INTERNAL_ERROR;
-    }
-    if (connection->connected) {
-        return INTERNAL_ERROR;
-    }
-    connection->connected = true;
-    task->completed = true;
-    return OK;
+plc4c_return_code plc4c_driver_simulated_connect_machine_function(
+    plc4c_system_task *task) {
+  plc4c_connection *connection = task->context;
+  if (connection == NULL) {
+    return INTERNAL_ERROR;
+  }
+  if (plc4c_connection_is_connected(connection)) {
+    return INTERNAL_ERROR;
+  }
+  plc4c_connection_set_connected(connection, true);
+  task->completed = true;
+  return OK;
 }
 
-plc4c_return_code plc4c_driver_simulated_disconnect_machine_function(plc4c_system_task *task) {
-    plc4c_connection *connection = task->context;
-    if (connection == NULL) {
-        return INTERNAL_ERROR;
-    }
+plc4c_return_code plc4c_driver_simulated_disconnect_machine_function(
+    plc4c_system_task *task) {
+  plc4c_connection *connection = task->context;
+  if (connection == NULL) {
+    return INTERNAL_ERROR;
+  }
 
-    switch (task->state_id) {
-        case PLC4C_DRIVER_SIMULATED_DISCONNECT_INIT: {
-            connection->disconnect = true;
-            task->state_id = PLC4C_DRIVER_SIMULATED_DISCONNECT_WAIT_TASKS_FINISHED;
-            break;
-        }
-        case PLC4C_DRIVER_SIMULATED_DISCONNECT_WAIT_TASKS_FINISHED: {
-            // The disconnect system-task also counts.
-            if(connection->num_running_system_tasks == 1) {
-                connection->connected = false;
-                task->completed = true;
-                task->state_id = PLC4C_DRIVER_SIMULATED_DISCONNECT_FINISHED;
-            }
-            break;
-        }
-        case PLC4C_DRIVER_SIMULATED_DISCONNECT_FINISHED: {
-            // Do nothing
-            break;
-        }
-        default: {
-            return INTERNAL_ERROR;
-        }
+  switch (task->state_id) {
+    case PLC4C_DRIVER_SIMULATED_DISCONNECT_INIT: {
+      plc4c_connection_disconnect_set(connection, true);
+      task->state_id = PLC4C_DRIVER_SIMULATED_DISCONNECT_WAIT_TASKS_FINISHED;
+      break;
     }
-    return OK;
+    case PLC4C_DRIVER_SIMULATED_DISCONNECT_WAIT_TASKS_FINISHED: {
+      // The disconnect system-task also counts.
+      if (plc4c_connection_running_tasks_count(connection) == 1) {
+        plc4c_connection_set_connected(connection, false);
+        task->completed = true;
+        task->state_id = PLC4C_DRIVER_SIMULATED_DISCONNECT_FINISHED;
+      }
+      break;
+    }
+    case PLC4C_DRIVER_SIMULATED_DISCONNECT_FINISHED: {
+      // Do nothing
+      break;
+    }
+    default: {
+      return INTERNAL_ERROR;
+    }
+  }
+  return OK;
 }
 
-plc4c_return_code plc4c_driver_simulated_read_machine_function(plc4c_system_task *task) {
-    if (task->context == NULL) {
-        return INTERNAL_ERROR;
+plc4c_return_code plc4c_driver_simulated_read_machine_function(
+    plc4c_system_task *task) {
+  if (task->context == NULL) {
+    return INTERNAL_ERROR;
+  }
+
+  plc4c_read_request_execution *read_request_execution = task->context;
+  plc4c_read_request *read_request = read_request_execution->read_request;
+  switch (task->state_id) {
+    case PLC4C_DRIVER_SIMULATED_READ_INIT: {
+      // Create a response.
+      plc4c_read_response *read_response = malloc(sizeof(plc4c_read_response));
+      read_response->read_request = read_request;
+      plc4c_utils_list_create(&(read_response->items));
+
+      // Process every field in the request.
+      plc4c_list_element *cur_element =
+          plc4c_utils_list_head(read_request->items);
+      while (cur_element != NULL) {
+        plc4c_driver_simulated_item *cur_item = cur_element->value;
+        plc4c_response_value_item *value_item =
+            malloc(sizeof(plc4c_response_value_item));
+        value_item->item = (plc4c_item *)cur_item;
+        value_item->response_code = PLC4C_RESPONSE_CODE_OK;
+        /*
+         * create the plc4c_data
+         * if this were a custom type we could set a custom destroy method
+         * we can also set a custom printf method
+         * right , now just create a new random value
+         */
+        value_item->value = plc4c_data_create_uint_data(arc4random());
+
+        // Add the value to the response.
+        plc4c_utils_list_insert_tail_value(read_response->items, value_item);
+        cur_element = cur_element->next;
+      }
+
+      read_request_execution->read_response = read_response;
+      task->state_id = PLC4C_DRIVER_SIMULATED_READ_FINISHED;
+      task->completed = true;
+      break;
     }
-
-    plc4c_read_request_execution *read_request_execution = task->context;
-    plc4c_read_request *read_request = read_request_execution->read_request;
-    switch (task->state_id) {
-        case PLC4C_DRIVER_SIMULATED_READ_INIT: {
-            // Create a response.
-            plc4c_read_response *read_response = malloc(sizeof(plc4c_read_response));
-            read_response->read_request = read_request;
-            plc4c_utils_list_create(&(read_response->items));
-
-            // Process every field in the request.
-            plc4c_list_element *cur_element = plc4c_utils_list_head(read_request->items);
-            while (cur_element != NULL) {
-                plc4c_driver_simulated_item *cur_item = cur_element->value;
-                plc4c_response_value_item *value_item = malloc(sizeof(plc4c_response_value_item));
-                value_item->item = (plc4c_item *) cur_item;
-                value_item->response_code = PLC4C_RESPONSE_CODE_OK;
-                /*
-                 * create the plc4c_data
-                 * if this were a custom type we could set a custom destroy method
-                 * we can also set a custom printf method
-                 * right , now just create a new random value
-                 */
-                value_item->value = plc4c_data_create_uint_data(arc4random());
-
-                // Add the value to the response.
-                plc4c_utils_list_insert_tail_value(read_response->items, value_item);
-                cur_element = cur_element->next;
-            }
-
-            read_request_execution->read_response = read_response;
-            task->state_id = PLC4C_DRIVER_SIMULATED_READ_FINISHED;
-            task->completed = true;
-            break;
-        }
-        case PLC4C_DRIVER_SIMULATED_READ_FINISHED: {
-            // Do nothing
-            break;
-        }
-        default: {
-            return INTERNAL_ERROR;
-        }
+    case PLC4C_DRIVER_SIMULATED_READ_FINISHED: {
+      // Do nothing
+      break;
     }
-    return OK;
+    default: {
+      return INTERNAL_ERROR;
+    }
+  }
+  return OK;
 }
 
-plc4c_return_code plc4c_driver_simulated_write_machine_function(plc4c_system_task *task) {
-    if (task->context == NULL) {
-        return INTERNAL_ERROR;
-    }
+plc4c_return_code plc4c_driver_simulated_write_machine_function(
+    plc4c_system_task *task) {
+  if (task->context == NULL) {
+    return INTERNAL_ERROR;
+  }
 
-    plc4c_write_request_execution *write_request_execution = task->context;
-    plc4c_write_request *write_request = write_request_execution->write_request;
-    switch (task->state_id) {
-        case PLC4C_DRIVER_SIMULATED_WRITE_INIT: {
-            // Create a response.
-            plc4c_write_response *write_response = malloc(sizeof(plc4c_write_response));
-            write_response->write_request = write_request;
-            plc4c_utils_list_create(&(write_response->response_items));
+  plc4c_write_request_execution *write_request_execution = task->context;
+  plc4c_write_request *write_request = write_request_execution->write_request;
+  switch (task->state_id) {
+    case PLC4C_DRIVER_SIMULATED_WRITE_INIT: {
+      // Create a response.
+      plc4c_write_response *write_response =
+          malloc(sizeof(plc4c_write_response));
+      write_response->write_request = write_request;
+      plc4c_utils_list_create(&(write_response->response_items));
 
-            // Process every field in the request.
-            plc4c_list_element *cur_element = plc4c_utils_list_head(write_request->items);
-            while (cur_element != NULL) {
-                plc4c_request_value_item *cur_value_item = cur_element->value;
-                plc4c_driver_simulated_item *cur_item = (plc4c_driver_simulated_item *) cur_value_item->item;
-                plc4c_data *write_data = cur_value_item->value;
-                plc4c_response_code response_code = -1;
-                switch (cur_item->type) {
-                    case STDOUT: {
-                        printf("");
-                        if (cur_item->data_type != write_data->data_type) {
-                            printf("--> Simulated Driver Write: Value is %s but Item type is %s",
-                                   plc4c_data_type_name(write_data->data_type),
-                                   plc4c_data_type_name(cur_item->data_type));
-                            response_code = PLC4C_RESPONSE_CODE_INVALID_DATATYPE;
-                            break;
-                        }
-                        printf("--> Simulated Driver Write: Value (%s) %s: ",
-                               plc4c_data_type_name(write_data->data_type),
-                               cur_item->name);
-                        plc4c_data_printf(write_data);
-                        printf("\n");
-                        response_code = PLC4C_RESPONSE_CODE_OK;
-                        break;
-                    }
-                    default: {
-                        response_code = PLC4C_RESPONSE_CODE_INVALID_ADDRESS;
-                        break;
-                    }
-                }
-
-                // Create a response element and add that to the response ...
-                plc4c_response_item *response_item = malloc(sizeof(plc4c_response_item));
-                response_item->item = (plc4c_item *) cur_item;
-                response_item->response_code = response_code;
-                plc4c_utils_list_insert_tail_value(write_response->response_items, response_item);
-
-                cur_element = cur_element->next;
+      // Process every field in the request.
+      plc4c_list_element *cur_element =
+          plc4c_utils_list_head(write_request->items);
+      while (cur_element != NULL) {
+        plc4c_request_value_item *cur_value_item = cur_element->value;
+        plc4c_driver_simulated_item *cur_item =
+            (plc4c_driver_simulated_item *)cur_value_item->item;
+        plc4c_data *write_data = cur_value_item->value;
+        plc4c_response_code response_code = -1;
+        switch (cur_item->type) {
+          case STDOUT: {
+            printf("");
+            if (cur_item->data_type != write_data->data_type) {
+              printf(
+                  "--> Simulated Driver Write: Value is %s but Item type is %s",
+                  plc4c_data_type_name(write_data->data_type),
+                  plc4c_data_type_name(cur_item->data_type));
+              response_code = PLC4C_RESPONSE_CODE_INVALID_DATATYPE;
+              break;
             }
+            printf("--> Simulated Driver Write: Value (%s) %s: ",
+                   plc4c_data_type_name(write_data->data_type), cur_item->name);
+            plc4c_data_printf(write_data);
+            printf("\n");
+            response_code = PLC4C_RESPONSE_CODE_OK;
+            break;
+          }
+          default: {
+            response_code = PLC4C_RESPONSE_CODE_INVALID_ADDRESS;
+            break;
+          }
+        }
 
-            write_request_execution->write_response = write_response;
-            task->state_id = PLC4C_DRIVER_SIMULATED_WRITE_FINISHED;
-            task->completed = true;
-            break;
-        }
-        case PLC4C_DRIVER_SIMULATED_WRITE_FINISHED: {
-            // Do nothing
-            break;
-        }
-        default: {
-            return INTERNAL_ERROR;
-        }
+        // Create a response element and add that to the response ...
+        plc4c_response_item *response_item =
+            malloc(sizeof(plc4c_response_item));
+        response_item->item = (plc4c_item *)cur_item;
+        response_item->response_code = response_code;
+        plc4c_utils_list_insert_tail_value(write_response->response_items,
+                                           response_item);
+
+        cur_element = cur_element->next;
+      }
+
+      write_request_execution->write_response = write_response;
+      task->state_id = PLC4C_DRIVER_SIMULATED_WRITE_FINISHED;
+      task->completed = true;
+      break;
     }
-    return OK;
+    case PLC4C_DRIVER_SIMULATED_WRITE_FINISHED: {
+      // Do nothing
+      break;
+    }
+    default: {
+      return INTERNAL_ERROR;
+    }
+  }
+  return OK;
 }
 
 plc4c_item *plc4c_driver_simulated_parse_address(char *address_string) {
-    plc4c_driver_simulated_field_type type = RANDOM;
-    char *name = NULL;
-    plc4c_data_type data_type = -1;
-    int num_elements = 0;
-    int start_segment_index = 0;
-    char *start_segment = address_string;
-    for (int i = 0; i <= strlen(address_string); i++) {
-        // This marks the end of the type part.
-        if (*(address_string + i) == '/') {
-            char *type_str = malloc(sizeof(char) * (i + 1));
-            strlcpy(type_str, start_segment, i + 1);
-            if (strcmp(type_str, "RANDOM") == 0) {
-                type = RANDOM;
-            } else if (strcmp(type_str, "STATE") == 0) {
-                type = STATE;
-            } else if (strcmp(type_str, "STDOUT") == 0) {
-                type = STDOUT;
-            } else {
-                return NULL;
-            }
-            start_segment = address_string + i + 1;
-            start_segment_index = i + 1;
-        }
-        // This marks the end of the name part.
-        if (*(address_string + i) == ':') {
-            name = malloc(sizeof(char) * ((i - start_segment_index) + 1));
-            strlcpy(name, start_segment, (i - start_segment_index) + 1);
-            start_segment = address_string + i + 1;
-            start_segment_index = i + 1;
-        }
-        // This marks the end of the data-type part if there is a size coming in addition.
-        if ((i == strlen(address_string)) || (*(address_string + i) == '[')) {
-            char *datatype_name = malloc(sizeof(char) * ((i - start_segment_index) + 1));
-            strlcpy(datatype_name, start_segment, (i - start_segment_index) + 1);
-
-            // Translate the string into a constant.
-            if (strcmp(datatype_name, "INTEGER") == 0) {
-                data_type = PLC4C_INT;
-            } else if (strcmp(datatype_name, "STRING") == 0) {
-                data_type = PLC4C_CONSTANT_STRING;
-            } else {
-                return NULL;
-            }
-
-            start_segment = address_string + i + 1;
-            start_segment_index = i + 1;
-            if (i == strlen(address_string)) {
-                num_elements = 1;
-                break;
-            }
-        }
-        // This marks the end of the size part.
-        if (*(address_string + i) == ']') {
-            char *num_elements_str = malloc(sizeof(char) * ((i - start_segment_index) + 1));
-            strlcpy(num_elements_str, start_segment, (i - start_segment_index) + 1);
-            char *success = NULL;
-            num_elements = (int) strtol(num_elements_str, &success, 10);
-            break;
-        }
+  plc4c_driver_simulated_field_type type = RANDOM;
+  char *name = NULL;
+  plc4c_data_type data_type = -1;
+  int num_elements = 0;
+  int start_segment_index = 0;
+  char *start_segment = address_string;
+  for (int i = 0; i <= strlen(address_string); i++) {
+    // This marks the end of the type part.
+    if (*(address_string + i) == '/') {
+      char *type_str = malloc(sizeof(char) * (i + 1));
+      strlcpy(type_str, start_segment, i + 1);
+      if (strcmp(type_str, "RANDOM") == 0) {
+        type = RANDOM;
+      } else if (strcmp(type_str, "STATE") == 0) {
+        type = STATE;
+      } else if (strcmp(type_str, "STDOUT") == 0) {
+        type = STDOUT;
+      } else {
+        return NULL;
+      }
+      start_segment = address_string + i + 1;
+      start_segment_index = i + 1;
     }
+    // This marks the end of the name part.
+    if (*(address_string + i) == ':') {
+      name = malloc(sizeof(char) * ((i - start_segment_index) + 1));
+      strlcpy(name, start_segment, (i - start_segment_index) + 1);
+      start_segment = address_string + i + 1;
+      start_segment_index = i + 1;
+    }
+    // This marks the end of the data-type part if there is a size coming in
+    // addition.
+    if ((i == strlen(address_string)) || (*(address_string + i) == '[')) {
+      char *datatype_name =
+          malloc(sizeof(char) * ((i - start_segment_index) + 1));
+      strlcpy(datatype_name, start_segment, (i - start_segment_index) + 1);
 
-    // Create a new driver specific item.
-    plc4c_driver_simulated_item *item = (plc4c_driver_simulated_item *) malloc(sizeof(plc4c_driver_simulated_item));
-    item->type = type;
-    item->name = name;
-    item->data_type = data_type;
-    item->num_elements = num_elements;
+      // Translate the string into a constant.
+      if (strcmp(datatype_name, "INTEGER") == 0) {
+        data_type = PLC4C_INT;
+      } else if (strcmp(datatype_name, "STRING") == 0) {
+        data_type = PLC4C_CONSTANT_STRING;
+      } else {
+        return NULL;
+      }
 
-    return (plc4c_item *) item;
+      start_segment = address_string + i + 1;
+      start_segment_index = i + 1;
+      if (i == strlen(address_string)) {
+        num_elements = 1;
+        break;
+      }
+    }
+    // This marks the end of the size part.
+    if (*(address_string + i) == ']') {
+      char *num_elements_str =
+          malloc(sizeof(char) * ((i - start_segment_index) + 1));
+      strlcpy(num_elements_str, start_segment, (i - start_segment_index) + 1);
+      char *success = NULL;
+      num_elements = (int)strtol(num_elements_str, &success, 10);
+      break;
+    }
+  }
+
+  // Create a new driver specific item.
+  plc4c_driver_simulated_item *item = (plc4c_driver_simulated_item *)malloc(
+      sizeof(plc4c_driver_simulated_item));
+  item->type = type;
+  item->name = name;
+  item->data_type = data_type;
+  item->num_elements = num_elements;
+
+  return (plc4c_item *)item;
 }
 
-
-plc4c_return_code plc4c_driver_simulated_connect_function(plc4c_connection *connection,
-                                                          plc4c_system_task **task) {
-    plc4c_system_task *new_task = malloc(sizeof(plc4c_system_task));
-    // There's nothing to do here, so no need for a state-machine.
-    new_task->state_id = -1;
-    new_task->state_machine_function = &plc4c_driver_simulated_connect_machine_function;
-    new_task->completed = false;
-    new_task->context = connection;
-    new_task->connection = connection;
-    *task = new_task;
-    return OK;
+plc4c_return_code plc4c_driver_simulated_connect_function(
+    plc4c_connection *connection, plc4c_system_task **task) {
+  plc4c_system_task *new_task = malloc(sizeof(plc4c_system_task));
+  // There's nothing to do here, so no need for a state-machine.
+  new_task->state_id = -1;
+  new_task->state_machine_function =
+      &plc4c_driver_simulated_connect_machine_function;
+  new_task->completed = false;
+  new_task->context = connection;
+  new_task->connection = connection;
+  *task = new_task;
+  return OK;
 }
 
-plc4c_return_code plc4c_driver_simulated_disconnect_function(plc4c_connection *connection,
-                                                             plc4c_system_task **task) {
-    plc4c_system_task *new_task = malloc(sizeof(plc4c_system_task));
-    new_task->state_id = PLC4C_DRIVER_SIMULATED_DISCONNECT_INIT;
-    new_task->state_machine_function = &plc4c_driver_simulated_disconnect_machine_function;
-    new_task->completed = false;
-    new_task->context = connection;
-    new_task->connection = connection;
-    *task = new_task;
-    return OK;
+plc4c_return_code plc4c_driver_simulated_disconnect_function(
+    plc4c_connection *connection, plc4c_system_task **task) {
+  plc4c_system_task *new_task = malloc(sizeof(plc4c_system_task));
+  new_task->state_id = PLC4C_DRIVER_SIMULATED_DISCONNECT_INIT;
+  new_task->state_machine_function =
+      &plc4c_driver_simulated_disconnect_machine_function;
+  new_task->completed = false;
+  new_task->context = connection;
+  new_task->connection = connection;
+  *task = new_task;
+  return OK;
 }
 
-plc4c_return_code plc4c_driver_simulated_read_function(plc4c_read_request_execution *read_request_execution,
-                                                       plc4c_system_task **task) {
-    plc4c_system_task *new_task = malloc(sizeof(plc4c_system_task));
-    new_task->state_id = PLC4C_DRIVER_SIMULATED_READ_INIT;
-    new_task->state_machine_function = &plc4c_driver_simulated_read_machine_function;
-    new_task->completed = false;
-    new_task->context = read_request_execution;
-    new_task->connection = read_request_execution->read_request->connection;
+plc4c_return_code plc4c_driver_simulated_read_function(
+    plc4c_read_request_execution *read_request_execution,
+    plc4c_system_task **task) {
+  plc4c_system_task *new_task = malloc(sizeof(plc4c_system_task));
+  new_task->state_id = PLC4C_DRIVER_SIMULATED_READ_INIT;
+  new_task->state_machine_function =
+      &plc4c_driver_simulated_read_machine_function;
+  new_task->completed = false;
+  new_task->context = read_request_execution;
+  new_task->connection = read_request_execution->read_request->connection;
 
-    read_request_execution->system_task = new_task;
+  read_request_execution->system_task = new_task;
 
-    *task = new_task;
-    return OK;
+  *task = new_task;
+  return OK;
 }
 
-plc4c_return_code plc4c_driver_simulated_write_function(plc4c_write_request_execution *write_request_execution,
-                                                        plc4c_system_task **task) {
-    plc4c_system_task *new_task = malloc(sizeof(plc4c_system_task));
-    new_task->state_id = PLC4C_DRIVER_SIMULATED_WRITE_INIT;
-    new_task->state_machine_function = &plc4c_driver_simulated_write_machine_function;
-    new_task->completed = false;
-    new_task->context = write_request_execution;
-    new_task->connection = write_request_execution->write_request->connection;
+plc4c_return_code plc4c_driver_simulated_write_function(
+    plc4c_write_request_execution *write_request_execution,
+    plc4c_system_task **task) {
+  plc4c_system_task *new_task = malloc(sizeof(plc4c_system_task));
+  new_task->state_id = PLC4C_DRIVER_SIMULATED_WRITE_INIT;
+  new_task->state_machine_function =
+      &plc4c_driver_simulated_write_machine_function;
+  new_task->completed = false;
+  new_task->context = write_request_execution;
+  new_task->connection = write_request_execution->write_request->connection;
 
-    write_request_execution->system_task = new_task;
+  write_request_execution->system_task = new_task;
 
-    *task = new_task;
-    return OK;
+  *task = new_task;
+  return OK;
 }
 
 void free_read_response_item(plc4c_list_element *read_item_element) {
-    plc4c_response_value_item *value_item = (plc4c_response_value_item *) read_item_element->value;
-    plc4c_data_delete(value_item->value);
-    value_item->value = NULL;
+  plc4c_response_value_item *value_item =
+      (plc4c_response_value_item *)read_item_element->value;
+  plc4c_data_delete(value_item->value);
+  value_item->value = NULL;
 }
 
 void plc4c_driver_simulated_free_read_response(plc4c_read_response *response) {
-    // the request will be cleaned up elsewhere
-    plc4c_utils_list_delete_elements(response->items, &free_read_response_item);
+  // the request will be cleaned up elsewhere
+  plc4c_utils_list_delete_elements(response->items, &free_read_response_item);
 }
 
 void free_write_response_item(plc4c_list_element *write_item_element) {
-    plc4c_response_value_item *value_item = (plc4c_response_value_item *) write_item_element->value;
-    // do not delete the plc4c_item
-    // we also, in THIS case don't delete the random value which isn't really
-    // a pointer
-    //free(value_item->value);
-    value_item->value = NULL;
+  plc4c_response_value_item *value_item =
+      (plc4c_response_value_item *)write_item_element->value;
+  // do not delete the plc4c_item
+  // we also, in THIS case don't delete the random value which isn't really
+  // a pointer
+  // free(value_item->value);
+  value_item->value = NULL;
 }
 
-void plc4c_driver_simulated_free_write_response(plc4c_write_response *response) {
-    // the request will be cleaned up elsewhere
-    plc4c_utils_list_delete_elements(response->response_items, &free_write_response_item);
+void plc4c_driver_simulated_free_write_response(
+    plc4c_write_response *response) {
+  // the request will be cleaned up elsewhere
+  plc4c_utils_list_delete_elements(response->response_items,
+                                   &free_write_response_item);
 }
-
 
 plc4c_driver *plc4c_driver_simulated_create() {
-    plc4c_driver *driver = (plc4c_driver *) malloc(sizeof(plc4c_driver));
-    driver->protocol_code = "simulated";
-    driver->protocol_name = "Simulated PLC4X Datasource";
-    driver->default_transport_code = "dummy";
-    driver->parse_address_function = &plc4c_driver_simulated_parse_address;
-    driver->connect_function = &plc4c_driver_simulated_connect_function;
-    driver->disconnect_function = &plc4c_driver_simulated_disconnect_function;
-    driver->read_function = &plc4c_driver_simulated_read_function;
-    driver->write_function = &plc4c_driver_simulated_write_function;
-    driver->free_read_response_function = &plc4c_driver_simulated_free_read_response;
-    driver->free_write_response_function = &plc4c_driver_simulated_free_write_response;
-    return driver;
+  plc4c_driver *driver = (plc4c_driver *)malloc(sizeof(plc4c_driver));
+  driver->protocol_code = "simulated";
+  driver->protocol_name = "Simulated PLC4X Datasource";
+  driver->default_transport_code = "dummy";
+  driver->parse_address_function = &plc4c_driver_simulated_parse_address;
+  driver->connect_function = &plc4c_driver_simulated_connect_function;
+  driver->disconnect_function = &plc4c_driver_simulated_disconnect_function;
+  driver->read_function = &plc4c_driver_simulated_read_function;
+  driver->write_function = &plc4c_driver_simulated_write_function;
+  driver->free_read_response_function =
+      &plc4c_driver_simulated_free_read_response;
+  driver->free_write_response_function =
+      &plc4c_driver_simulated_free_write_response;
+  return driver;
 }
-

--- a/sandbox/plc4c/examples/hello-world/src/hello_world.c
+++ b/sandbox/plc4c/examples/hello-world/src/hello_world.c
@@ -220,7 +220,7 @@ int main() {
                 }
 
                 // Clean up.
-                //plc4c_connection_read_response_destroy(read_response);
+                plc4c_connection_read_response_destroy(read_response);
                 plc4c_read_request_execution_destroy(read_request_execution);
                 plc4c_read_request_destroy(read_request);
 
@@ -284,8 +284,7 @@ int main() {
 
                 // Clean up.
                 plc4c_connection_write_response_destroy(write_response);
-                //plc4c_read_request_execution_destroy(read_request_execution);
-                plc4c_read_request_destroy(read_request);
+                plc4c_write_request_execution_destroy(write_request_execution);
 
                 // Disconnect.
                 printf("Disconnecting ... ");
@@ -301,6 +300,9 @@ int main() {
             case DISCONNECTING: {
                 if (!plc4c_connection_is_connected(connection)) {
                     printf("SUCCESS\n");
+                    // we could let the system shut this down,
+                    // or do it ourselves
+                    plc4c_system_remove_connection(system, connection);
                     plc4c_connection_destroy(connection);
                     state = DISCONNECTED;
 

--- a/sandbox/plc4c/spi/include/plc4c/spi/types_private.h
+++ b/sandbox/plc4c/spi/include/plc4c/spi/types_private.h
@@ -19,11 +19,11 @@
 #ifndef PLC4C_SPI_TYPES_PRIVATE_H_
 #define PLC4C_SPI_TYPES_PRIVATE_H_
 
-#include <plc4c/types.h>
+#include <plc4c/data.h>
 #include <plc4c/system.h>
+#include <plc4c/types.h>
 #include <plc4c/utils/list.h>
 #include <plc4c/utils/queue.h>
-#include <plc4c/data.h>
 
 typedef struct plc4c_item_t plc4c_item;
 typedef struct plc4c_driver_list_item_t plc4c_driver_list_item;
@@ -33,194 +33,199 @@ typedef struct plc4c_request_value_item_t plc4c_request_value_item;
 typedef struct plc4c_response_value_item_t plc4c_response_value_item;
 typedef struct plc4c_response_item_t plc4c_response_item;
 
-typedef plc4c_item *(*plc4c_connection_parse_address_item)(char *address_string);
+typedef plc4c_item *(*plc4c_connection_parse_address_item)(
+    char *address_string);
 
-typedef plc4c_return_code (*plc4c_connection_encode_value_item)(plc4c_item *item, void *value, void **encoded_value);
+typedef plc4c_return_code (*plc4c_connection_encode_value_item)(
+    plc4c_item *item, void *value, void **encoded_value);
 
 typedef struct plc4c_system_task_t plc4c_system_task;
 
-typedef plc4c_return_code (*plc4c_system_task_state_machine_function)(plc4c_system_task *task);
+typedef plc4c_return_code (*plc4c_system_task_state_machine_function)(
+    plc4c_system_task *task);
 
-typedef plc4c_return_code (*plc4c_connection_connect_function)(plc4c_connection *connection,
-                                                               plc4c_system_task **task);
+typedef plc4c_return_code (*plc4c_connection_connect_function)(
+    plc4c_connection *connection, plc4c_system_task **task);
 
-typedef plc4c_return_code (*plc4c_connection_disconnect_function)(plc4c_connection *connection,
-                                                                  plc4c_system_task **task);
+typedef plc4c_return_code (*plc4c_connection_disconnect_function)(
+    plc4c_connection *connection, plc4c_system_task **task);
 
-typedef plc4c_return_code (*plc4c_connection_read_function)(plc4c_read_request_execution *read_request_execution,
-                                                            plc4c_system_task **task);
+typedef plc4c_return_code (*plc4c_connection_read_function)(
+    plc4c_read_request_execution *read_request_execution,
+    plc4c_system_task **task);
 
-typedef plc4c_return_code (*plc4c_connection_write_function)(plc4c_write_request_execution *write_request_execution,
-                                                             plc4c_system_task **task);
+typedef plc4c_return_code (*plc4c_connection_write_function)(
+    plc4c_write_request_execution *write_request_execution,
+    plc4c_system_task **task);
 
-typedef void (*plc4c_connect_free_read_response_function)(plc4c_read_response *response);
+typedef void (*plc4c_connect_free_read_response_function)(
+    plc4c_read_response *response);
 
-typedef void (*plc4c_connect_free_write_response_function)(plc4c_write_response *response);
+typedef void (*plc4c_connect_free_write_response_function)(
+    plc4c_write_response *response);
 
 struct plc4c_system_t {
-    /* drivers */
-    plc4c_list *driver_list;
+  /* drivers */
+  plc4c_list *driver_list;
 
-    /* transports */
-    plc4c_list *transport_list;
+  /* transports */
+  plc4c_list *transport_list;
 
-    /* connections */
-    plc4c_list *connection_list;
+  /* connections */
+  plc4c_list *connection_list;
 
-    /* tasks */
-    plc4c_list *task_list;
+  /* tasks */
+  plc4c_list *task_list;
 
-    /* callbacks */
-    plc4c_system_on_driver_load_success_callback on_driver_load_success_callback;
-    plc4c_system_on_driver_load_failure_callback on_driver_load_failure_callback;
-    plc4c_system_on_connect_success_callback on_connect_success_callback;
-    plc4c_system_on_connect_failure_callback on_connect_failure_callback;
-    plc4c_system_on_disconnect_success_callback on_disconnect_success_callback;
-    plc4c_system_on_disconnect_failure_callback on_disconnect_failure_callback;
-    plc4c_system_on_loop_failure_callback on_loop_failure_callback;
+  /* callbacks */
+  plc4c_system_on_driver_load_success_callback on_driver_load_success_callback;
+  plc4c_system_on_driver_load_failure_callback on_driver_load_failure_callback;
+  plc4c_system_on_connect_success_callback on_connect_success_callback;
+  plc4c_system_on_connect_failure_callback on_connect_failure_callback;
+  plc4c_system_on_disconnect_success_callback on_disconnect_success_callback;
+  plc4c_system_on_disconnect_failure_callback on_disconnect_failure_callback;
+  plc4c_system_on_loop_failure_callback on_loop_failure_callback;
 };
 
 struct plc4c_item_t {
-    char *name;
+  char *name;
 };
 
 struct plc4c_driver_t {
-    char *protocol_code;
-    char *protocol_name;
-    char *default_transport_code;
-    plc4c_connection_parse_address_item parse_address_function;
-    plc4c_connection_connect_function connect_function;
-    plc4c_connection_disconnect_function disconnect_function;
-    plc4c_connection_read_function read_function;
-    plc4c_connection_write_function write_function;
-    plc4c_connect_free_read_response_function free_read_response_function;
-    plc4c_connect_free_write_response_function free_write_response_function;
+  char *protocol_code;
+  char *protocol_name;
+  char *default_transport_code;
+  plc4c_connection_parse_address_item parse_address_function;
+  plc4c_connection_connect_function connect_function;
+  plc4c_connection_disconnect_function disconnect_function;
+  plc4c_connection_read_function read_function;
+  plc4c_connection_write_function write_function;
+  plc4c_connect_free_read_response_function free_read_response_function;
+  plc4c_connect_free_write_response_function free_write_response_function;
 };
 
 struct plc4c_driver_list_item_t {
-    plc4c_driver *driver;
-    plc4c_driver_list_item *next;
+  plc4c_driver *driver;
+  plc4c_driver_list_item *next;
 };
 
-
 struct plc4c_transport_t {
-    char *transport_code;
+  char *transport_code;
 
-    // TODO: add the send and receive function references here ...
+  // TODO: add the send and receive function references here ...
 };
 
 struct plc4c_transport_list_item_t {
-    plc4c_transport *transport;
-    plc4c_transport_list_item *next;
+  plc4c_transport *transport;
+  plc4c_transport_list_item *next;
 };
 
-
 struct plc4c_connection_t {
-    char *connection_string;
-    char *protocol_code;
-    char *transport_code;
-    char *transport_connect_information;
-    char *parameters;
+  char *connection_string;
+  char *protocol_code;
+  char *transport_code;
+  char *transport_connect_information;
+  char *parameters;
 
-    bool connected;
-    // Internal flag indicating the connection should be disconnected
-    bool disconnect;
-    // Number of system_tasks currently still active in the system.
-    int num_running_system_tasks;
+  bool connected;
+  // Internal flag indicating the connection should be disconnected
+  bool disconnect;
+  // Number of system_tasks currently still active in the system.
+  int num_running_system_tasks;
 
-    plc4c_system *system;
-    plc4c_driver *driver;
-    plc4c_transport *transport;
+  plc4c_system *system;
+  plc4c_driver *driver;
+  plc4c_transport *transport;
 
-    bool supports_reading;
-    bool supports_writing;
-    bool supports_subscriptions;
+  bool supports_reading;
+  bool supports_writing;
+  bool supports_subscriptions;
 };
 
 struct plc4c_connection_list_item_t {
-    plc4c_connection *connection;
-    plc4c_connection_list_item *prev;
-    plc4c_connection_list_item *next;
+  plc4c_connection *connection;
+  plc4c_connection_list_item *prev;
+  plc4c_connection_list_item *next;
 };
 
 struct plc4c_data_t {
-    plc4c_data_type data_type;
-    size_t size;
-    union {
-        bool boolean_value;
-        char char_value;
-        unsigned char uchar_value;
-        short short_value;
-        unsigned short ushort_value;
-        int int_value;
-        unsigned int uint_value;
-        /* more */
-        float float_value;
-        char *pstring_value;
-        char *const_string_value;
-        void *pvoid_value;
-    } data;
+  plc4c_data_type data_type;
+  size_t size;
+  union {
+    bool boolean_value;
+    char char_value;
+    unsigned char uchar_value;
+    short short_value;
+    unsigned short ushort_value;
+    int int_value;
+    unsigned int uint_value;
+    /* more */
+    float float_value;
+    char *pstring_value;
+    char *const_string_value;
+    void *pvoid_value;
+  } data;
 
-    plc4c_data_custom_destroy custom_destroy;
-    plc4c_data_custom_printf custom_printf;
+  plc4c_data_custom_destroy custom_destroy;
+  plc4c_data_custom_printf custom_printf;
 };
 
 struct plc4c_request_value_item_t {
-    plc4c_item *item;
-    plc4c_data *value;
+  plc4c_item *item;
+  plc4c_data *value;
 };
 
 struct plc4c_response_value_item_t {
-    plc4c_item *item;
-    plc4c_response_code response_code;
-    void *value;
+  plc4c_item *item;
+  plc4c_response_code response_code;
+  void *value;
 };
 
 struct plc4c_response_item_t {
-    plc4c_item *item;
-    plc4c_response_code response_code;
+  plc4c_item *item;
+  plc4c_response_code response_code;
 };
 
 struct plc4c_read_request_t {
-    plc4c_connection *connection;
-    plc4c_list *items;
+  plc4c_connection *connection;
+  plc4c_list *items;
 };
 
 struct plc4c_write_request_t {
-    plc4c_connection *connection;
-    plc4c_list *items;
+  plc4c_connection *connection;
+  plc4c_list *items;
 };
 
 struct plc4c_read_request_execution_t {
-    plc4c_read_request *read_request;
-    plc4c_read_response *read_response;
-    plc4c_system_task *system_task;
+  plc4c_read_request *read_request;
+  plc4c_read_response *read_response;
+  plc4c_system_task *system_task;
 };
 
 struct plc4c_write_request_execution_t {
-    plc4c_write_request *write_request;
-    plc4c_write_response *write_response;
-    plc4c_system_task *system_task;
+  plc4c_write_request *write_request;
+  plc4c_write_response *write_response;
+  plc4c_system_task *system_task;
 };
 
 struct plc4c_read_response_t {
-    plc4c_read_request *read_request;
-    plc4c_list *items;
+  plc4c_read_request *read_request;
+  plc4c_list *items;
 };
 
 struct plc4c_write_response_t {
-    plc4c_write_request *write_request;
-    plc4c_list *response_items;
+  plc4c_write_request *write_request;
+  plc4c_list *response_items;
 };
 
 struct plc4c_system_task_t {
-    int state_id;
-    plc4c_system_task_state_machine_function state_machine_function;
-    bool completed;
+  int state_id;
+  plc4c_system_task_state_machine_function state_machine_function;
+  bool completed;
 
-    void *context;
-    // Reference to the connection that owns this task
-    plc4c_connection *connection;
+  void *context;
+  // Reference to the connection that owns this task
+  plc4c_connection *connection;
 };
 
-#endif //PLC4C_SPI_TYPES_PRIVATE_H_
+#endif  // PLC4C_SPI_TYPES_PRIVATE_H_

--- a/sandbox/plc4c/spi/src/connection.c
+++ b/sandbox/plc4c/spi/src/connection.c
@@ -17,118 +17,270 @@
  * under the License.
  */
 
-#include <stdlib.h>
 #include <plc4c/connection.h>
 #include <plc4c/spi/types_private.h>
+#include <stdlib.h>
+#include <string.h>
+
+void plc4c_connection_initialize(plc4c_connection *new_connection) {
+  new_connection->connected = false;
+  new_connection->disconnect = false;
+  new_connection->num_running_system_tasks = 0;
+
+  new_connection->system = NULL;
+  new_connection->driver = NULL;
+  new_connection->transport = NULL;
+
+  new_connection->supports_reading = NULL;
+  new_connection->supports_writing = NULL;
+  new_connection->supports_subscriptions = NULL;
+}
+
+void plc4c_connection_set_connection_string(plc4c_connection *connection,
+                                            char *connection_string) {
+  if (connection_string != NULL) {
+    connection->connection_string =
+        (char *)malloc((strlen(connection_string) + 1) * sizeof(char));
+    strcpy(connection->connection_string, connection_string);
+  } else {
+    connection->connection_string = NULL;
+  }
+}
+
+char *plc4c_connection_get_protocol_code(plc4c_connection *connection) {
+  return connection->protocol_code;
+}
+
+void plc4c_connection_set_protocol_code(plc4c_connection *connection,
+                                        char *protocol_code) {
+  if (protocol_code != NULL) {
+    connection->protocol_code =
+        (char *)malloc((strlen(protocol_code) + 1) * sizeof(char));
+    strcpy(connection->protocol_code, protocol_code);
+  } else {
+    connection->protocol_code = NULL;
+  }
+}
+
+char *plc4c_connection_get_transport_code(plc4c_connection *connection) {
+  return connection->transport_code;
+}
+
+void plc4c_connection_set_transport_code(plc4c_connection *connection,
+                                         char *transport_code) {
+  if (transport_code != NULL) {
+    connection->transport_code =
+        (char *)malloc((strlen(transport_code) + 1) * sizeof(char));
+    strcpy(connection->transport_code, transport_code);
+  } else {
+    connection->transport_code = NULL;
+  }
+}
+
+char *plc4c_connection_get_transport_connect_information(
+    plc4c_connection *connection) {
+  return connection->transport_connect_information;
+}
+
+void plc4c_connection_set_transport_connect_information(
+    plc4c_connection *connection, char *transport_connect_information) {
+  if (transport_connect_information != NULL) {
+    connection->transport_connect_information = (char *)malloc(
+        (strlen(transport_connect_information) + 1) * sizeof(char));
+    strcpy(connection->transport_connect_information,
+           transport_connect_information);
+  } else {
+    connection->transport_connect_information = NULL;
+  }
+}
+
+char *plc4c_connection_get_parameters(plc4c_connection *connection) {
+  return connection->parameters;
+}
+
+void plc4c_connection_set_parameters(plc4c_connection *connection,
+                                     char *parameters) {
+  if (parameters != NULL) {
+    connection->parameters =
+        (char *)malloc((strlen(parameters) + 1) * sizeof(char));
+    strcpy(connection->parameters, parameters);
+  } else {
+    connection->parameters = NULL;
+  }
+}
 
 bool plc4c_connection_is_connected(plc4c_connection *connection) {
-    return connection->connected;
+  return connection->connected;
 }
 
-bool plc4c_connection_has_error(plc4c_connection *connection) {
-    return false;
+void plc4c_connection_set_connected(plc4c_connection *connection,
+                                    bool connected) {
+  connection->connected = connected;
 }
+
+bool plc4c_connection_disconnect_is_set(plc4c_connection *connection) {
+  return connection->disconnect;
+}
+
+void plc4c_connection_disconnect_set(plc4c_connection *connection,
+                                     bool disconnect) {
+  connection->disconnect = disconnect;
+}
+
+plc4c_system *plc4c_connection_get_system(plc4c_connection *connection) {
+  return connection->system;
+}
+
+void plc4c_connection_set_system(plc4c_connection *connection,
+                                 plc4c_system *system) {
+  connection->system = system;
+}
+
+bool plc4c_connection_has_error(plc4c_connection *connection) { return false; }
 
 plc4c_return_code plc4c_connection_disconnect(plc4c_connection *connection) {
-    plc4c_system_task *new_disconnection_task = NULL;
-    plc4c_return_code result = connection->driver->disconnect_function(connection, &new_disconnection_task);
-    if (result != OK) {
-        return -1;
-    }
-    // Increment the number of running tasks for this connection.
-    connection->num_running_system_tasks++;
-    plc4c_utils_list_insert_tail_value(connection->system->task_list, new_disconnection_task);
-    return OK;
+  plc4c_system_task *new_disconnection_task = NULL;
+  plc4c_return_code result = connection->driver->disconnect_function(
+      connection, &new_disconnection_task);
+  if (result != OK) {
+    return -1;
+  }
+  // Increment the number of running tasks for this connection.
+  connection->num_running_system_tasks++;
+  plc4c_utils_list_insert_tail_value(
+      plc4c_system_get_task_list(plc4c_connection_get_system(connection)),
+      new_disconnection_task);
+  return OK;
 }
 
 void plc4c_connection_destroy(plc4c_connection *connection) {
-    free(connection);
+  if (connection == NULL) {
+    return;
+  }
+  if (connection->connection_string != NULL) {
+    free(connection->connection_string);
+  }
+  if (connection->transport != NULL) {
+    free(connection->transport);
+  }
+  if (connection->transport_code != NULL) {
+    free(connection->transport_code);
+  }
+  if (connection->transport_connect_information != NULL) {
+    free(connection->transport_connect_information);
+  }
+  if (connection->protocol_code != NULL) {
+    free(connection->protocol_code);
+  }
+  if (connection->parameters != NULL) {
+    free(connection->parameters);
+  }
 }
 
 char *plc4c_connection_get_connection_string(plc4c_connection *connection) {
-    return connection->connection_string;
+  return connection->connection_string;
 }
 
 bool plc4c_connection_supports_reading(plc4c_connection *connection) {
-    return connection->supports_reading;
+  return connection->supports_reading;
 }
 
-plc4c_return_code plc4c_connection_create_read_request(plc4c_connection *connection,
-                                                       plc4c_list *addresses,
-                                                       plc4c_read_request **read_request) {
-    // NEED NULL ASSERTS
+plc4c_return_code plc4c_connection_create_read_request(
+    plc4c_connection *connection, plc4c_list *addresses,
+    plc4c_read_request **read_request) {
+  // NEED NULL ASSERTS
 
-    // we need something to do
-    if (plc4c_utils_list_size(addresses) == 0) {
-        return INVALID_LIST_SIZE;
-    }
-    plc4c_read_request *new_read_request = malloc(sizeof(plc4c_read_request));
-    new_read_request->connection = connection;
-    plc4c_utils_list_create(&(new_read_request->items));
-    plc4c_list_element *element = plc4c_utils_list_head(addresses);
-    if (element != NULL) {
-        do {
-            plc4c_item *item = connection->driver->parse_address_function((char *) element->value);
-            plc4c_utils_list_insert_tail_value(new_read_request->items, item);
-            element = element->next;
-        } while (element != NULL);
-    }
-    *read_request = new_read_request;
-    return OK;
+  // we need something to do
+  if (plc4c_utils_list_size(addresses) == 0) {
+    return INVALID_LIST_SIZE;
+  }
+  plc4c_read_request *new_read_request = malloc(sizeof(plc4c_read_request));
+  new_read_request->connection = connection;
+  plc4c_utils_list_create(&(new_read_request->items));
+  plc4c_list_element *element = plc4c_utils_list_head(addresses);
+  if (element != NULL) {
+    do {
+      plc4c_item *item =
+          connection->driver->parse_address_function((char *)element->value);
+      plc4c_utils_list_insert_tail_value(new_read_request->items, item);
+      element = element->next;
+    } while (element != NULL);
+  }
+  *read_request = new_read_request;
+  return OK;
 }
 
-void plc4c_connection_read_response_destroy(plc4c_read_response *read_response) {
-    read_response->read_request->connection->driver->free_read_response_function(read_response);
+void plc4c_connection_read_response_destroy(
+    plc4c_read_response *read_response) {
+  read_response->read_request->connection->driver->free_read_response_function(
+      read_response);
 }
 
 bool plc4c_connection_supports_writing(plc4c_connection *connection) {
-    return connection->supports_writing;
+  return connection->supports_writing;
 }
 
-plc4c_return_code plc4c_connection_create_write_request(plc4c_connection *connection,
-                                                        plc4c_list *addresses,
-                                                        plc4c_list *values,
-                                                        plc4c_write_request **write_request) {
-    // NEED NULL ASSERTS
+plc4c_return_code plc4c_connection_create_write_request(
+    plc4c_connection *connection, plc4c_list *addresses, plc4c_list *values,
+    plc4c_write_request **write_request) {
+  // NEED NULL ASSERTS
 
-    // the address and value lists must match
-    if (plc4c_utils_list_size(addresses) != plc4c_utils_list_size(values)) {
-        return NON_MATCHING_LISTS;
-    }
+  // the address and value lists must match
+  if (plc4c_utils_list_size(addresses) != plc4c_utils_list_size(values)) {
+    return NON_MATCHING_LISTS;
+  }
 
-    // we need something to do
-    if (plc4c_utils_list_size(addresses) == 0) {
-        return INVALID_LIST_SIZE;
-    }
-    plc4c_write_request *new_write_request = (plc4c_write_request *) malloc(sizeof(plc4c_write_request));
-    new_write_request->connection = connection;
-    plc4c_utils_list_create(&(new_write_request->items));
+  // we need something to do
+  if (plc4c_utils_list_size(addresses) == 0) {
+    return INVALID_LIST_SIZE;
+  }
+  plc4c_write_request *new_write_request =
+      (plc4c_write_request *)malloc(sizeof(plc4c_write_request));
+  new_write_request->connection = connection;
+  plc4c_utils_list_create(&(new_write_request->items));
 
-    plc4c_list_element *address_element = plc4c_utils_list_head(addresses);
-    plc4c_list_element *value_element = plc4c_utils_list_head(values);
-    if (address_element != NULL && value_element != NULL) {
-        do {
-            char *address = (char *) address_element->value;
-            // Parse an address string and get a driver-dependent data-structure representing the address back.
-            plc4c_item *address_item = connection->driver->parse_address_function(address);
+  plc4c_list_element *address_element = plc4c_utils_list_head(addresses);
+  plc4c_list_element *value_element = plc4c_utils_list_head(values);
+  if (address_element != NULL && value_element != NULL) {
+    do {
+      char *address = (char *)address_element->value;
+      // Parse an address string and get a driver-dependent data-structure
+      // representing the address back.
+      plc4c_item *address_item =
+          connection->driver->parse_address_function(address);
 
-            // Create a new value item, binding an address item to a value.
-            plc4c_request_value_item *value_item = malloc(sizeof(plc4c_request_value_item));
-            value_item->item = address_item;
-            value_item->value = (plc4c_data *) value_element->value;
+      // Create a new value item, binding an address item to a value.
+      plc4c_request_value_item *value_item =
+          malloc(sizeof(plc4c_request_value_item));
+      value_item->item = address_item;
+      value_item->value = (plc4c_data *)value_element->value;
 
-            // Add the new item ot the list of items.
-            plc4c_utils_list_insert_tail_value(new_write_request->items, value_item);
+      // Add the new item ot the list of items.
+      plc4c_utils_list_insert_tail_value(new_write_request->items, value_item);
 
-            address_element = address_element->next;
-            value_element = value_element->next;
-        } while (address_element != NULL && value_element != NULL);
-    }
+      address_element = address_element->next;
+      value_element = value_element->next;
+    } while (address_element != NULL && value_element != NULL);
+  }
 
-    *write_request = new_write_request;
-    return OK;
+  *write_request = new_write_request;
+  return OK;
 }
 
-void plc4c_connection_write_response_destroy(plc4c_write_response *write_response) {
-    write_response->write_request->connection->driver->free_write_response_function(write_response);
+void plc4c_connection_write_response_destroy(
+    plc4c_write_response *write_response) {
+  write_response->write_request->connection->driver
+      ->free_write_response_function(write_response);
+}
+
+int plc4c_connection_running_tasks_count(plc4c_connection *connection) {
+  return connection->num_running_system_tasks;
+}
+
+int plc4c_connection_task_added(plc4c_connection *connection) {
+  return ++connection->num_running_system_tasks;
+}
+
+int plc4c_connection_task_removed(plc4c_connection *connection) {
+  return --connection->num_running_system_tasks;
 }

--- a/sandbox/plc4c/spi/src/read.c
+++ b/sandbox/plc4c/spi/src/read.c
@@ -17,56 +17,75 @@
  * under the License.
  */
 
-#include <stdlib.h>
+#include <plc4c/plc4c.h>
 #include <plc4c/read.h>
 #include <plc4c/spi/types_private.h>
+#include <stdlib.h>
 
-
-plc4c_return_code plc4c_read_request_execute(plc4c_read_request *read_request,
-                                             plc4c_read_request_execution **read_request_execution) {
-    // Inject the default read context into the system task.
-    plc4c_read_request_execution *new_read_request_execution = malloc(sizeof(plc4c_read_request_execution));
-    new_read_request_execution->read_request = read_request;
-    new_read_request_execution->read_response = NULL;
-    new_read_request_execution->system_task = NULL;
-
-    plc4c_system_task *system_task;
-    read_request->connection->driver->read_function(new_read_request_execution, &system_task);
-    // Increment the number of running tasks for this connection.
-    read_request->connection->num_running_system_tasks++;
-    // Add the new task to the task-list.
-    plc4c_utils_list_insert_tail_value(read_request->connection->system->task_list, system_task);
-
-    *read_request_execution = new_read_request_execution;
-    return OK;
+plc4c_connection *plc4c_read_request_get_connection(
+    plc4c_read_request *read_request) {
+  return read_request->connection;
 }
 
-bool plc4c_read_request_finished_successfully(plc4c_read_request_execution *read_request_execution) {
-    if (read_request_execution == NULL) {
-        return true;
-    }
-    if (read_request_execution->system_task == NULL) {
-        return true;
-    }
-    return read_request_execution->system_task->completed;
+void plc4c_read_request_set_connection(plc4c_read_request *read_request,
+                                       plc4c_connection *connection) {
+  read_request->connection = connection;
 }
 
-bool plc4c_read_request_has_error(plc4c_read_request_execution *read_request_execution) {
-    return false;
+plc4c_return_code plc4c_read_request_execute(
+    plc4c_read_request *read_request,
+    plc4c_read_request_execution **read_request_execution) {
+  // Inject the default read context into the system task.
+  plc4c_read_request_execution *new_read_request_execution =
+      malloc(sizeof(plc4c_read_request_execution));
+  new_read_request_execution->read_request = read_request;
+  new_read_request_execution->read_response = NULL;
+  new_read_request_execution->system_task = NULL;
+
+  plc4c_system_task *system_task;
+  read_request->connection->driver->read_function(new_read_request_execution,
+                                                  &system_task);
+  // Increment the number of running tasks for this connection.
+  plc4c_connection_task_added(read_request->connection);
+  // Add the new task to the task-list.
+  plc4c_utils_list_insert_tail_value(
+      plc4c_system_get_task_list(plc4c_connection_get_system(
+          plc4c_read_request_get_connection(read_request))),
+      system_task);
+
+  *read_request_execution = new_read_request_execution;
+  return OK;
 }
 
-plc4c_read_response *plc4c_read_request_get_response(plc4c_read_request_execution *read_request_execution) {
-    if (read_request_execution == NULL) {
-        return NULL;
-    }
-    return read_request_execution->read_response;
+bool plc4c_read_request_finished_successfully(
+    plc4c_read_request_execution *read_request_execution) {
+  if (read_request_execution == NULL) {
+    return true;
+  }
+  if (read_request_execution->system_task == NULL) {
+    return true;
+  }
+  return read_request_execution->system_task->completed;
+}
+
+bool plc4c_read_request_has_error(
+    plc4c_read_request_execution *read_request_execution) {
+  return false;
+}
+
+plc4c_read_response *plc4c_read_request_get_response(
+    plc4c_read_request_execution *read_request_execution) {
+  if (read_request_execution == NULL) {
+    return NULL;
+  }
+  return read_request_execution->read_response;
 }
 
 void plc4c_read_request_destroy(plc4c_read_request *read_request) {
-    free(read_request);
+  free(read_request);
 }
 
-void plc4c_read_request_execution_destroy(plc4c_read_request_execution *read_request_execution) {
-    free(read_request_execution);
+void plc4c_read_request_execution_destroy(
+    plc4c_read_request_execution *read_request_execution) {
+  free(read_request_execution);
 }
-

--- a/sandbox/plc4c/spi/src/system.c
+++ b/sandbox/plc4c/spi/src/system.c
@@ -17,394 +17,466 @@
  * under the License.
  */
 
+#include <plc4c/plc4c.h>
+#include <plc4c/system.h>
 #include <stdlib.h>
 #include <string.h>
-#include <plc4c/system.h>
-#include "plc4c/spi/types_private.h"
+
 #include "plc4c/spi/system_private.h"
+#include "plc4c/spi/types_private.h"
+
+static void delete_driver_list_element(plc4c_list_element *driver_element) {
+  plc4c_driver *driver = (plc4c_driver *)driver_element->value;
+  // plc4c_driver_destroy(driver);
+}
+
+static void delete_transport_list_element(
+    plc4c_list_element *transport_element) {
+  plc4c_transport *transport = (plc4c_transport *)transport_element->value;
+  // plc4c_transport_destroy(transport);
+}
+static void delete_connection_list_element(
+    plc4c_list_element *connection_element) {
+  plc4c_connection *connection = (plc4c_connection *)connection_element->value;
+  plc4c_connection_destroy(connection);
+  connection_element->value = NULL;
+}
+static void delete_task_list_element(plc4c_list_element *task_list_element) {
+  plc4c_driver *driver = (plc4c_driver *)task_list_element->value;
+  // plc4c_driver_destroy(driver);
+}
 
 plc4c_return_code plc4c_system_create(plc4c_system **system) {
-    plc4c_system *new_system = malloc(sizeof(plc4c_system));
+  plc4c_system *new_system = malloc(sizeof(plc4c_system));
 
-    plc4c_list *new_list = NULL;
-    plc4c_utils_list_create(&new_list);
-    new_system->driver_list = new_list;
-    plc4c_utils_list_create(&new_list);
-    new_system->transport_list = new_list;
-    plc4c_utils_list_create(&new_list);
-    new_system->connection_list = new_list;
-    plc4c_utils_list_create(&new_list);
-    new_system->task_list = new_list;
+  plc4c_list *new_list = NULL;
+  plc4c_utils_list_create(&new_list);
+  new_system->driver_list = new_list;
+  plc4c_utils_list_create(&new_list);
+  new_system->transport_list = new_list;
+  plc4c_utils_list_create(&new_list);
+  new_system->connection_list = new_list;
+  plc4c_utils_list_create(&new_list);
+  new_system->task_list = new_list;
 
-    new_system->on_driver_load_success_callback = NULL;
-    new_system->on_driver_load_failure_callback = NULL;
-    new_system->on_connect_success_callback = NULL;
-    new_system->on_connect_failure_callback = NULL;
-    new_system->on_disconnect_success_callback = NULL;
-    new_system->on_disconnect_failure_callback = NULL;
-    new_system->on_loop_failure_callback = NULL;
+  new_system->on_driver_load_success_callback = NULL;
+  new_system->on_driver_load_failure_callback = NULL;
+  new_system->on_connect_success_callback = NULL;
+  new_system->on_connect_failure_callback = NULL;
+  new_system->on_disconnect_success_callback = NULL;
+  new_system->on_disconnect_failure_callback = NULL;
+  new_system->on_loop_failure_callback = NULL;
 
-    *system = new_system;
-    return OK;
+  *system = new_system;
+  return OK;
 }
 
 void plc4c_system_destroy(plc4c_system *system) {
-    // TODO: So some more cleaning up ...
-    free(system);
+  // TODO: So some more cleaning up ...
+  plc4c_utils_list_delete_elements(system->driver_list,
+                                   &delete_driver_list_element);
+  plc4c_utils_list_delete_elements(system->transport_list,
+                                   &delete_transport_list_element);
+  plc4c_utils_list_delete_elements(system->connection_list,
+                                   &delete_connection_list_element);
+  plc4c_utils_list_delete_elements(system->task_list,
+                                   &delete_task_list_element);
+  free(system->driver_list);
+  free(system->transport_list);
+  free(system->connection_list);
+  free(system->task_list);
+  free(system);
 }
 
-void plc4c_system_set_on_driver_load_success_callback(plc4c_system *system,
-                                                      plc4c_system_on_driver_load_success_callback callback) {
-    system->on_driver_load_success_callback = callback;
+plc4c_list *plc4c_system_get_task_list(plc4c_system *system) {
+  return system->task_list;
 }
 
-void plc4c_system_set_on_driver_load_failure_callback(plc4c_system *system,
-                                                      plc4c_system_on_driver_load_failure_callback callback) {
-    system->on_driver_load_failure_callback = callback;
+void plc4c_system_set_task_list(plc4c_system *system, plc4c_list *task_list) {
+  system->task_list = task_list;
 }
 
-void plc4c_system_set_on_connect_success_callback(plc4c_system *system,
-                                                  plc4c_system_on_connect_success_callback callback) {
-    system->on_connect_success_callback = callback;
+void plc4c_system_set_on_driver_load_success_callback(
+    plc4c_system *system,
+    plc4c_system_on_driver_load_success_callback callback) {
+  system->on_driver_load_success_callback = callback;
 }
 
-void plc4c_system_set_on_connect_failure_callback(plc4c_system *system,
-                                                  plc4c_system_on_connect_failure_callback callback) {
-    system->on_connect_failure_callback = callback;
+void plc4c_system_set_on_driver_load_failure_callback(
+    plc4c_system *system,
+    plc4c_system_on_driver_load_failure_callback callback) {
+  system->on_driver_load_failure_callback = callback;
 }
 
-void plc4c_system_set_on_disconnect_success_callback(plc4c_system *system,
-                                                     plc4c_system_on_disconnect_success_callback callback) {
-    system->on_disconnect_success_callback = callback;
+void plc4c_system_set_on_connect_success_callback(
+    plc4c_system *system, plc4c_system_on_connect_success_callback callback) {
+  system->on_connect_success_callback = callback;
 }
 
-void plc4c_system_set_on_disconnection_failure_callback(plc4c_system *system,
-                                                        plc4c_system_on_disconnect_failure_callback callback) {
-    system->on_disconnect_failure_callback = callback;
+void plc4c_system_set_on_connect_failure_callback(
+    plc4c_system *system, plc4c_system_on_connect_failure_callback callback) {
+  system->on_connect_failure_callback = callback;
 }
 
-void plc4c_system_set_on_loop_failure_callback(plc4c_system *system,
-                                               plc4c_system_on_loop_failure_callback callback) {
-    system->on_loop_failure_callback = callback;
+void plc4c_system_set_on_disconnect_success_callback(
+    plc4c_system *system,
+    plc4c_system_on_disconnect_success_callback callback) {
+  system->on_disconnect_success_callback = callback;
+}
+
+void plc4c_system_set_on_disconnection_failure_callback(
+    plc4c_system *system,
+    plc4c_system_on_disconnect_failure_callback callback) {
+  system->on_disconnect_failure_callback = callback;
+}
+
+void plc4c_system_set_on_loop_failure_callback(
+    plc4c_system *system, plc4c_system_on_loop_failure_callback callback) {
+  system->on_loop_failure_callback = callback;
 }
 
 plc4c_return_code plc4c_system_add_driver(plc4c_system *system,
                                           plc4c_driver *driver) {
-    // If the system is not initialized, return an error.
-    // There is nothing we can do here.
-    if (system == NULL) {
-        return INTERNAL_ERROR;
-    }
+  // If the system is not initialized, return an error.
+  // There is nothing we can do here.
+  if (system == NULL) {
+    return INTERNAL_ERROR;
+  }
 
-    plc4c_utils_list_insert_tail_value(system->driver_list, driver);
+  plc4c_utils_list_insert_tail_value(system->driver_list, driver);
 
-    return OK;
+  return OK;
 }
 
 plc4c_return_code plc4c_system_add_transport(plc4c_system *system,
                                              plc4c_transport *transport) {
-    // If the system is not initialized, return an error.
-    // There is nothing we can do here.
-    if (system == NULL) {
-        return INTERNAL_ERROR;
-    }
+  // If the system is not initialized, return an error.
+  // There is nothing we can do here.
+  if (system == NULL) {
+    return INTERNAL_ERROR;
+  }
 
-    plc4c_utils_list_insert_tail_value(system->transport_list, transport);
+  plc4c_utils_list_insert_tail_value(system->transport_list, transport);
 
-    return OK;
+  return OK;
 }
 
-plc4c_return_code plc4c_system_add_connection(plc4c_system *system, plc4c_connection *connection) {
-    // If the system is not initialized, return an error.
-    // There is nothing we can do here.
-    if (system == NULL) {
-        return INTERNAL_ERROR;
-    }
+plc4c_return_code plc4c_system_add_connection(plc4c_system *system,
+                                              plc4c_connection *connection) {
+  // If the system is not initialized, return an error.
+  // There is nothing we can do here.
+  if (system == NULL) {
+    return INTERNAL_ERROR;
+  }
 
-    plc4c_utils_list_insert_tail_value(system->connection_list, connection);
+  plc4c_utils_list_insert_tail_value(system->connection_list, connection);
 
-    return OK;
+  return OK;
+}
+
+void plc4c_system_remove_connection(plc4c_system *system,
+                                    plc4c_connection *connection) {
+  if (system == NULL || connection == NULL) {
+    return;
+  }
+  plc4c_list_element *element = plc4c_utils_list_find_element_by_item(
+      system->connection_list, connection);
+  if (element != NULL) {
+    plc4c_utils_list_remove(system->connection_list, element);
+  }
+  free(element);
 }
 
 plc4c_return_code plc4c_system_init(plc4c_system *system) {
-    // Nothing to really do at the moment.
+  // Nothing to really do at the moment.
 
-    return OK;
+  return OK;
 }
 
-void plc4c_system_shutdown(plc4c_system *system) {
+void plc4c_system_shutdown(plc4c_system *system) {}
 
-}
+plc4c_return_code plc4c_system_create_connection(
+    char *connection_string, plc4c_connection **connection) {
+  // Count the number of colons and question-marks so we know which pattern to
+  // use for matching and how large the arrays for containing the different
+  // segments should be.
+  int num_colons = 0;
+  int num_question_marks = 0;
+  char *protocol_code = NULL;
+  char *transport_code = NULL;
+  char *transport_connect_information = NULL;
+  char *parameters = NULL;
+  int start_segment_index = 0;
+  char *start_segment = connection_string;
+  // The connection string has two parts ... the first, where colons are the
+  // delimiters and the second where a question mark is the delimiter.
+  enum mode {
+    SEARCHING_FOR_COLONS,
+    SEARCHING_FOR_QUESTION_MARKS
+  } mode = SEARCHING_FOR_COLONS;
+  for (int i = 0; i <= strlen(connection_string); i++) {
+    // If we're in the first part of the connection string ... watch out for
+    // colons.
+    if (mode == SEARCHING_FOR_COLONS) {
+      // If we encounter a colon, depending on the number of colons already
+      // found, save the information in either the protocol code or transport
+      // code variable.
+      if (*(connection_string + i) == ':') {
+        num_colons++;
+        // The first colon delimits the protocol-code.
+        if (num_colons == 1) {
+          // Allocate enough memory to hold the sub-string.
+          protocol_code =
+              malloc(sizeof(char) * ((i - start_segment_index) + 1));
+          // Copy the sub-string to the freshly allocated memory area.
+          strlcpy(protocol_code, start_segment, (i - start_segment_index) + 1);
 
-plc4c_return_code plc4c_system_create_connection(char *connection_string, plc4c_connection **connection) {
-    // Count the number of colons and question-marks so we know which pattern to use for
-    // matching and how large the arrays for containing the different segments should be.
-    int num_colons = 0;
-    int num_question_marks = 0;
-    char *protocol_code = NULL;
-    char *transport_code = NULL;
-    char *transport_connect_information = NULL;
-    char *parameters = NULL;
-    int start_segment_index = 0;
-    char *start_segment = connection_string;
-    // The connection string has two parts ... the first, where colons are the delimiters
-    // and the second where a question mark is the delimiter.
-    enum mode {
-        SEARCHING_FOR_COLONS,
-        SEARCHING_FOR_QUESTION_MARKS
-    } mode = SEARCHING_FOR_COLONS;
-    for (int i = 0; i <= strlen(connection_string); i++) {
-        // If we're in the first part of the connection string ... watch out for colons.
-        if (mode == SEARCHING_FOR_COLONS) {
-            // If we encounter a colon, depending on the number of colons already found, save the information in
-            // either the protocol code or transport code variable.
-            if (*(connection_string + i) == ':') {
-                num_colons++;
-                // The first colon delimits the protocol-code.
-                if (num_colons == 1) {
-                    // Allocate enough memory to hold the sub-string.
-                    protocol_code = malloc(sizeof(char) * ((i - start_segment_index) + 1));
-                    // Copy the sub-string to the freshly allocated memory area.
-                    strlcpy(protocol_code, start_segment, (i - start_segment_index) + 1);
+          // Set the start of the next segment to directly after the colon.
+          start_segment_index = i + 1;
+          start_segment = connection_string + start_segment_index;
 
-                    // Set the start of the next segment to directly after the colon.
-                    start_segment_index = i + 1;
-                    start_segment = connection_string + start_segment_index;
-
-                    // If the following character would be a slash, we're probably finished and no transport code is
-                    // provided. If this is the case, ensure it's actually a double-slash and if this is the case
-                    // switch to the question-mark searching mode.
-                    if (*start_segment == '/') {
-                        if (*(start_segment + 1) == '/') {
-                            mode = SEARCHING_FOR_QUESTION_MARKS;
-                            start_segment_index += 2;
-                            start_segment += 2;
-                        } else {
-                            return INVALID_CONNECTION_STRING;
-                        }
-                    }
-                }
-                    // If we encountered a second colon, this is the transport code.
-                else if (num_colons == 2) {
-                    // Allocate enough memory to hold the sub-string.
-                    transport_code = malloc(sizeof(char) * ((i - start_segment_index) + 1));
-                    // Copy the sub-string to the freshly allocated memory area.
-                    strlcpy(transport_code, start_segment, (i - start_segment_index) + 1);
-
-                    // Set the start of the next segment to directly after the colon.
-                    start_segment_index = i + 1;
-                    start_segment = connection_string + start_segment_index;
-
-                    // The transport code is always followed by "://". So check if this is the case.
-                    // If it is, switch to question-mark searching mode.
-                    if ((*start_segment != '/') || (*(start_segment + 1) != '/')) {
-                        return INVALID_CONNECTION_STRING;
-                    }
-                    mode = SEARCHING_FOR_QUESTION_MARKS;
-
-                    // Bump the start of the segment to after the double slashes.
-                    start_segment_index += 2;
-                    start_segment += 2;
-                } else {
-                    return INVALID_CONNECTION_STRING;
-                }
+          // If the following character would be a slash, we're probably
+          // finished and no transport code is provided. If this is the case,
+          // ensure it's actually a double-slash and if this is the case switch
+          // to the question-mark searching mode.
+          if (*start_segment == '/') {
+            if (*(start_segment + 1) == '/') {
+              mode = SEARCHING_FOR_QUESTION_MARKS;
+              start_segment_index += 2;
+              start_segment += 2;
+            } else {
+              return INVALID_CONNECTION_STRING;
             }
+          }
         }
-            // If we're in the second part, look for question marks.
+        // If we encountered a second colon, this is the transport code.
+        else if (num_colons == 2) {
+          // Allocate enough memory to hold the sub-string.
+          transport_code =
+              malloc(sizeof(char) * ((i - start_segment_index) + 1));
+          // Copy the sub-string to the freshly allocated memory area.
+          strlcpy(transport_code, start_segment, (i - start_segment_index) + 1);
+
+          // Set the start of the next segment to directly after the colon.
+          start_segment_index = i + 1;
+          start_segment = connection_string + start_segment_index;
+
+          // The transport code is always followed by "://". So check if this is
+          // the case. If it is, switch to question-mark searching mode.
+          if ((*start_segment != '/') || (*(start_segment + 1) != '/')) {
+            return INVALID_CONNECTION_STRING;
+          }
+          mode = SEARCHING_FOR_QUESTION_MARKS;
+
+          // Bump the start of the segment to after the double slashes.
+          start_segment_index += 2;
+          start_segment += 2;
+        } else {
+          return INVALID_CONNECTION_STRING;
+        }
+      }
+    }
+    // If we're in the second part, look for question marks.
+    else {
+      // The question-mark separates the transport connect information from the
+      // parameters.
+      if (*(connection_string + i) == '?') {
+        num_question_marks++;
+        // Only one question-mark is allowed in connection strings.
+        if (num_question_marks > 1) {
+          return INVALID_CONNECTION_STRING;
+        }
+
+        // Allocate enough memory to hold the sub-string.
+        transport_connect_information =
+            malloc(sizeof(char) * ((i - start_segment_index) + 1));
+        // Copy the sub-string to the freshly allocated memory area.
+        strlcpy(transport_connect_information, start_segment,
+                (i - start_segment_index) + 1);
+
+        // Set the start of the next segment to directly after the
+        // question-mark.
+        start_segment_index = i + 1;
+        start_segment = connection_string + start_segment_index;
+      }
+      // This is the last character ... finish up the last loose end.
+      if (i == strlen(connection_string)) {
+        // If no question-mark has been encountered, this connection string
+        // doesn't have one and the remaining part is simply the transport
+        // connect information.
+        if (num_question_marks == 0) {
+          transport_connect_information =
+              malloc(sizeof(char) * ((i - start_segment_index) + 1));
+          strlcpy(transport_connect_information, start_segment,
+                  (i - start_segment_index) + 1);
+        }
+        // I a question-mark was found, this is the paramters section.
         else {
-            // The question-mark separates the transport connect information from the parameters.
-            if (*(connection_string + i) == '?') {
-                num_question_marks++;
-                // Only one question-mark is allowed in connection strings.
-                if (num_question_marks > 1) {
-                    return INVALID_CONNECTION_STRING;
-                }
-
-                // Allocate enough memory to hold the sub-string.
-                transport_connect_information = malloc(sizeof(char) * ((i - start_segment_index) + 1));
-                // Copy the sub-string to the freshly allocated memory area.
-                strlcpy(transport_connect_information, start_segment, (i - start_segment_index) + 1);
-
-                // Set the start of the next segment to directly after the question-mark.
-                start_segment_index = i + 1;
-                start_segment = connection_string + start_segment_index;
-            }
-            // This is the last character ... finish up the last loose end.
-            if (i == strlen(connection_string)) {
-                // If no question-mark has been encountered, this connection string doesn't have one and the
-                // remaining part is simply the transport connect information.
-                if (num_question_marks == 0) {
-                    transport_connect_information = malloc(sizeof(char) * ((i - start_segment_index) + 1));
-                    strlcpy(transport_connect_information, start_segment, (i - start_segment_index) + 1);
-                }
-                    // I a question-mark was found, this is the paramters section.
-                else {
-                    parameters = malloc(sizeof(char) * (i - start_segment_index));
-                    strlcpy(parameters, start_segment, (i - start_segment_index) + 1);
-                }
-            }
+          parameters = malloc(sizeof(char) * (i - start_segment_index));
+          strlcpy(parameters, start_segment, (i - start_segment_index) + 1);
         }
+      }
     }
-    if (num_colons == 0) {
-        return INVALID_CONNECTION_STRING;
-    }
+  }
+  if (num_colons == 0) {
+    return INVALID_CONNECTION_STRING;
+  }
 
-    // Initialize a new connection data-structure with the parsed information.
-    plc4c_connection *new_connection = malloc(sizeof(plc4c_connection));
-    new_connection->connection_string = connection_string;
-    new_connection->protocol_code = protocol_code;
-    new_connection->transport_code = transport_code;
-    new_connection->transport_connect_information = transport_connect_information;
-    new_connection->parameters = parameters;
+  // Initialize a new connection data-structure with the parsed information.
+  plc4c_connection *new_connection = malloc(sizeof(plc4c_connection));
+  plc4c_connection_initialize(new_connection);
+  plc4c_connection_set_connection_string(new_connection, connection_string);
+  plc4c_connection_set_protocol_code(new_connection, protocol_code);
+  plc4c_connection_set_transport_code(new_connection, transport_code);
+  plc4c_connection_set_transport_connect_information(
+      new_connection, transport_connect_information);
+  plc4c_connection_set_parameters(new_connection, parameters);
 
-    new_connection->connected = false;
-    new_connection->disconnect = false;
-    new_connection->num_running_system_tasks = 0;
-
-    new_connection->system = NULL;
-    new_connection->driver = NULL;
-    new_connection->transport = NULL;
-
-    new_connection->supports_reading = NULL;
-    new_connection->supports_writing = NULL;
-    new_connection->supports_subscriptions = NULL;
-
-    *connection = new_connection;
-    return OK;
+  *connection = new_connection;
+  return OK;
 }
 
 plc4c_return_code plc4c_system_connect(plc4c_system *system,
                                        char *connection_string,
                                        plc4c_connection **connection) {
+  // Parse the connection string and initialize some of the connection field
+  // variables from this.
+  plc4c_connection *new_connection = NULL;
+  plc4c_return_code result =
+      plc4c_system_create_connection(connection_string, &new_connection);
+  if (result != OK) {
+    return result;
+  }
 
-    // Parse the connection string and initialize some of the connection field variables from this.
-    plc4c_connection *new_connection = NULL;
-    plc4c_return_code result = plc4c_system_create_connection(connection_string, &new_connection);
-    if (result != OK) {
-        return result;
-    }
+  plc4c_connection_set_system(new_connection, system);
 
-    new_connection->system = system;
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Find a matching driver from the driver-list
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // Find a matching driver from the driver-list
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-    // If no driver is available at all this is definitely a developer error,
-    // so we output a special error code for this case
-    if (plc4c_utils_list_empty(system->driver_list)) {
-        return NO_DRIVER_AVAILABLE;
-    }
-    plc4c_list_element *cur_driver_list_element = system->driver_list->head;
-    do {
-        plc4c_driver *cur_driver = (plc4c_driver *) cur_driver_list_element->value;
-        if (strcmp(cur_driver->protocol_code, new_connection->protocol_code) == 0) {
-            // Set the driver reference in the new connection.
-            new_connection->driver = cur_driver;
-            // If no transport was selected, use the drivers default transport (if it exists).
-            if (new_connection->transport_code == NULL) {
-                if (cur_driver->default_transport_code != NULL) {
-                    new_connection->transport_code = cur_driver->default_transport_code;
-                }
-            }
-            break;
+  // If no driver is available at all this is definitely a developer error,
+  // so we output a special error code for this case
+  if (plc4c_utils_list_empty(system->driver_list)) {
+    return NO_DRIVER_AVAILABLE;
+  }
+  plc4c_list_element *cur_driver_list_element = system->driver_list->head;
+  do {
+    plc4c_driver *cur_driver = (plc4c_driver *)cur_driver_list_element->value;
+    if (strcmp(cur_driver->protocol_code,
+               plc4c_connection_get_protocol_code(new_connection)) == 0) {
+      // Set the driver reference in the new connection.
+      new_connection->driver = cur_driver;
+      // If no transport was selected, use the drivers default transport (if it
+      // exists).
+      if (plc4c_connection_get_transport_code(new_connection) == NULL) {
+        if (cur_driver->default_transport_code != NULL) {
+          plc4c_connection_set_transport_code(
+              new_connection, cur_driver->default_transport_code);
         }
-        cur_driver_list_element = cur_driver_list_element->next;
-    } while (cur_driver_list_element != NULL);
-
-    // If the driver property is still NULL, the desired driver was not found.
-    if (new_connection->driver == NULL) {
-        return UNKNOWN_DRIVER;
+      }
+      break;
     }
+    cur_driver_list_element = cur_driver_list_element->next;
+  } while (cur_driver_list_element != NULL);
 
-    // Return an error if the user didn't specify a transport and the driver doesn't have a default one.
-    if (new_connection->transport_code == NULL) {
-        return UNSPECIFIED_TRANSPORT;
+  // If the driver property is still NULL, the desired driver was not found.
+  if (new_connection->driver == NULL) {
+    return UNKNOWN_DRIVER;
+  }
+
+  // Return an error if the user didn't specify a transport and the driver
+  // doesn't have a default one.
+  if (plc4c_connection_get_transport_code(new_connection) == NULL) {
+    return UNSPECIFIED_TRANSPORT;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Find a matching transport from the transport-list
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  // If no transport is available at all this is definitely a developer error,
+  // so we output a special error code for this case
+  if (plc4c_utils_list_empty(system->transport_list)) {
+    return NO_TRANSPORT_AVAILABLE;
+  }
+  plc4c_list_element *cur_transport_list_element = system->transport_list->head;
+  do {
+    plc4c_transport *cur_transport =
+        (plc4c_transport *)cur_transport_list_element->value;
+    if (strcmp(cur_transport->transport_code,
+               plc4c_connection_get_transport_code(new_connection)) == 0) {
+      // Set the transport reference in the new connection.
+      new_connection->transport = cur_transport;
+      break;
     }
+    cur_transport_list_element = cur_transport_list_element->next;
+  } while (cur_transport_list_element != NULL);
 
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // Find a matching transport from the transport-list
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // If the transport property is still NULL, the desired transport was not
+  // found.
+  if (new_connection->transport == NULL) {
+    return UNKNOWN_TRANSPORT;
+  }
 
-    // If no transport is available at all this is definitely a developer error,
-    // so we output a special error code for this case
-    if (plc4c_utils_list_empty(system->transport_list)) {
-        return NO_TRANSPORT_AVAILABLE;
-    }
-    plc4c_list_element *cur_transport_list_element = system->transport_list->head;
-    do {
-        plc4c_transport *cur_transport = (plc4c_transport *) cur_transport_list_element->value;
-        if (strcmp(cur_transport->transport_code, new_connection->transport_code) == 0) {
-            // Set the transport reference in the new connection.
-            new_connection->transport = cur_transport;
-            break;
-        }
-        cur_transport_list_element = cur_transport_list_element->next;
-    } while (cur_transport_list_element != NULL);
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Initialize a new connection task and schedule that.
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    // If the transport property is still NULL, the desired transport was not found.
-    if (new_connection->transport == NULL) {
-        return UNKNOWN_TRANSPORT;
-    }
+  plc4c_system_task *new_connection_task = NULL;
+  result = new_connection->driver->connect_function(new_connection,
+                                                    &new_connection_task);
+  if (result != OK) {
+    return -1;
+  }
+  // Increment the number of running tasks for this connection.
+  plc4c_connection_task_added(new_connection);
+  plc4c_utils_list_insert_tail_value(system->task_list, new_connection_task);
 
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // Initialize a new connection task and schedule that.
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Add the new connection to the systems connection-list.
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    plc4c_system_task *new_connection_task = NULL;
-    result = new_connection->driver->connect_function(new_connection, &new_connection_task);
-    if (result != OK) {
-        return -1;
-    }
-    // Increment the number of running tasks for this connection.
-    new_connection->num_running_system_tasks++;
-    plc4c_utils_list_insert_tail_value(system->task_list, new_connection_task);
+  result = plc4c_system_add_connection(system, new_connection);
+  if (result != OK) {
+    return result;
+  }
 
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // Add the new connection to the systems connection-list.
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // Pass the new connection back.
+  *connection = new_connection;
 
-    result = plc4c_system_add_connection(system, new_connection);
-    if (result != OK) {
-        return result;
-    }
-
-    // Pass the new connection back.
-    *connection = new_connection;
-
-    return OK;
+  return OK;
 }
 
 plc4c_return_code plc4c_system_loop(plc4c_system *system) {
-    // If the task-queue is empty, just return.
-    if (plc4c_utils_list_empty(system->task_list)) {
-        return OK;
+  // If the task-queue is empty, just return.
+  if (plc4c_utils_list_empty(system->task_list)) {
+    return OK;
+  }
+
+  plc4c_list_element *cur_task_element =
+      plc4c_utils_list_head(system->task_list);
+  do {
+    // Get the current element's system task.
+    plc4c_system_task *cur_task = cur_task_element->value;
+
+    // If the task is already completed, no need to do anything.
+    if ((!cur_task->completed) && (cur_task->state_machine_function != NULL)) {
+      // Pass the task itself to the state-machine function of this task.
+      cur_task->state_machine_function(cur_task);
     }
 
-    plc4c_list_element *cur_task_element = plc4c_utils_list_head(system->task_list);
-    do {
-        // Get the current element's system task.
-        plc4c_system_task *cur_task = cur_task_element->value;
+    // If the current task is completed at the end, remove it from the
+    // task_queue.
+    if (cur_task->completed) {
+      plc4c_utils_list_remove(system->task_list, cur_task_element);
+      if (cur_task->connection != NULL) {
+        plc4c_connection_task_removed(cur_task->connection);
+      }
+      // TODO: clean up the memory of the cur_task_element and cur_task
+    }
 
-        // If the task is already completed, no need to do anything.
-        if ((!cur_task->completed) && (cur_task->state_machine_function != NULL)) {
-            // Pass the task itself to the state-machine function of this task.
-            cur_task->state_machine_function(cur_task);
-        }
+    cur_task_element = cur_task_element->next;
+  } while (cur_task_element != NULL);
 
-        // If the current task is completed at the end, remove it from the task_queue.
-        if (cur_task->completed) {
-            plc4c_utils_list_remove(system->task_list, cur_task_element);
-            if (cur_task->connection != NULL) {
-                cur_task->connection->num_running_system_tasks--;
-            }
-            // TODO: clean up the memory of the cur_task_element and cur_task
-        }
-
-        cur_task_element = cur_task_element->next;
-    } while (cur_task_element != NULL);
-
-    return OK;
+  return OK;
 }
-
-

--- a/sandbox/plc4c/spi/src/utils/list.c
+++ b/sandbox/plc4c/spi/src/utils/list.c
@@ -173,3 +173,14 @@ void plc4c_utils_list_delete_elements(plc4c_list *list, plc4c_list_delete_elemen
     }
     // at this point the list is empty
 }
+
+plc4c_list_element *plc4c_utils_list_find_element_by_item(plc4c_list *list, void *item){
+  plc4c_list_element *head = plc4c_utils_list_head(list);
+  while (head != NULL) {
+    if (head->value == item) {
+      break;
+    }
+    head = head->next;
+  }
+  return head;
+}

--- a/sandbox/plc4c/spi/src/write.c
+++ b/sandbox/plc4c/spi/src/write.c
@@ -17,54 +17,75 @@
  * under the License.
  */
 
-#include <stdlib.h>
-#include <plc4c/write.h>
+#include <plc4c/plc4c.h>
 #include <plc4c/spi/types_private.h>
+#include <plc4c/write.h>
+#include <stdlib.h>
 
-plc4c_return_code plc4c_write_request_execute(plc4c_write_request *write_request,
-                                              plc4c_write_request_execution **write_request_execution) {
-    // Inject the default write context into the system task.
-    plc4c_write_request_execution *new_write_request_execution = malloc(sizeof(plc4c_write_request_execution));
-    new_write_request_execution->write_request = write_request;
-    new_write_request_execution->write_response = NULL;
-    new_write_request_execution->system_task = NULL;
-
-    plc4c_system_task *system_task;
-    write_request->connection->driver->write_function(new_write_request_execution, &system_task);
-    // Increment the number of running tasks for this connection.
-    write_request->connection->num_running_system_tasks++;
-    // Add the new task to the task-list.
-    plc4c_utils_list_insert_tail_value(write_request->connection->system->task_list, system_task);
-
-    *write_request_execution = new_write_request_execution;
-    return OK;
+plc4c_connection *plc4c_write_request_get_connection(
+    plc4c_write_request *write_request) {
+  return write_request->connection;
 }
 
-bool plc4c_write_request_finished_successfully(plc4c_write_request_execution *write_request_execution) {
-    if (write_request_execution == NULL) {
-        return true;
-    }
-    if (write_request_execution->system_task == NULL) {
-        return true;
-    }
-    return write_request_execution->system_task->completed;
+void plc4c_write_request_set_connection(plc4c_write_request *write_request,
+                                        plc4c_connection *connection) {
+  write_request->connection = connection;
 }
 
-bool plc4c_write_request_has_error(plc4c_write_request_execution *write_request_execution) {
-    return false;
+plc4c_return_code plc4c_write_request_execute(
+    plc4c_write_request *write_request,
+    plc4c_write_request_execution **write_request_execution) {
+  // Inject the default write context into the system task.
+  plc4c_write_request_execution *new_write_request_execution =
+      malloc(sizeof(plc4c_write_request_execution));
+  new_write_request_execution->write_request = write_request;
+  new_write_request_execution->write_response = NULL;
+  new_write_request_execution->system_task = NULL;
+
+  plc4c_system_task *system_task;
+  write_request->connection->driver->write_function(new_write_request_execution,
+                                                    &system_task);
+  // Increment the number of running tasks for this connection.
+  plc4c_connection_task_added(write_request->connection);
+  // Add the new task to the task-list.
+  plc4c_utils_list_insert_tail_value(
+      plc4c_system_get_task_list(plc4c_connection_get_system(
+          plc4c_write_request_get_connection(write_request))),
+      system_task);
+
+  *write_request_execution = new_write_request_execution;
+  return OK;
 }
 
-plc4c_write_response *plc4c_write_request_get_response(plc4c_write_request_execution *write_request_execution) {
-    if (write_request_execution == NULL) {
-        return NULL;
-    }
-    return write_request_execution->write_response;
+bool plc4c_write_request_finished_successfully(
+    plc4c_write_request_execution *write_request_execution) {
+  if (write_request_execution == NULL) {
+    return true;
+  }
+  if (write_request_execution->system_task == NULL) {
+    return true;
+  }
+  return write_request_execution->system_task->completed;
+}
+
+bool plc4c_write_request_has_error(
+    plc4c_write_request_execution *write_request_execution) {
+  return false;
+}
+
+plc4c_write_response *plc4c_write_request_get_response(
+    plc4c_write_request_execution *write_request_execution) {
+  if (write_request_execution == NULL) {
+    return NULL;
+  }
+  return write_request_execution->write_response;
 }
 
 void plc4c_write_request_destroy(plc4c_write_request *write_request) {
-    free(write_request);
+  free(write_request);
 }
 
-void plc4c_write_request_execution_destroy(plc4c_write_request_execution *write_request_execution) {
-    free(write_request_execution);
+void plc4c_write_request_execution_destroy(
+    plc4c_write_request_execution *write_request_execution) {
+  free(write_request_execution);
 }


### PR DESCRIPTION
… to plc4_connection and plc4c_system to start

clang-format changes

add ability to look up an element from a void*
fix some bugs around cleanup.
logic to destroy connections
connections now own copies of their strings so they can destroy them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/plc4x/150)
<!-- Reviewable:end -->
