### PR TITLE
Modbus/update documentation

### DIFF
--- a/src/site/asciidoc/users/protocols/modbus.adoc
+++ b/src/site/asciidoc/users/protocols/modbus.adoc
@@ -108,9 +108,10 @@ There are a number of memory areas defined in the Modbus specification.
 
 |===
 
-Initially the Modbus format was specified allowing up to 10000 address to be specified or the discrete inputs, coils, input registers and holding registers.
-Later on this was expanded to allow up 65536 address to be specified per memory area (except the extended register area).
-When using the long address format i.e. input-registers:1 the addresses between 1 and 65535 are able to be specified. When using the shorter versions there are two formats available  i.e. 30001 and 300001.
+Initially the Modbus format allowed up to 10000 address to be specified or the discrete inputs, coils, input registers and holding registers.
+Later on, this was expanded to allow up 65536 address within each memory area (except the extended register area).
+When using the long address format i.e. input-registers:1 the addresses between 1 and 65535 are able to be specified. 
+When using the shorter versions there are two formats available  i.e. 30001 and 300001.
 With the shorter format 3XXXX being limited to between 30001 and 39999, while the longer format 3XXXXX being limited to between 300001 and 365535.
 These memory areas all start at address 1.
 
@@ -136,6 +137,7 @@ Most memory areas start at address 1, except for the extended register area whic
 The input, holding and extended registers consist of 16-bit registers while the discrete input and coil areas consist of bits.
 
 The Modbus function codes:-
+
 - 0x01 (Read Coils)
 - 0x02 (Read Discrete Inputs)
 - 0x03 (Read Holding Registers)
@@ -147,10 +149,10 @@ The Modbus function codes:-
 - 0x14 (Read File Record)(Extended Register Read)
 - 0x15 (Write File Record)(Extended Register Write is not yet supported)
 
-
 ==== Examples
 
 To read 10 holding registers starting at address 20 the following examples are all valid.
+
 - holding-register:20[10]
 - 400020[10]
 - 4x00020[10]
@@ -158,6 +160,7 @@ To read 10 holding registers starting at address 20 the following examples are a
 - 4x0020[10]
 
 To read 1 holding register at address 5678 the following examples are valid.
+
 - holding-register:5678
 - 405678
 - 4x05678
@@ -165,18 +168,22 @@ To read 1 holding register at address 5678 the following examples are valid.
 - 4x5678
 
 To read 10 extended registers starting at address 50 the following examples are valid.
+
 - extended-register:50[10]
 - 600050[10]
 - 6x00050[10]
 - 60050[10]
 - 6x0050[10]
+
 This corresponds to addresses 50-60 in file record 1.
 
 To read 10 extended registers starting at address 9995 the following examples are valid.
+
 - extended-register:9995[10]
 - 609995[10]
 - 6x09995[10]
 - 69995[10]
 - 6x9995[10]
+
 This corresponds to addresses 9995-9999 in file record 1 and addresses 0-5 in file record 2.
 Note that this request is split into 2 sub requests in the Modbus protocol.

--- a/src/site/asciidoc/users/protocols/modbus.adoc
+++ b/src/site/asciidoc/users/protocols/modbus.adoc
@@ -106,6 +106,8 @@ There are a number of memory areas defined in the Modbus specification.
 |Holding Register |`holding-register:` or `4` or `4x` |Short value, usually representing an analog output from the PLC    |16 |Read/Write|1
 |Extended Register |`extended-register:` or `6` or `6x` |Short value,    |16 |Read Only|0
 
+|===
+
 Initially the Modbus format was specified allowing up to 10000 address to be specified or the discrete inputs, coils, input registers and holding registers.
 Later on this was expanded to allow up 65536 address to be specified per memory area (except the extended register area).
 When using the long address format i.e. input-registers:1 the addresses between 1 and 65535 are able to be specified. When using the shorter versions there are two formats available  i.e. 30001 and 300001.

--- a/src/site/asciidoc/users/protocols/modbus.adoc
+++ b/src/site/asciidoc/users/protocols/modbus.adoc
@@ -120,9 +120,6 @@ Using the extended-register: format you are able to reference all of these, if t
 This memory area starts at address 0.
 At the moment this implementation only supports reading the extended memory area.
 
-|===
-
-
 ==== Data Types
 
 In contrast to most other protocols Modbus only supports two datatypes.

--- a/src/site/asciidoc/users/protocols/modbus.adoc
+++ b/src/site/asciidoc/users/protocols/modbus.adoc
@@ -74,43 +74,110 @@
 
 === Individual Resource Address Format
 
-In contrast to most other protocols Modbus only supports two datatypes.
 
-- Bit (Coil)
-- Short (2-bytes) (Registers)
 
-Some implementations implement more types based on these, such as 16 bit half-precision floating point types wrapped in a Register or joining multiple Coils or Registers to bigger data-types, but this is not handled by the Modbus specification.
+==== General Format
 
-Coils and Registers are generally separated into pure inputs which are read-only and writable versions.
+In general all Modbus addresses have this format:
 
-Inputs (Read-Only):
+----
+{Memory-Area}{start-address}[{array-size}]
+----
 
-- Discrete Input (Boolean / 1 bit)
-- Input Register (Short / 16 bit)
+If the array-part is omitted, the size-default of `1` is assumed.
 
-Output (Read/Write):
+==== Memory Areas
 
-- Coil (Boolean / 1 bit)
-- Holding Register (Short / 16 bit)
+There are a number of memory areas defined in the Modbus specification.
 
-Extended Registers (6x) - Function Code 20 - (Short / 16 bit)
-
-These are able to be referenced as a continuous data area 600000 - 699999. Internally this is converted to the file number/register format. File number 1 corresponds to the first 10000 registers (600000 - 609999), file number 2 the next 10000 (610000 - 619999) and so on.
-
-Note unlike the other areas this area starts at address 0.
-
-At the moment this implementation only supports reading the extended memory area.
-
-Here come the syntax descriptions of these addresses (Each address can reference either a single item or an array):
+- Discrete Input Area
+- Coil Area
+- Input Register Area
+- Holding Register
+- Extended Register Area
 
 [cols="2,2a,5,1"]
 |===
-|Name |Address Syntax |Description |Bit-Size
+|Name |Memory Area Aliases |Description |Bit-Size | Permissions | Starting Address
 
-|Discrete Input   |`discrete-input:{start-address}` or `discrete-input:{start-address}[{count}]` or `1{start-address}` or `1{start-address}[{count}]` or `1x{start-address}` or `1x{start-address}[{count}]`   |Read-only Boolean input value, usually representing a binary input to the PLC |1
-|Input Register   |`input-register:{start-address}` or `input-register:{start-address}[{count}]` or `3{start-address}` or `3{start-address}[{count}]` or `3x{start-address}` or `3x{start-address}[{count}]`   |Read-only Short input value, usually representing an analog input to the PLC  |16
-|Coil             |`coil:{start-address}` or `coil:{start-address}[{count}]` or `0{start-address}` or `0{start-address}[{count}]` or `0x{start-address}` or `0x{start-address}[{count}]`             |Read/Write Boolean value, usually representing a binary output from the PLC   |1
-|Holding Register |`holding-register:{start-address}` or `holding-register:{start-address}[{count}]` or `4{start-address}` or `4{start-address}[{count}]` or `4x{start-address}` or `4x{start-address}[{count}]` |Read/Write Short value, usually representing an analog output from the PLC    |16
-|Extended Register |`extended-register:{start-address}` or `extended-register:{start-address}[{count}]` or `6{start-address}` or `6{start-address}[{count}]` or `6x{start-address}` or `6x{start-address}[{count}]` |Read/Write Short value,    |16
+|Discrete Input   |`discrete-input:` or `1` or `1x`   |Boolean input value, usually representing a binary input to the PLC |1 |Read Only|1
+|Coil             |`coil:` or `0` or `0x`             |Boolean value, usually representing a binary output from the PLC   |1 |Read/Write|1
+|Input Register   |`input-register:` or `3` or `3x`   |Short input value, usually representing an analog input to the PLC  |16 |Read Only|1
+|Holding Register |`holding-register:` or `4` or `4x` |Short value, usually representing an analog output from the PLC    |16 |Read/Write|1
+|Extended Register |`extended-register:` or `6` or `6x` |Short value,    |16 |Read Only|0
+
+Initially the Modbus format was specified allowing up to 10000 address to be specified or the discrete inputs, coils, input registers and holding registers.
+Later on this was expanded to allow up 65536 address to be specified per memory area (except the extended register area).
+When using the long address format i.e. input-registers:1 the addresses between 1 and 65535 are able to be specified. When using the shorter versions there are two formats available  i.e. 30001 and 300001.
+With the shorter format 3XXXX being limited to between 30001 and 39999, while the longer format 3XXXXX being limited to between 300001 and 365535.
+These memory areas all start at address 1.
+
+For the extended register area the addresses 0-99999 are able to be specified. These registers are mapped to file records with a length of 10000. Address 600000 corresponds to the first address in file record 0.
+Address 610000 is then the first address in the second file record and so on. It is noted that there is generally only 10 file records (600000 thru to 699999) however the spec allows for 65536 file records.
+Using the extended-register: format you are able to reference all of these, if the shorter format is used then it is limited to 699999.
+This memory area starts at address 0.
+At the moment this implementation only supports reading the extended memory area.
 
 |===
+
+
+==== Data Types
+
+In contrast to most other protocols Modbus only supports two datatypes.
+
+- Bit (Discrete Inputs/Coils)
+- Short (2-bytes) (Registers)
+
+A lot of the time different data types are placed within 16 bit registers areas. Such as 32-Bit Floating Points values which could be placed within two adjoining registers, currently PLC4X doesn't have a way to convert these before passing them to the user.
+
+==== Some useful tips
+
+Most memory areas start at address 1, except for the extended register area which starts at 0. These are both mapped to 0x0000 when it is sent in the Modbus protocol.
+
+The input, holding and extended registers consist of 16-bit registers while the discrete input and coil areas consist of bits.
+
+The Modbus function codes:-
+- 0x01 (Read Coils)
+- 0x02 (Read Discrete Inputs)
+- 0x03 (Read Holding Registers)
+- 0x04 (Read Input Registers)
+- 0x05 (Write Single Coil)
+- 0x06 (Write Single Register)
+- 0x0F (Write Multiple Coils)
+- 0x10 (Write Multiple Registers)
+- 0x14 (Read File Record)(Extended Register Read)
+- 0x15 (Write File Record)(Extended Register Write is not yet supported)
+
+
+==== Examples
+
+To read 10 holding registers starting at address 20 the following examples are all valid.
+- holding-register:20[10]
+- 400020[10]
+- 4x00020[10]
+- 40020[10]
+- 4x0020[10]
+
+To read 1 holding register at address 5678 the following examples are valid.
+- holding-register:5678
+- 405678
+- 4x05678
+- 45678
+- 4x5678
+
+To read 10 extended registers starting at address 50 the following examples are valid.
+- extended-register:50[10]
+- 600050[10]
+- 6x00050[10]
+- 60050[10]
+- 6x0050[10]
+This corresponds to addresses 50-60 in file record 1.
+
+To read 10 extended registers starting at address 9995 the following examples are valid.
+- extended-register:9995[10]
+- 609995[10]
+- 6x09995[10]
+- 69995[10]
+- 6x9995[10]
+This corresponds to addresses 9995-9999 in file record 1 and addresses 0-5 in file record 2.
+Note that this request is split into 2 sub requests in the Modbus protocol.

--- a/src/site/asciidoc/users/protocols/modbus.adoc
+++ b/src/site/asciidoc/users/protocols/modbus.adoc
@@ -96,7 +96,7 @@ There are a number of memory areas defined in the Modbus specification.
 - Holding Register
 - Extended Register Area
 
-[cols="2,2a,5,1"]
+[cols="2,2a,5,1,2,1"]
 |===
 |Name |Memory Area Aliases |Description |Bit-Size | Permissions | Starting Address
 


### PR DESCRIPTION
Updated the Modbus documentation including references to the starting addresses and extended registers.
I have also included the headers used in the S7 protocol documentation to help keep it a bit more consistent between different protocols.