### PR TITLE
changes to allow running tests not coupled to maven build phase

### DIFF
--- a/sandbox/plc4c/CMakeLists.txt
+++ b/sandbox/plc4c/CMakeLists.txt
@@ -32,29 +32,7 @@ set(PLC4C_ROOT_DIR ${CMAKE_SOURCE_DIR})
 set(BUILD_PHASE compile CACHE STRING "Phase of the Maven build we are executing cmake")
 
 # Access the Unity version the maven build is providing us with.
-set(UNITY_VERSION 0 CACHE STRING "Version of the used Unity test framework")
-
-# Depending on the phase of the build we are currently running, initialize
-# The test system.
-if (BUILD_PHASE STREQUAL compile)
-    # Nothing really to do here ... just need it to check the known values.
-elseif (BUILD_PHASE STREQUAL test-compile)
-    # Initialize the test subsystem as well as the Unity library sources
-    include(CTest)
-
-    # Make the Unity sources available to the build as "Unity" library
-    add_subdirectory(target/dependency/Unity-${UNITY_VERSION})
-
-    #add_library(Unity STATIC
-    #  target/dependency/Unity-${UNITY_VERSION}/src/unity.c
-    #)
-    #target_include_directories(Unity PUBLIC
-    #  target/dependency/Unity-${UNITY_VERSION}/src
-    #)
-else ()
-    # Output an error
-    message(FATAL_ERROR "Given BUILD_PHASE unknown. Known values are 'compile' and 'test-compile'")
-endif ()
+set(UNITY_VERSION 2.5.0)
 
 set(DEBUG_OUTPUT OFF CACHE BOOL "Enable outputting of debug information")
 if (DEBUG_OUTPUT)
@@ -65,6 +43,13 @@ if (DEBUG_OUTPUT)
         message(STATUS "${_variableName}=${${_variableName}}")
     endforeach ()
 endif ()
+
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    include(CTest)
+
+    # Make the Unity sources available to the build as "Unity" library
+    add_subdirectory(target/dependency/Unity-${UNITY_VERSION})
+endif()
 
 #[[
     Build all the modules of PLC4C

--- a/sandbox/plc4c/spi/test/CMakeLists.txt
+++ b/sandbox/plc4c/spi/test/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 #[[
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -17,12 +18,10 @@
   under the License.
 ]]
 
-include_directories("include" "../api/include")
-
-file(GLOB_RECURSE sources "src/*.c")
-
-add_library(plc4c-spi SHARED ${sources} "src/utils/list.c" "src/utils/queue.c")
-
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
-    add_subdirectory(test)
-endif()
+file(GLOB testSources "*.c")
+add_executable(plc4c-spi-test ${testSources} system_test.c)
+target_link_libraries(plc4c-spi-test
+        plc4c-spi
+        unity
+        )
+add_test(NAME plc4c-spi-test COMMAND plc4c-spi-test)


### PR DESCRIPTION
If you are just working on c, and in CLion or something, the dependency on BUILD_PHASE for the maven caller doesn't make sense.

Changes so that you can work only in C.

note: you still have to run mvn once to get unity to install in target.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/plc4x/156)
<!-- Reviewable:end -->
