### PR TITLE
Updated Eclipse Milo to 0.3.7

### DIFF
--- a/plc4j/drivers/opcua/pom.xml
+++ b/plc4j/drivers/opcua/pom.xml
@@ -94,17 +94,17 @@
     <dependency>
       <groupId>org.eclipse.milo</groupId>
       <artifactId>sdk-client</artifactId>
-      <version>0.3.6</version>
+      <version>0.3.7</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.milo</groupId>
       <artifactId>stack-core</artifactId>
-      <version>0.3.6</version>
+      <version>0.3.7</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.milo</groupId>
       <artifactId>stack-client</artifactId>
-      <version>0.3.6</version>
+      <version>0.3.7</version>
     </dependency>
 
     <dependency>
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>org.eclipse.milo</groupId>
       <artifactId>server-examples</artifactId>
-      <version>0.3.6</version>
+      <version>0.3.7</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Eclipse Milo 0.3.7 supports relaxed nonce validation when not using protected credentials. It's needed to talk to development PLC from Schneider Electric.

https://github.com/eclipse/milo/commit/35ee06ea87676db9fdf4caf748b9265c40d1c841

Signed-off-by: Patrick Sernetz <psernetz@cad-schroer.de>