### PR TITLE
Remove merge button when merging PR's, this forces the use of squash

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -46,7 +46,7 @@ github:
 
   enabled_merge_buttons:
     squash: true
-    merge: true
+    merge: false
     rebase: false
 
 notifications:


### PR DESCRIPTION
Following on from Chris's comment about using a standardized commit comments, What are people thoughts on removing the merge button infavour of squash when merging PR's?