### PR TITLE
Add support for writing arrays to the hello world write example.

### DIFF
--- a/plc4j/examples/hello-world-plc4x-write/src/main/java/org/apache/plc4x/java/examples/helloplc4x/write/HelloPlc4xWrite.java
+++ b/plc4j/examples/hello-world-plc4x-write/src/main/java/org/apache/plc4x/java/examples/helloplc4x/write/HelloPlc4xWrite.java
@@ -54,7 +54,13 @@ public class HelloPlc4xWrite {
             // - Give the single item requested the alias name "value"
             final PlcWriteRequest.Builder builder = plcConnection.writeRequestBuilder();
             for (int i = 0; i < options.getFieldAddress().length; i++) {
-                builder.addItem("value-" + i, options.getFieldAddress()[i], options.getFieldValues()[i]);
+                //If an array value is passed instead of a single value then convert to a String array
+                if ((options.getFieldValues()[i].charAt(0) == '[') && (options.getFieldValues()[i].charAt(options.getFieldValues()[i].length() - 1) == ']')) {
+                    String[] values = options.getFieldValues()[i].substring(1,options.getFieldValues()[i].length() - 1).split(",");
+                    builder.addItem("value-" + i, options.getFieldAddress()[i], values);
+                } else {
+                    builder.addItem("value-" + i, options.getFieldAddress()[i], options.getFieldValues()[i]);
+                }
             }
             PlcWriteRequest writeRequest = builder.build();
 


### PR DESCRIPTION
This allows us to pass an array of values to the hello world write example. The format is

--field-addresses 000004:BOOL[2] --field-values [true,true]
--field-addresses 400004:LINT[2] --field-values [1,1]

can be used.
