### PR TITLE
PLC4X-311 Handling of compact answers for ADS read requests.

### DIFF
--- a/protocols/ads/src/test/resources/protocols/ads/DriverTestsuite.xml
+++ b/protocols/ads/src/test/resources/protocols/ads/DriverTestsuite.xml
@@ -174,13 +174,19 @@
               <data>
                 <AdsData>
                   <AdsReadResponse>
-                    <result>
-                      <ReturnCode dataType="uint" bitLength="32">0</ReturnCode>
-                    </result>
-                    <length dataType="uint" bitLength="32">1</length>
-                    <data isList="true">
-                      <value dataType="int" bitLength="8">1</value>
-                    </data>
+                    <payload>
+                      <AdsResponseData>
+                        <AdsReadFullResponse>
+                          <result>
+                            <ReturnCode dataType="uint" bitLength="32">0</ReturnCode>
+                          </result>
+                          <length dataType="uint" bitLength="32">1</length>
+                          <data isList="true">
+                            <value dataType="int" bitLength="8">1</value>
+                          </data>
+                        </AdsReadFullResponse>
+                      </AdsResponseData>
+                    </payload>
                   </AdsReadResponse>
                 </AdsData>
               </data>
@@ -724,22 +730,28 @@
               <data>
                 <AdsData>
                   <AdsReadResponse>
-                    <result>
-                      <ReturnCode dataType="uint" bitLength="32">0</ReturnCode>
-                    </result>
-                    <length dataType="uint" bitLength="32">10</length>
-                    <data isList="true">
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">1</value>
-                      <value dataType="int" bitLength="8">1</value>
-                    </data>
+                    <payload>
+                      <AdsResponseData>
+                        <AdsReadFullResponse>
+                          <result>
+                            <ReturnCode dataType="uint" bitLength="32">0</ReturnCode>
+                          </result>
+                          <length dataType="uint" bitLength="32">10</length>
+                          <data isList="true">
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">1</value>
+                            <value dataType="int" bitLength="8">1</value>
+                          </data>
+                        </AdsReadFullResponse>
+                      </AdsResponseData>
+                    </payload>
                   </AdsReadResponse>
                 </AdsData>
               </data>
@@ -1064,22 +1076,28 @@
               <data>
                 <AdsData>
                   <AdsReadResponse>
-                    <result>
-                      <ReturnCode dataType="uint" bitLength="32">0</ReturnCode>
-                    </result>
-                    <length dataType="uint" bitLength="32">10</length>
-                    <data isList="true">
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">1</value>
-                      <value dataType="int" bitLength="8">1</value>
-                    </data>
+                    <payload>
+                      <AdsResponseData>
+                        <AdsReadFullResponse>
+                          <result>
+                            <ReturnCode dataType="uint" bitLength="32">0</ReturnCode>
+                          </result>
+                          <length dataType="uint" bitLength="32">10</length>
+                          <data isList="true">
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">1</value>
+                            <value dataType="int" bitLength="8">1</value>
+                          </data>
+                        </AdsReadFullResponse>
+                      </AdsResponseData>
+                    </payload>
                   </AdsReadResponse>
                 </AdsData>
               </data>
@@ -1234,22 +1252,28 @@
               <data>
                 <AdsData>
                   <AdsReadResponse>
-                    <result>
-                      <ReturnCode dataType="uint" bitLength="32">0</ReturnCode>
-                    </result>
-                    <length dataType="uint" bitLength="32">10</length>
-                    <data isList="true">
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">0</value>
-                      <value dataType="int" bitLength="8">1</value>
-                      <value dataType="int" bitLength="8">1</value>
-                    </data>
+                    <payload>
+                      <AdsResponseData>
+                        <AdsReadFullResponse>
+                          <result>
+                            <ReturnCode dataType="uint" bitLength="32">0</ReturnCode>
+                          </result>
+                          <length dataType="uint" bitLength="32">10</length>
+                          <data isList="true">
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">0</value>
+                            <value dataType="int" bitLength="8">1</value>
+                            <value dataType="int" bitLength="8">1</value>
+                          </data>
+                        </AdsReadFullResponse>
+                      </AdsResponseData>
+                    </payload>
                   </AdsReadResponse>
                 </AdsData>
               </data>

--- a/protocols/ads/src/test/resources/protocols/ads/ParserSerializerTestsuite.xml
+++ b/protocols/ads/src/test/resources/protocols/ads/ParserSerializerTestsuite.xml
@@ -147,13 +147,19 @@
             <data>
               <AdsData>
                 <AdsReadResponse>
-                  <result>
-                    <ReturnCode dataType="uint" bitLength="32" stringRepresentation="OK">0</ReturnCode>
-                  </result>
-                  <length dataType="uint" bitLength="32">1</length>
-                  <data isList="true">
-                    <value dataType="int" bitLength="8">1</value>
-                  </data>
+                  <payload>
+                    <AdsResponseData>
+                      <AdsReadFullResponse>
+                        <result>
+                          <ReturnCode dataType="uint" bitLength="32" stringRepresentation="OK">0</ReturnCode>
+                        </result>
+                        <length dataType="uint" bitLength="32">1</length>
+                        <data isList="true">
+                          <value dataType="int" bitLength="8">1</value>
+                        </data>
+                      </AdsReadFullResponse>
+                    </AdsResponseData>
+                  </payload>
                 </AdsReadResponse>
               </AdsData>
             </data>
@@ -457,13 +463,19 @@
             <data>
               <AdsData>
                 <AdsReadResponse>
-                  <result>
-                    <ReturnCode dataType="uint" bitLength="32" stringRepresentation="OK">0</ReturnCode>
-                  </result>
-                  <length dataType="uint" bitLength="32">1</length>
-                  <data isList="true">
-                    <value dataType="int" bitLength="8">1</value>
-                  </data>
+                  <payload>
+                    <AdsResponseData>
+                      <AdsReadFullResponse>
+                        <result>
+                          <ReturnCode dataType="uint" bitLength="32" stringRepresentation="OK">0</ReturnCode>
+                        </result>
+                        <length dataType="uint" bitLength="32">1</length>
+                        <data isList="true">
+                          <value dataType="int" bitLength="8">1</value>
+                        </data>
+                      </AdsReadFullResponse>
+                    </AdsResponseData>
+                  </payload>
                 </AdsReadResponse>
               </AdsData>
             </data>


### PR DESCRIPTION
Please have a look on fix. I tested it with TC2 and it works fine. I am not quite sure if such serious mspec modification is justified. I'd opt for optional fields, however I am not sure if we can have an `optional implicit`.