### PR TITLE
plc4go: fixed passing parameters incorrectly, resulting in a null pointer

### DIFF
--- a/plc4go/internal/plc4go/modbus/Reader.go
+++ b/plc4go/internal/plc4go/modbus/Reader.go
@@ -175,7 +175,7 @@ func (m *Reader) ToPlc4xReadResponse(responseAdu readWriteModel.ModbusTcpADU, re
 		data = utils.Int8ArrayToUint8Array(pdu.Value)
 		// Pure Boolean ...
 	case *readWriteModel.ModbusPDUReadCoilsResponse:
-		pdu := readWriteModel.CastModbusPDUReadCoilsResponse(&responseAdu.Pdu)
+		pdu := readWriteModel.CastModbusPDUReadCoilsResponse(responseAdu.Pdu)
 		data = utils.Int8ArrayToUint8Array(pdu.Value)
 		// Pure Boolean ...
 	case *readWriteModel.ModbusPDUReadInputRegistersResponse:


### PR DESCRIPTION
When read 000019:BOOL throw "recovered from runtime error: invalid memory address or nil pointer dereference"
{"level":"trace","time":"2021-04-30T19:05:40+08:00","message":"convert response to ADU"}
{"level":"trace","time":"2021-04-30T19:05:40+08:00","message":"convert response to PLC4X response"}
{"level":"error","time":"2021-04-30T19:05:40+08:00","message":"recovered from runtime error: invalid memory address or nil pointer dereference"}