### PR TITLE
PLC4X-248 Permit more locations for MSpec comments.

### DIFF
--- a/build-utils/protocol-base-mspec/src/main/antlr4/org/apache/plc4x/plugins/codegenerator/language/mspec/MSpec.g4
+++ b/build-utils/protocol-base-mspec/src/main/antlr4/org/apache/plc4x/plugins/codegenerator/language/mspec/MSpec.g4
@@ -23,7 +23,7 @@ file
  ;
 
 complexTypeDefinition
- : (COMMENT.*?)? LBRACKET complexType RBRACKET
+ : (COMMENT.*?)? LBRACKET complexType RBRACKET (COMMENT.*?)?
  ;
 
 complexType
@@ -34,11 +34,11 @@ complexType
  ;
 
 fieldDefinition
- : (COMMENT.*?)? LBRACKET field (LBRACKET params=multipleExpressions RBRACKET)? RBRACKET
+ : (COMMENT.*?)? LBRACKET field (LBRACKET params=multipleExpressions RBRACKET)? RBRACKET (COMMENT.*?)?
  ;
 
 dataIoDefinition
- : (COMMENT.*?)? LBRACKET typeSwitchField (LBRACKET params=multipleExpressions RBRACKET)? RBRACKET
+ : (COMMENT.*?)? LBRACKET typeSwitchField (LBRACKET params=multipleExpressions RBRACKET)? RBRACKET (COMMENT.*?)?
  ;
 
 field


### PR DESCRIPTION
Comments might occur after field, so rule for next one will catch it. However this does not work in case of last field. It will confuse parser with unexpected input.