### PR TITLE
PLC4X-197 do not stop the global timer, remove and cancel the Timeouts instead

### DIFF
--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/protocol/SingleItemToSingleRequestProtocol.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/protocol/SingleItemToSingleRequestProtocol.java
@@ -183,7 +183,9 @@ public class SingleItemToSingleRequestProtocol extends ChannelDuplexHandler {
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         // Send everything so we get a proper failure for those pending writes
         this.queue.removeAndWriteAll();
-        this.timer.stop();
+        for (Timeout timeout : this.scheduledTimeouts.values()) {
+            timeout.cancel();
+        }
         this.scheduledTimeouts.clear();
         this.sentButUnacknowledgedSubContainer.clear();
         this.correlationToParentContainer.clear();

--- a/pom.xml
+++ b/pom.xml
@@ -904,7 +904,7 @@
             <!-- Git related files -->
             <exclude>**/.git/**</exclude>
             <exclude>**/.gitignore</exclude>
-
+            <exclude>**/cmake-*/**</exclude>
             <!-- License Files for other licenses -->
             <exclude>**/UNLICENSE</exclude>
             <!--


### PR DESCRIPTION
rat exception for cmake-* directories' as well.

SingleItemToSingleRequestProtocol uses the global DefaultNettyPlcConnection timer object, which is a static singleton shared between all instances.

It was calling `stop()` on the timer, which cancels all the outstanding tasks in the timer when the channel when inactive.  This has the effect of killing all the other connections.

This pr changes SingleItemToSingleRequestProtocol to instead, cancel all it's outstanding Timeouts and not touch the timer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/plc4x/155)
<!-- Reviewable:end -->
