### PR TITLE
hello_world_s7 (C) now working

### DIFF
--- a/sandbox/plc4c/drivers/s7/src/driver_s7_packets.c
+++ b/sandbox/plc4c/drivers/s7/src/driver_s7_packets.c
@@ -27,6 +27,10 @@
 
 #include "plc4c/driver_s7_encode_decode.h"
 
+// forward declaration of helper function, TODO: move somewhere, or re-inline
+void plc4c_driver_s7_time_transport_size(
+    plc4c_s7_read_write_transport_size *transport_size);
+
 /**
  * Function used by the driver to tell the transport if there is a full
  * packet the driver can operate on available.
@@ -87,14 +91,16 @@ int16_t plc4c_driver_s7_select_message_function(uint8_t* buffer_data,
 
 plc4c_return_code plc4c_driver_s7_send_packet(plc4c_connection* connection,
                               plc4c_s7_read_write_tpkt_packet* packet) {
+  
+  uint16_t packet_size;
+  plc4c_spi_write_buffer* write_buffer;
+  plc4c_return_code return_code;
+  
   // Get the size required to contain the serialized form of this packet.
-  uint16_t packet_size =
-      plc4c_s7_read_write_tpkt_packet_length_in_bytes(packet);
+  packet_size = plc4c_s7_read_write_tpkt_packet_length_in_bytes(packet);
 
   // Serialize this message to a byte-array.
-  plc4c_spi_write_buffer* write_buffer;
-  plc4c_return_code return_code =
-      plc4c_spi_write_buffer_create(packet_size, &write_buffer);
+  return_code = plc4c_spi_write_buffer_create(packet_size, &write_buffer);
   if (return_code != OK) {
     return return_code;
   }
@@ -392,114 +398,79 @@ plc4c_return_code plc4c_driver_s7_create_s7_identify_remote_request(
 plc4c_return_code plc4c_driver_s7_create_s7_read_request(
     plc4c_read_request* read_request,
     plc4c_s7_read_write_tpkt_packet** s7_read_request_packet) {
-  plc4c_driver_s7_config* configuration =
-      read_request->connection->configuration;
 
+  plc4c_driver_s7_config* configuration;
+  plc4c_s7_read_write_cotp_packet *payload;
+  plc4c_list_element* cur_item;
+
+  configuration = read_request->connection->configuration;
+  
   *s7_read_request_packet = malloc(sizeof(s7_read_request_packet));
   if (*s7_read_request_packet == NULL) {
     return NO_MEMORY;
   }
 
-  (*s7_read_request_packet)->payload =
-      malloc(sizeof(plc4c_s7_read_write_cotp_packet));
-  if((*s7_read_request_packet)->payload == NULL) {
-    return NO_MEMORY;
-  }
-  (*s7_read_request_packet)->payload->_type =
-      plc4c_s7_read_write_cotp_packet_type_plc4c_s7_read_write_cotp_packet_data;
-  (*s7_read_request_packet)->payload->cotp_packet_data_tpdu_ref =
-      configuration->pdu_id++;
-  (*s7_read_request_packet)->payload->cotp_packet_data_eot = true;
-  (*s7_read_request_packet)->payload->parameters = NULL;
-  (*s7_read_request_packet)->payload->payload =
-      malloc(sizeof(plc4c_s7_read_write_s7_message));
-  if((*s7_read_request_packet)->payload->payload == NULL) {
-    return NO_MEMORY;
-  }
-  (*s7_read_request_packet)->payload->payload->_type =
-      plc4c_s7_read_write_s7_message_type_plc4c_s7_read_write_s7_message_request;
-  (*s7_read_request_packet)->payload->payload->parameter =
-      malloc(sizeof(plc4c_s7_read_write_s7_parameter));
-  if((*s7_read_request_packet)->payload->payload->parameter == NULL) {
-    return NO_MEMORY;
-  }
-  (*s7_read_request_packet)->payload->payload->parameter->_type =
-      plc4c_s7_read_write_s7_parameter_type_plc4c_s7_read_write_s7_parameter_read_var_request;
-  plc4c_utils_list_create(
-      &(*s7_read_request_packet)
-           ->payload->payload->parameter->s7_parameter_read_var_request_items);
+  (*s7_read_request_packet)->payload = malloc(sizeof(plc4c_s7_read_write_cotp_packet));
+    
+  // Terse local variable for clarity
+  payload = (*s7_read_request_packet)->payload;
 
-  plc4c_list_element* cur_item = read_request->items->tail;
+  if (payload == NULL) {
+    return NO_MEMORY;
+  }
+  payload->_type = plc4c_s7_read_write_cotp_packet_type_plc4c_s7_read_write_cotp_packet_data;
+  payload->cotp_packet_data_tpdu_ref = configuration->pdu_id++;
+  payload->cotp_packet_data_eot = true;
+  payload->parameters = NULL;
+  payload->payload = malloc(sizeof(plc4c_s7_read_write_s7_message));
+  if(payload->payload == NULL) {
+    return NO_MEMORY;
+  }
+  payload->payload->_type = plc4c_s7_read_write_s7_message_type_plc4c_s7_read_write_s7_message_request;
+  payload->payload->parameter = malloc(sizeof(plc4c_s7_read_write_s7_parameter));
+  if(payload->payload->parameter == NULL) {
+    return NO_MEMORY;
+  }
+  payload->payload->parameter->_type = plc4c_s7_read_write_s7_parameter_type_plc4c_s7_read_write_s7_parameter_read_var_request;
+  plc4c_utils_list_create(&payload->payload->parameter->s7_parameter_read_var_request_items);
+
+  cur_item = read_request->items->tail;
+  
   while (cur_item != NULL) {
     plc4c_item* item = cur_item->value;
     // Get the item address from the API request.
     plc4c_s7_read_write_s7_var_request_parameter_item* parsed_item_address = item->address;
 
     // Create a copy of the request item...
-    plc4c_s7_read_write_s7_var_request_parameter_item* updated_item_address =
+    plc4c_s7_read_write_s7_var_request_parameter_item* updated_item_address = 
         malloc(sizeof(plc4c_s7_read_write_s7_var_request_parameter_item));
     if (updated_item_address == NULL) {
       return NO_MEMORY;
     }
     updated_item_address->_type = parsed_item_address->_type;
-    updated_item_address->s7_var_request_parameter_item_address_address = malloc(sizeof(plc4c_s7_read_write_s7_address));
+    updated_item_address->s7_var_request_parameter_item_address_address = 
+        malloc(sizeof(plc4c_s7_read_write_s7_address));
     if (updated_item_address->s7_var_request_parameter_item_address_address == NULL) {
       return NO_MEMORY;
     }
-    updated_item_address->s7_var_request_parameter_item_address_address->_type =
-        parsed_item_address->s7_var_request_parameter_item_address_address->_type;
-    updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_transport_size =
-        parsed_item_address->s7_var_request_parameter_item_address_address->s7_address_any_transport_size;
-    updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_area =
-        parsed_item_address->s7_var_request_parameter_item_address_address->s7_address_any_area;
-    updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_db_number =
-        parsed_item_address->s7_var_request_parameter_item_address_address->s7_address_any_db_number;
-    updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_byte_address =
-        parsed_item_address->s7_var_request_parameter_item_address_address->s7_address_any_byte_address;
-    updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_bit_address =
-        parsed_item_address->s7_var_request_parameter_item_address_address->s7_address_any_bit_address;
-    updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_number_of_elements =
-        parsed_item_address->s7_var_request_parameter_item_address_address->s7_address_any_number_of_elements;
+    // Memcpy inplace of fields assignment, as all fields where assigned
+    memcpy(updated_item_address->s7_var_request_parameter_item_address_address,
+      parsed_item_address->s7_var_request_parameter_item_address_address, 
+      sizeof(plc4c_s7_read_write_s7_address));
 
-    // Update the data-types and sizes...
-    /*if (updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_transport_size ==
-        plc4c_s7_read_write_transport_size_STRING) {
-      if (string_length != NULL) {
-        updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_number_of_elements =
-            strtol(string_length, 0, 10) *
-                updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_number_of_elements;
-      } else if (updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_transport_size ==
-                 plc4c_s7_read_write_transport_size_STRING) {
-        updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_number_of_elements =
-            254 * updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_number_of_elements;
-      }
-    }*/
-      // In case of TIME values, we read 4 bytes for each value instead.
-    if(updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_transport_size ==
-            plc4c_s7_read_write_transport_size_TIME) {
-      updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_transport_size =
-          plc4c_s7_read_write_transport_size_DINT;
-    } else if(updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_transport_size ==
-              plc4c_s7_read_write_transport_size_DATE) {
-      updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_transport_size =
-          plc4c_s7_read_write_transport_size_UINT;
-    } else if(updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_transport_size ==
-                   plc4c_s7_read_write_transport_size_TIME_OF_DAY ||
-               updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_transport_size ==
-                   plc4c_s7_read_write_transport_size_TOD) {
-      updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_transport_size =
-          plc4c_s7_read_write_transport_size_UDINT;
-    }
+    // In case of TIME values, we read 4 bytes for each value instead.
+    plc4c_driver_s7_time_transport_size(
+      &updated_item_address->s7_var_request_parameter_item_address_address->s7_address_any_transport_size);
+    
     // Add the new item to the request.
     plc4c_utils_list_insert_head_value(
-        (*s7_read_request_packet)
-            ->payload->payload->parameter->s7_parameter_read_var_request_items,
+        payload->payload->parameter->s7_parameter_read_var_request_items,
         updated_item_address);
 
     cur_item = cur_item->next;
   }
 
-  (*s7_read_request_packet)->payload->payload->payload = NULL;
+  payload->payload->payload = NULL;
   return OK;
 }
 
@@ -511,69 +482,136 @@ plc4c_return_code plc4c_driver_s7_create_s7_read_request(
  * @return OK, if the packet was correctly prepared, otherwise not-OK.
  */
 plc4c_return_code plc4c_driver_s7_create_s7_write_request(
-    plc4c_write_request* write_request,
-    plc4c_s7_read_write_tpkt_packet** s7_write_request_packet) {
-  plc4c_driver_s7_config* configuration =
-      write_request->connection->configuration;
+    plc4c_write_request* request,
+    plc4c_s7_read_write_tpkt_packet** request_packet) {
 
-  *s7_write_request_packet = malloc(sizeof(s7_write_request_packet));
-  if (*s7_write_request_packet == NULL) {
+
+  plc4c_driver_s7_config* configuration;
+  plc4c_s7_read_write_cotp_packet *payload;
+  plc4c_list_element* list_item;
+  plc4c_s7_read_write_s7_parameter* s7_parameters;
+  plc4c_s7_read_write_s7_payload* s7_payload;
+
+  configuration = request->connection->configuration;
+
+  *request_packet = malloc(sizeof(request_packet));
+  if (*request_packet == NULL) 
     return NO_MEMORY;
-  }
+  
 
-  (*s7_write_request_packet)->payload =
-      malloc(sizeof(plc4c_s7_read_write_cotp_packet));
-  (*s7_write_request_packet)->payload->_type =
-      plc4c_s7_read_write_cotp_packet_type_plc4c_s7_read_write_cotp_packet_data;
-  (*s7_write_request_packet)->payload->cotp_packet_data_tpdu_ref =
-      configuration->pdu_id++;
-  (*s7_write_request_packet)->payload->cotp_packet_data_eot = true;
-  (*s7_write_request_packet)->payload->payload =
-      malloc(sizeof(plc4c_s7_read_write_s7_message));
-  (*s7_write_request_packet)->payload->payload->_type =
-      plc4c_s7_read_write_s7_message_type_plc4c_s7_read_write_s7_message_request;
-  (*s7_write_request_packet)->payload->payload->parameter =
-      malloc(sizeof(plc4c_s7_read_write_s7_parameter));
-  (*s7_write_request_packet)->payload->payload->parameter->_type =
-      plc4c_s7_read_write_s7_parameter_type_plc4c_s7_read_write_s7_parameter_write_var_request;
-  plc4c_utils_list_create(
-      &(*s7_write_request_packet)
-          ->payload->payload->parameter->s7_parameter_read_var_request_items);
+  (*request_packet)->payload = malloc(sizeof(plc4c_s7_read_write_cotp_packet));
+  if ((*request_packet)->payload == NULL) 
+    return NO_MEMORY;
+  
+  // Terse local variable for clarity
+  payload = (*request_packet)->payload;
 
-  plc4c_list_element* item = write_request->items->tail;
-  while (item != NULL) {
+  payload->_type = plc4c_s7_read_write_cotp_packet_type_plc4c_s7_read_write_cotp_packet_data;
+  payload->cotp_packet_data_tpdu_ref = configuration->pdu_id++;
+  payload->cotp_packet_data_eot = true;
+  payload->parameters = NULL;
+
+  // Allocate and initalise payload->payload 
+  payload->payload = malloc(sizeof(plc4c_s7_read_write_s7_message));
+  if (payload->payload == NULL)
+    return NO_MEMORY;
+  payload->payload->_type = plc4c_s7_read_write_s7_message_type_plc4c_s7_read_write_s7_message_request;
+
+  // Allocate and initalise payload->payload->parameter
+  payload->payload->parameter = malloc(sizeof(plc4c_s7_read_write_s7_parameter));
+  s7_parameters = payload->payload->parameter;
+  if (s7_parameters == NULL)
+    return NO_MEMORY;
+  s7_parameters->_type = plc4c_s7_read_write_s7_parameter_type_plc4c_s7_read_write_s7_parameter_write_var_request;
+  plc4c_utils_list_create(&s7_parameters->s7_parameter_write_var_request_items);
+  
+  //  Allocate and initalise payload->payload->payload
+  payload->payload->payload = malloc(sizeof(plc4c_s7_read_write_s7_payload));
+  s7_payload = payload->payload->payload;
+  if (s7_payload == NULL) 
+    return NO_MEMORY;
+  s7_payload->_type = plc4c_s7_read_write_s7_payload_type_plc4c_s7_read_write_s7_payload_write_var_request;
+  plc4c_utils_list_create(&s7_payload->s7_payload_write_var_request_items);
+  
+  list_item = request->items->tail;
+  
+  while (list_item != NULL) {
+
+    plc4c_request_value_item *item;
+    plc4c_item *parsed_item;
+    plc4c_s7_read_write_s7_var_request_parameter_item *parsed_param;
+    plc4c_s7_read_write_s7_var_request_parameter_item *request_param;
+    plc4c_data *parsed_value;
+    plc4c_s7_read_write_s7_var_payload_data_item *request_value;
+    plc4c_return_code return_code;
+
+    
+    // Set things off to a good start 
+    return_code = OK;
+
     // Get the item address from the API request.
-    char* itemAddress = item->value;
+    item = list_item->value; 
+    parsed_item = item->item;
+    parsed_param = parsed_item->address;
+    parsed_value = item->value;
 
-    // Create the item ...
-    plc4c_s7_read_write_s7_var_request_parameter_item* request_item;
-    plc4c_return_code return_code =
-        plc4c_driver_s7_encode_address(itemAddress, &request_item);
-    if (return_code != OK) {
+    // Make a copy of the param
+    request_param = malloc(sizeof(plc4c_s7_read_write_s7_var_request_parameter_item));
+    if (!request_param) 
+      return NO_MEMORY;
+    
+    request_param->_type = parsed_param->_type;
+    request_param->s7_var_request_parameter_item_address_address = 
+        malloc(sizeof(plc4c_s7_read_write_s7_address));
+    if (!request_param->s7_var_request_parameter_item_address_address)
+      return NO_MEMORY;
+    
+    memcpy(request_param->s7_var_request_parameter_item_address_address,
+      parsed_param->s7_var_request_parameter_item_address_address, 
+      sizeof(plc4c_s7_read_write_s7_address));
+
+    if (return_code != OK) 
       return return_code;
-    }
+    
+    // Make a copy of the value 
+    request_value = malloc(sizeof(plc4c_s7_read_write_s7_var_payload_data_item));
+    request_value->transport_size = plc4c_s7_read_write_data_transport_size_BYTE_WORD_DWORD;
+    plc4c_utils_list_create(&request_value->data);
+    plc4c_utils_list_insert_head_value(request_value->data, parsed_value);
+    
+    // Add the new parameter to the request
+    plc4c_utils_list_insert_head_value(s7_parameters->s7_parameter_write_var_request_items, request_param);
+    
+    // Add the new value to the request
+    plc4c_utils_list_insert_head_value(s7_payload->s7_payload_write_var_request_items, request_value);
 
-    // Add the new item to the request.
-    plc4c_utils_list_insert_head_value(
-        (*s7_write_request_packet)
-            ->payload->payload->parameter->s7_parameter_read_var_request_items,
-        request_item);
-
-    item = item->next;
+    list_item = list_item->next;
   }
 
-  (*s7_write_request_packet)->payload->payload->payload =
-      malloc(sizeof(plc4c_s7_read_write_s7_payload));
-  if((*s7_write_request_packet)->payload->payload->payload == NULL) {
-    return NO_MEMORY;
-  }
-  (*s7_write_request_packet)->payload->payload->payload->_type =
-      plc4c_s7_read_write_s7_payload_type_plc4c_s7_read_write_s7_payload_write_var_request;
-  plc4c_utils_list_create(
-      &(*s7_write_request_packet)->payload->payload->payload->s7_payload_write_var_request_items);
 
   // TODO: Implement the value encoding ...
   // TODO: Add all the encoded item values ...
 
   return OK;
+}
+
+/**
+ * Adjust transport sizes for time values
+ *
+ * @param transport_size current transport size of item
+ */
+void plc4c_driver_s7_time_transport_size(plc4c_s7_read_write_transport_size *transport_size) {
+  // In case of TIME values, we read 4 bytes for each value instead.
+  switch (*transport_size) {
+    case plc4c_s7_read_write_transport_size_TIME:
+      *transport_size = plc4c_s7_read_write_transport_size_DINT;
+      break;
+    case plc4c_s7_read_write_transport_size_DATE:
+      *transport_size = plc4c_s7_read_write_transport_size_UINT;
+      break;
+    case plc4c_s7_read_write_transport_size_TIME_OF_DAY:
+    case plc4c_s7_read_write_transport_size_TOD:
+      *transport_size = plc4c_s7_read_write_transport_size_UDINT;
+      break;
+  }
 }

--- a/sandbox/plc4c/drivers/s7/src/driver_s7_sm_read.c
+++ b/sandbox/plc4c/drivers/s7/src/driver_s7_sm_read.c
@@ -33,33 +33,42 @@ enum plc4c_driver_s7_read_states {
   PLC4C_DRIVER_S7_READ_FINISHED
 };
 
+// Forward declaration of helper function to stop PLC4C_DRIVER_S7_READ_FINISHED
+// state become too big, TODO: move to some header or inline
+plc4c_return_code plc4c_driver_s7_parse_read_responce(plc4c_read_request* request,
+    plc4c_read_response* response, plc4c_s7_read_write_tpkt_packet* packet);
+
 plc4c_return_code plc4c_driver_s7_read_machine_function(
     plc4c_system_task* task) {
-  plc4c_read_request_execution* read_request_execution = task->context;
+
+  plc4c_read_request_execution* read_request_execution;
+  plc4c_read_request* read_request;
+  plc4c_connection* connection;
+  plc4c_s7_read_write_tpkt_packet* s7_read_packet;
+  plc4c_return_code return_code;
+
+  read_request_execution = task->context;
   if (read_request_execution == NULL) {
     return INTERNAL_ERROR;
   }
-  plc4c_read_request* read_request = read_request_execution->read_request;
+  read_request = read_request_execution->read_request;
   if (read_request == NULL) {
     return INTERNAL_ERROR;
   }
-  plc4c_connection* connection = task->connection;
+  connection = task->connection;
   if (connection == NULL) {
     return INTERNAL_ERROR;
   }
 
   switch (task->state_id) {
     case PLC4C_DRIVER_S7_READ_INIT: {
-      plc4c_s7_read_write_tpkt_packet* s7_read_request_packet;
-      plc4c_return_code return_code =
-          plc4c_driver_s7_create_s7_read_request(
-              read_request, &s7_read_request_packet);
+      return_code = plc4c_driver_s7_create_s7_read_request(read_request, &s7_read_packet);
       if (return_code != OK) {
         return return_code;
       }
 
       // Send the packet to the remote.
-      return_code = plc4c_driver_s7_send_packet(connection, s7_read_request_packet);
+      return_code = plc4c_driver_s7_send_packet(connection, s7_read_packet);
       if (return_code != OK) {
         return return_code;
       }
@@ -68,10 +77,12 @@ plc4c_return_code plc4c_driver_s7_read_machine_function(
       break;
     }
     case PLC4C_DRIVER_S7_READ_FINISHED: {
+      
+      plc4c_s7_read_write_s7_parameter* parameter;
+      plc4c_read_response* read_response;
+
       // Read a response packet.
-      plc4c_s7_read_write_tpkt_packet* s7_read_response_packet;
-      plc4c_return_code return_code =
-          plc4c_driver_s7_receive_packet(connection, &s7_read_response_packet);
+      return_code = plc4c_driver_s7_receive_packet(connection, &s7_read_packet);
       // If we haven't read enough to process a full message, just try again
       // next time.
       if (return_code == UNFINISHED) {
@@ -81,81 +92,30 @@ plc4c_return_code plc4c_driver_s7_read_machine_function(
       }
 
       // Check the response.
-      plc4c_s7_read_write_s7_parameter* parameter = s7_read_response_packet->payload->payload->parameter;
-      if(parameter->_type != plc4c_s7_read_write_s7_parameter_type_plc4c_s7_read_write_s7_parameter_read_var_response) {
+      parameter = s7_read_packet->payload->payload->parameter;
+      if (parameter->_type != plc4c_s7_read_write_s7_parameter_type_plc4c_s7_read_write_s7_parameter_read_var_response) {
         return INTERNAL_ERROR;
       }
       // Check if the number of items matches that of the request
       // (Otherwise we won't know how to interpret the items)
-      if(parameter->s7_parameter_read_var_response_num_items != plc4c_utils_list_size(read_request->items)) {
+      if (parameter->s7_parameter_read_var_response_num_items != plc4c_utils_list_size(read_request->items)) {
         return INTERNAL_ERROR;
       }
 
-      plc4c_read_response* read_response = malloc(sizeof(plc4c_read_response));
-      if(read_response == NULL) {
+      read_response = malloc(sizeof(plc4c_read_response));
+      if (read_response == NULL) {
         return NO_MEMORY;
       }
       read_response->read_request = read_request;
       read_request_execution->read_response = read_response;
-      plc4c_utils_list_create(&(read_response->items));
+      plc4c_utils_list_create(&read_response->items);
 
-      // Iterate over the request items and use the types to decode the
-      // response items.
-      plc4c_s7_read_write_s7_payload* payload = s7_read_response_packet->payload->payload->payload;
-      plc4c_list_element* cur_request_item_element = plc4c_utils_list_tail(read_request->items);
-      plc4c_list_element* cur_response_item_element = plc4c_utils_list_tail(payload->s7_payload_read_var_response_items);
-      while((cur_request_item_element != NULL) && (cur_response_item_element != NULL)) {
-        plc4c_item* cur_request_item = cur_request_item_element->value;
-
-        // Get the protocol id for the current item from the corresponding
-        // request item. Also get the number of elements, if it's an array.
-        plc4c_s7_read_write_s7_var_request_parameter_item* s7_address = cur_request_item->address;
-        plc4c_s7_read_write_transport_size transport_size = s7_address->s7_var_request_parameter_item_address_address->s7_address_any_transport_size;
-        char* data_protocol_id = plc4c_s7_read_write_transport_size_get_data_protocol_id(transport_size);
-        uint16_t num_elements = s7_address->s7_var_request_parameter_item_address_address->s7_address_any_number_of_elements;
-        int32_t string_length = 0;
-        if(transport_size == plc4c_s7_read_write_transport_size_STRING) {
-          // TODO: This needs to be changed to read arrays of strings.
-          string_length = num_elements;
-          num_elements = 1;
-        }
-
-        // Convert the linked list with uint8_t elements into an array of uint8_t.
-        plc4c_s7_read_write_s7_var_payload_data_item* cur_response_item = cur_response_item_element->value;
-        uint8_t* byte_array = plc4c_list_to_byte_array(cur_response_item->data);
-        if(byte_array == NULL) {
-          return INTERNAL_ERROR;
-        }
-
-        // Create a new read-buffer for reading data from the uint8_t array.
-        plc4c_spi_read_buffer* read_buffer;
-        enum plc4c_return_code result = plc4c_spi_read_buffer_create(byte_array, plc4c_utils_list_size(cur_response_item->data), &read_buffer);
-        if(result != OK) {
-          return result;
-        }
-
-        // Parse the data item.
-        plc4c_data* data_item;
-        plc4c_s7_read_write_data_item_parse(read_buffer, data_protocol_id, string_length, &data_item);
-
-        // Create a new response value-item
-        plc4c_response_value_item* response_value_item = malloc(sizeof(plc4c_response_value_item));
-        if(response_value_item == NULL) {
-          return NO_MEMORY;
-        }
-        response_value_item->item = cur_request_item;
-        response_value_item->response_code = PLC4C_RESPONSE_CODE_OK;
-        response_value_item->value = data_item;
-
-        // Add the value-item to the list.
-        plc4c_utils_list_insert_head_value(read_response->items, response_value_item);
-
-        cur_request_item_element = cur_request_item_element->next;
-        cur_response_item_element = cur_response_item_element->next;
-      }
+      return_code = plc4c_driver_s7_parse_read_responce(read_request, 
+          read_response, s7_read_packet);
+      if (return_code != OK)
+        return return_code;
 
       // TODO: Return the results to the API ...
-
       task->completed = true;
       break;
     }
@@ -191,4 +151,84 @@ void plc4c_driver_s7_free_read_response(plc4c_read_response* response) {
   // the request will be cleaned up elsewhere
   plc4c_utils_list_delete_elements(response->items,
                                    &plc4c_driver_s7_free_read_response_item);
+}
+
+plc4c_return_code plc4c_driver_s7_parse_read_responce( 
+                                plc4c_read_request* request, 
+                                plc4c_read_response* response,
+                                plc4c_s7_read_write_tpkt_packet* packet) {
+
+  // Locals
+  plc4c_s7_read_write_s7_payload* payload;
+  plc4c_list_element* cur_request_item_element;
+  plc4c_list_element* cur_response_item_element;
+  plc4c_item* cur_request_item;
+  plc4c_s7_read_write_s7_var_request_parameter_item* s7_address;
+  plc4c_s7_read_write_transport_size transport_size;
+
+  plc4c_s7_read_write_s7_var_payload_data_item* cur_response_item;
+  plc4c_spi_read_buffer* read_buffer;
+  plc4c_data* data_item;
+  plc4c_response_value_item* response_value_item;
+
+  char* data_protocol_id;
+  uint16_t num_elements;
+  int32_t string_length;
+  uint8_t* byte_array;
+  size_t list_size;
+  enum plc4c_return_code result;
+
+  // Iterate over the request items and use the types to decode the
+  // response items.
+  payload = packet->payload->payload->payload;
+  cur_request_item_element = plc4c_utils_list_tail(request->items);
+  cur_response_item_element = plc4c_utils_list_tail(payload->s7_payload_read_var_response_items);
+  
+  while ((cur_request_item_element != NULL) && (cur_response_item_element != NULL)) {
+    cur_request_item = cur_request_item_element->value;
+
+    // Get the protocol id for the current item from the corresponding
+    // request item. Also get the number of elements, if it's an array.
+    s7_address = cur_request_item->address;
+    transport_size = s7_address->s7_var_request_parameter_item_address_address->s7_address_any_transport_size;
+    data_protocol_id = plc4c_s7_read_write_transport_size_get_data_protocol_id(transport_size);
+    num_elements = s7_address->s7_var_request_parameter_item_address_address->s7_address_any_number_of_elements;
+    string_length = 0;
+    if (transport_size == plc4c_s7_read_write_transport_size_STRING) {
+      // TODO: This needs to be changed to read arrays of strings.
+      string_length = num_elements;
+      num_elements = 1;
+    }
+
+    // Convert the linked list with uint8_t elements into an array of uint8_t.
+    cur_response_item = cur_response_item_element->value;
+    byte_array = plc4c_list_to_byte_array(cur_response_item->data);
+    if (byte_array == NULL) 
+      return INTERNAL_ERROR;
+
+    // Create a new read-buffer for reading data from the uint8_t array.
+    list_size = plc4c_utils_list_size(cur_response_item->data);
+    result = plc4c_spi_read_buffer_create(byte_array, list_size, &read_buffer);
+    if (result != OK) 
+      return result;
+
+    // Parse the data item.
+    plc4c_s7_read_write_data_item_parse(read_buffer, data_protocol_id, string_length, &data_item);
+
+    // Create a new response value-item
+    response_value_item = malloc(sizeof(plc4c_response_value_item));
+    if (response_value_item == NULL) 
+      return NO_MEMORY;
+
+    response_value_item->item = cur_request_item;
+    response_value_item->response_code = PLC4C_RESPONSE_CODE_OK;
+    response_value_item->value = data_item;
+
+    // Add the value-item to the list.
+    plc4c_utils_list_insert_head_value(response->items, response_value_item);
+
+    cur_request_item_element = cur_request_item_element->next;
+    cur_response_item_element = cur_response_item_element->next;
+  }
+  return OK;
 }

--- a/sandbox/plc4c/drivers/s7/src/driver_s7_sm_write.c
+++ b/sandbox/plc4c/drivers/s7/src/driver_s7_sm_write.c
@@ -33,33 +33,42 @@ enum plc4c_driver_s7_write_states {
   PLC4C_DRIVER_S7_WRITE_FINISHED
 };
 
+// Forward declaration of helper function to stop PLC4C_DRIVER_S7_WRITE_FINISHED
+// state become too big, TODO: move to some header or inline
+plc4c_return_code plc4c_driver_s7_parse_write_responce(plc4c_write_request* request, 
+    plc4c_write_response* response, plc4c_s7_read_write_tpkt_packet* packet);
+
 plc4c_return_code plc4c_driver_s7_write_machine_function(
     plc4c_system_task* task) {
-  plc4c_write_request_execution* write_request_execution = task->context;
+
+  plc4c_write_request_execution* write_request_execution;
+  plc4c_write_request* write_request;
+  plc4c_connection* connection;
+  plc4c_s7_read_write_tpkt_packet* write_packet;
+  plc4c_return_code return_code;
+
+  write_request_execution = task->context;
   if (write_request_execution == NULL) {
     return INTERNAL_ERROR;
   }
-  plc4c_write_request* write_request = write_request_execution->write_request;
+  write_request = write_request_execution->write_request;
   if (write_request == NULL) {
     return INTERNAL_ERROR;
   }
-  plc4c_connection* connection = task->context;
+  connection = task->connection;
   if (connection == NULL) {
     return INTERNAL_ERROR;
   }
 
   switch (task->state_id) {
     case PLC4C_DRIVER_S7_WRITE_INIT: {
-      plc4c_s7_read_write_tpkt_packet* s7_write_request_packet;
-      plc4c_return_code return_code =
-          plc4c_driver_s7_create_s7_write_request(
-              write_request, &s7_write_request_packet);
+      return_code = plc4c_driver_s7_create_s7_write_request(write_request, &write_packet);
       if (return_code != OK) {
         return return_code;
       }
 
       // Send the packet to the remote.
-      return_code = plc4c_driver_s7_send_packet(connection, s7_write_request_packet);
+      return_code = plc4c_driver_s7_send_packet(connection, write_packet);
       if (return_code != OK) {
         return return_code;
       }
@@ -68,10 +77,12 @@ plc4c_return_code plc4c_driver_s7_write_machine_function(
       break;
     }
     case PLC4C_DRIVER_S7_WRITE_FINISHED: {
+      
+      plc4c_s7_read_write_s7_parameter* parameter;
+      plc4c_write_response* write_response;
+
       // Read a response packet.
-      plc4c_s7_read_write_tpkt_packet* s7_write_response_packet;
-      plc4c_return_code return_code =
-          plc4c_driver_s7_receive_packet(connection, &s7_write_response_packet);
+      return_code = plc4c_driver_s7_receive_packet(connection, &write_packet);
       // If we haven't read enough to process a full message, just try again
       // next time.
       if (return_code == UNFINISHED) {
@@ -80,10 +91,30 @@ plc4c_return_code plc4c_driver_s7_write_machine_function(
         return return_code;
       }
 
-      // TODO: Check the response ...
-      // TODO: Decode the return codes in the response ...
-      // TODO: Return the results to the API ...
+      // Check the response
+      parameter = write_packet->payload->payload->parameter;
+      if (parameter->_type != plc4c_s7_read_write_s7_parameter_type_plc4c_s7_read_write_s7_parameter_write_var_response) {
+        return INTERNAL_ERROR;
+      }
+      // Check if the number of items matches that of the request
+      // (Otherwise we won't know how to interpret the items)
+      if (parameter->s7_parameter_read_var_response_num_items != plc4c_utils_list_size(write_request->items)) {
+        return INTERNAL_ERROR;
+      }
 
+      write_response = malloc(sizeof(plc4c_write_response));
+      if (write_response == NULL) {
+        return NO_MEMORY;
+      }
+      write_response->write_request = write_request;
+      write_request_execution->write_response = write_response;
+      plc4c_utils_list_create(&write_response->response_items);
+
+      return_code = plc4c_driver_s7_parse_write_responce(write_request, write_response, write_packet);
+      if (return_code != OK)
+        return return_code;
+
+      // TODO: Return the results to the API ...
       task->completed = true;
       break;
     }
@@ -94,20 +125,25 @@ plc4c_return_code plc4c_driver_s7_write_machine_function(
 plc4c_return_code plc4c_driver_s7_write_function(
     plc4c_write_request_execution* write_request_execution,
     plc4c_system_task** task) {
+
   plc4c_system_task* new_task = malloc(sizeof(plc4c_system_task));
+  if(new_task == NULL)
+    return NO_MEMORY;
+  
   new_task->state_id = PLC4C_DRIVER_S7_WRITE_INIT;
   new_task->state_machine_function = &plc4c_driver_s7_write_machine_function;
   new_task->completed = false;
   new_task->context = write_request_execution;
-  new_task->connection = write_request_execution->write_request->connection;
+  new_task->connection = plc4c_write_request_get_connection(write_request_execution->write_request);
   *task = new_task;
   return OK;
 }
 
 void plc4c_driver_s7_free_write_response_item(
     plc4c_list_element* write_item_element) {
-  plc4c_response_value_item* value_item =
-      (plc4c_response_value_item*)write_item_element->value;
+  
+  plc4c_response_value_item* value_item;
+  value_item = (plc4c_response_value_item*)write_item_element->value;
   // do not delete the plc4c_item
   // we also, in THIS case don't delete the random value which isn't really
   // a pointer
@@ -119,4 +155,53 @@ void plc4c_driver_s7_free_write_response(plc4c_write_response* response) {
   // the request will be cleaned up elsewhere
   plc4c_utils_list_delete_elements(response->response_items,
                                    &plc4c_driver_s7_free_write_response_item);
+}
+
+plc4c_return_code plc4c_driver_s7_parse_write_responce(
+                                plc4c_write_request* request, 
+                                plc4c_write_response* response,
+                                plc4c_s7_read_write_tpkt_packet* packet) {
+  
+  // Locals
+  plc4c_s7_read_write_s7_payload* s7_payload;
+  plc4c_list_element* request_list_element;
+  plc4c_list_element* response_list_element;
+  
+  plc4c_request_value_item* request_item;
+  plc4c_s7_read_write_s7_var_request_parameter_item* s7_parameter;
+  plc4c_s7_read_write_s7_var_payload_status_item* s7_payload_status;
+
+  plc4c_spi_read_buffer* read_buffer;
+  plc4c_response_item* response_item;
+
+  uint8_t* byte_array;
+  size_t list_size;
+  enum plc4c_return_code result;
+  
+	// Iterate over the request items and use the types to decode the
+	// response items. TODO: Decode the return codes in the response ...
+	s7_payload = packet->payload->payload->payload;
+	request_list_element = plc4c_utils_list_tail(request->items);
+	response_list_element = plc4c_utils_list_tail(s7_payload->s7_payload_write_var_response_items);
+
+	while ((request_list_element != NULL) && (response_list_element != NULL)) {
+		
+    request_item = request_list_element->value;
+		s7_payload_status = response_list_element->value;
+
+		// Create a new response value-item
+		response_item = malloc(sizeof(plc4c_response_item));
+		if (response_item == NULL)
+		  return NO_MEMORY;
+		
+		response_item->item = request_item->item;
+		response_item->response_code = PLC4C_RESPONSE_CODE_OK;
+
+		// Add the value-item to the list.
+		plc4c_utils_list_insert_head_value(response->response_items, response_item);
+
+		request_list_element = request_list_element->next;
+		response_list_element = response_list_element->next;
+	}
+  return OK;
 }

--- a/sandbox/plc4c/examples/hello-world-s7/CMakeLists.txt
+++ b/sandbox/plc4c/examples/hello-world-s7/CMakeLists.txt
@@ -25,8 +25,18 @@ add_executable(plc4c-examples-hello-world-s7
         src/hello_world_s7.c
         )
 
+add_executable(plc4c-examples-loopback-s7
+		src/hello_world_s7_loopback.c
+		)
+
 IF (NOT WIN32)
     target_link_libraries(plc4c-examples-hello-world-s7
+            plc4c-spi
+            plc4c-driver-s7
+            plc4c-transport-tcp
+            m
+    )
+    target_link_libraries(plc4c-examples-loopback-s7
             plc4c-spi
             plc4c-driver-s7
             plc4c-transport-tcp
@@ -38,4 +48,10 @@ ELSE()
             plc4c-driver-s7
             plc4c-transport-tcp
     )
+    target_link_libraries(plc4c-examples-loopback-s7
+            plc4c-spi
+            plc4c-driver-s7
+            plc4c-transport-tcp
+    )
 ENDIF()
+

--- a/sandbox/plc4c/examples/hello-world-s7/src/hello_world_s7.c
+++ b/sandbox/plc4c/examples/hello-world-s7/src/hello_world_s7.c
@@ -21,7 +21,6 @@
 #include <plc4c/transport_tcp.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 
 
 #include "../../../spi/include/plc4c/spi/types_private.h"
@@ -151,8 +150,6 @@ int main(int argc, char** argv) {
         } else if (plc4c_connection_has_error(connection)) {
           printf("FAILED\n");
           return -1;
-        } else {
-          usleep(1000*100);
         }
         break;
       }

--- a/sandbox/plc4c/examples/hello-world-s7/src/hello_world_s7.c
+++ b/sandbox/plc4c/examples/hello-world-s7/src/hello_world_s7.c
@@ -21,8 +21,12 @@
 #include <plc4c/transport_tcp.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
+
 
 #include "../../../spi/include/plc4c/spi/types_private.h"
+
+#define DEFAULT_CONNECTION_TEST_STRING "s7:tcp://192.168.23.30:20"
 
 int numOpenConnections = 0;
 
@@ -58,12 +62,19 @@ typedef enum plc4c_connection_state_t plc4c_connection_state;
 //#pragma clang diagnostic push
 //#pragma ide diagnostic ignored "hicpp-multiway-paths-covered"
 
-int main() {
+int main(int argc, char** argv) {
+  
+  char* connection_test_string;
   bool loop = true;
   plc4c_system *system = NULL;
   plc4c_connection *connection = NULL;
   plc4c_read_request *read_request = NULL;
   plc4c_read_request_execution *read_request_execution = NULL;
+
+  if (argc == 1)
+    connection_test_string = DEFAULT_CONNECTION_TEST_STRING;
+  else
+    connection_test_string = argv[1];
 
   // Create a new uninitialized plc4c_system
   printf("Creating new PLC4C System (Initializing inner data-structures) ... ");
@@ -74,7 +85,7 @@ int main() {
   }
   printf("SUCCESS\n");
 
-  // Manually register the "simulated" driver with the system.
+  // Manually register the "s7" driver with the system.
   printf("Registering driver for the 's7' protocol ... ");
   plc4c_driver *s7_driver = plc4c_driver_s7_create();
   result = plc4c_system_add_driver(system, s7_driver);
@@ -84,6 +95,7 @@ int main() {
   }
   printf("SUCCESS\n");
 
+  printf("Registering driver for 'tcp' transport ... ");
   plc4c_transport *tcp_transport = plc4c_transport_tcp_create();
   result = plc4c_system_add_transport(system, tcp_transport);
   if (result != OK) {
@@ -109,8 +121,9 @@ int main() {
 
   // Establish connections to remote devices
   // you may or may not care about the connection handle
-  printf("Connecting to 's7:tcp://192.168.23.30' ... ");
-  result = plc4c_system_connect(system, "s7:tcp://192.168.23.30", &connection);
+
+  printf("Connecting to '%s' ... ", connection_test_string);
+  result = plc4c_system_connect(system, connection_test_string, &connection);
   if (result != OK) {
     printf("FAILED\n");
     return -1;
@@ -138,6 +151,8 @@ int main() {
         } else if (plc4c_connection_has_error(connection)) {
           printf("FAILED\n");
           return -1;
+        } else {
+          usleep(1000*100);
         }
         break;
       }

--- a/sandbox/plc4c/generated-sources/s7/src/s7_var_payload_data_item.c
+++ b/sandbox/plc4c/generated-sources/s7/src/s7_var_payload_data_item.c
@@ -121,7 +121,8 @@ plc4c_return_code plc4c_s7_read_write_s7_var_payload_data_item_serialize(plc4c_s
     for(int curItem = 0; curItem < itemCount; curItem++) {
 
       int8_t* _value = (int8_t*) plc4c_utils_list_get_value(_message->data, curItem);
-      plc4c_spi_write_signed_byte(io, 8, *_value);
+      // TODO: fix this brutal hack gets us from data_item to data_item->data
+      plc4c_spi_write_signed_byte(io, 8, *(_value+=16)); 
     }
   }
 

--- a/sandbox/plc4c/spi/src/read.c
+++ b/sandbox/plc4c/spi/src/read.c
@@ -33,17 +33,26 @@ void plc4c_read_request_set_connection(plc4c_read_request *read_request,
 }
 
 plc4c_return_code plc4c_read_request_add_item(plc4c_read_request *read_request,
-                                              char* field_name, char *address) {
-  plc4c_item *item = malloc(sizeof(plc4c_item));
-  if(item == NULL) {
+    char* field_name, char *address) {
+  
+  // Parse an address string and get a driver-dependent data-structure
+  // representing the address back.
+  plc4c_item *item;
+  plc4c_return_code result;
+
+  item = malloc(sizeof(plc4c_item));
+  if(item == NULL) 
     return NO_MEMORY;
-  }
-  item->name = field_name;
-  plc4c_return_code result =
-      read_request->connection->driver->parse_address_function(address, &(item->address));
-  if(result != OK) {
+  
+  result = read_request->connection->driver->parse_address_function(
+          address, &item->address );
+  
+  if(result != OK) 
     return result;
-  }
+  
+  // Bind name to the plc_item
+  item->name = field_name;
+
   plc4c_utils_list_insert_head_value(read_request->items, item);
   return OK;
 }

--- a/sandbox/plc4c/spi/src/write.c
+++ b/sandbox/plc4c/spi/src/write.c
@@ -36,21 +36,25 @@ plc4c_return_code plc4c_write_request_add_item(
     plc4c_write_request *write_request, char *address, plc4c_data *value) {
   // Parse an address string and get a driver-dependent data-structure
   // representing the address back.
-  plc4c_item *address_item = malloc(sizeof(plc4c_item));
-  if(address_item == NULL) {
+  plc4c_request_value_item *value_item;
+  plc4c_item *address_item;
+  plc4c_return_code result;
+
+  address_item = malloc(sizeof(plc4c_item));
+  if(address_item == NULL) 
     return NO_MEMORY;
-  }
-
-  plc4c_return_code result =
-      write_request->connection->driver->parse_address_function(address, &(address_item->address));
-
+  
+  result = write_request->connection->driver->parse_address_function(
+          address, &address_item->address );
+  
+  if(result != OK) 
+    return result;
+  
   // Create a new value item, binding an address item to a value.
-  plc4c_request_value_item *value_item =
-      malloc(sizeof(plc4c_request_value_item));
+  value_item = malloc(sizeof(plc4c_request_value_item));
   value_item->item = address_item;
-  value_item->value = (plc4c_data *)value;
+  value_item->value = value;
 
-  // Add the new item ot the list of items.
   plc4c_utils_list_insert_tail_value(write_request->items, value_item);
   return OK;
 }
@@ -58,23 +62,32 @@ plc4c_return_code plc4c_write_request_add_item(
 plc4c_return_code plc4c_write_request_execute(
     plc4c_write_request *write_request,
     plc4c_write_request_execution **write_request_execution) {
+
+  plc4c_write_request_execution *new_write_request_execution;
+  plc4c_connection *connection;
+  plc4c_driver *driver;
+  plc4c_system *system;
+  plc4c_list *system_tasks;
+
+  // Extract some plc4c pointers for clarity
+  connection = plc4c_write_request_get_connection(write_request);
+  system = plc4c_connection_get_system(connection);
+  driver = plc4c_connection_get_driver(connection);
+  system_tasks = plc4c_system_get_task_list(system);
+
   // Inject the default write context into the system task.
-  plc4c_write_request_execution *new_write_request_execution =
-      malloc(sizeof(plc4c_write_request_execution));
+  new_write_request_execution = malloc(sizeof(plc4c_write_request_execution));
   new_write_request_execution->write_request = write_request;
   new_write_request_execution->write_response = NULL;
   new_write_request_execution->system_task = NULL;
+  
+  driver->write_function(new_write_request_execution, &(new_write_request_execution->system_task));
 
-  plc4c_system_task *system_task;
-  plc4c_connection_get_driver(plc4c_write_request_get_connection(write_request))
-      ->write_function(new_write_request_execution, &system_task);
   // Increment the number of running tasks for this connection.
-  plc4c_connection_task_added(write_request->connection);
+  plc4c_connection_task_added(connection);
+
   // Add the new task to the task-list.
-  plc4c_utils_list_insert_tail_value(
-      plc4c_system_get_task_list(plc4c_connection_get_system(
-          plc4c_write_request_get_connection(write_request))),
-      system_task);
+  plc4c_utils_list_insert_tail_value(system_tasks, new_write_request_execution->system_task);
 
   *write_request_execution = new_write_request_execution;
   return OK;

--- a/sandbox/plc4c/transports/tcp/src/transport_tcp.c
+++ b/sandbox/plc4c/transports/tcp/src/transport_tcp.c
@@ -29,7 +29,7 @@
 #include <arpa/inet.h>
 #else
 #include <winsock.h>
-# define strtok_r strtok_s
+#define strtok_r strtok_s
 #define bzero(b,len) (memset((b), '\0', (len)), (void) 0)
 #define MSG_DONTWAIT 0
 #endif
@@ -39,7 +39,7 @@ extern int errno;
 plc4c_return_code plc4c_transport_tcp_configure_function(
     char* transport_connect_information, plc4c_list* parameters, void** configuration) {
   plc4c_transport_tcp_config* tcp_configuration = malloc(sizeof(plc4c_transport_tcp_config));
-  if(tcp_configuration == NULL) {
+  if (tcp_configuration == NULL) {
     return NO_MEMORY;
   }
 
@@ -47,7 +47,7 @@ plc4c_return_code plc4c_transport_tcp_configure_function(
   char *host = strtok_r(transport_connect_information, ":", &port);
   tcp_configuration->address = host;
   // If no port was specified, generally use the default port for this driver
-  if(strlen(port) == 0) {
+  if (strlen(port) == 0) {
     // TODO: Currently return an error.
     return INTERNAL_ERROR;
   } else {
@@ -88,7 +88,7 @@ plc4c_return_code plc4c_transport_tcp_open_function(void* config) {
                        sizeof(servaddr));
   if(result != 0) {
     char* error_msg = strerror(errno);
-    printf(error_msg);
+    printf("%s\n", error_msg);
     return CONNECTION_ERROR;
   }
   return OK;


### PR DESCRIPTION
hello-world-s7 now working when passed connection string with port eg. `s7:tcp://0.0.0.0:102` I don't think it possible that it was working before... ?

`spi/src/system.c`: plugged mem leaks, removed unneeded mallocs (ie. mallocs in both `spi/src/system.c` and `spi/src/connection.c`, needed only in 1 of these locations), fixed compiler warnings on `hurz` cast and de-globalized `hurz` (maybe globalness was intended?). Rewrote the connection string parser to use tokenisation rather than walking pointer, which is IMO much clearer.

`hello_world_s7.c` beautified some `printf`s and allowed optional cli arguments for setting the test connection string. 

`transport_tcp.c` fixed compile warning on `printf` without const format specifier. 