### PR TITLE
Fix/PLC4X 303

### DIFF
--- a/plc4j/drivers/opcua/pom.xml
+++ b/plc4j/drivers/opcua/pom.xml
@@ -130,11 +130,20 @@
       <artifactId>plc4j-api</artifactId>
       <version>0.10.0-SNAPSHOT</version>
     </dependency>
+
     <dependency>
       <groupId>org.apache.plc4x</groupId>
       <artifactId>plc4j-spi</artifactId>
       <version>0.10.0-SNAPSHOT</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.plc4x</groupId>
+      <artifactId>plc4j-utils-test-utils</artifactId>
+      <version>0.10.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>io.vavr</groupId>
       <artifactId>vavr</artifactId>
@@ -201,6 +210,12 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.plc4x</groupId>
+      <artifactId>plc4j-utils-test-utils</artifactId>
+      <version>0.10.0-SNAPSHOT</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/plc4j/drivers/opcua/pom.xml
+++ b/plc4j/drivers/opcua/pom.xml
@@ -211,12 +211,6 @@
       <artifactId>bcprov-jdk15on</artifactId>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.plc4x</groupId>
-      <artifactId>plc4j-utils-test-utils</artifactId>
-      <version>0.10.0-SNAPSHOT</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/OpcuaPlcDriver.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/OpcuaPlcDriver.java
@@ -47,8 +47,6 @@ import static org.apache.plc4x.java.spi.configuration.ConfigurationFactory.confi
 
 public class OpcuaPlcDriver extends GeneratedDriverBase<OpcuaAPU> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(OpcuaPlcDriver.class);
-
     public static final Pattern INET_ADDRESS_PATTERN = Pattern.compile("(:(?<transportCode>[a-z0-9]*))?://" +
                                                                         "(?<transportHost>[\\w.-]+)(:" +
                                                                         "(?<transportPort>\\d*))?");

--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/OpcuaPlcDriver.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/OpcuaPlcDriver.java
@@ -47,7 +47,9 @@ import static org.apache.plc4x.java.spi.configuration.ConfigurationFactory.confi
 
 public class OpcuaPlcDriver extends GeneratedDriverBase<OpcuaAPU> {
 
-    public static final Pattern INET_ADDRESS_PATTERN = Pattern.compile("(:(?<transportCode>tcp))?://" +
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpcuaPlcDriver.class);
+
+    public static final Pattern INET_ADDRESS_PATTERN = Pattern.compile("(:(?<transportCode>[a-z0-9]*))?://" +
                                                                         "(?<transportHost>[\\w.-]+)(:" +
                                                                         "(?<transportPort>\\d*))?");
 

--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannel.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannel.java
@@ -1105,7 +1105,7 @@ public class SecureChannel {
      * @throws PlcRuntimeException - If no endpoint with a compatible policy is found raise and error.
      */
     private void selectEndpoint(CreateSessionResponse sessionResponse) throws PlcRuntimeException {
-        List<String> returnedEndpoints = new LinkedList<String>();
+        List<String> returnedEndpoints = new ArrayList<String>();
 
         // Get a list of the endpoints which match ours.
         Stream<EndpointDescription> filteredEndpoints = Arrays.stream(Arrays.copyOf(sessionResponse.getServerEndpoints(), sessionResponse.getServerEndpoints().length, EndpointDescription[].class))

--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannel.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannel.java
@@ -1157,8 +1157,9 @@ public class SecureChannel {
     }
 
     /**
-     *
-     * @param policies
+     * Confirms that a policy that matches the connection string is available from
+     * the returned endpoints. It sets the policyId and tokenType for the policy to use.
+     * @param policies - A list of policies returned with the endpoint description.
      */
     private void hasIdentity(UserTokenPolicy[] policies) {
         for (UserTokenPolicy identityToken : policies) {

--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannel.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannel.java
@@ -56,6 +56,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class SecureChannel {
@@ -1108,11 +1109,16 @@ public class SecureChannel {
         List<String> returnedEndpoints = new ArrayList<String>();
 
         // Get a list of the endpoints which match ours.
-        Stream<EndpointDescription> filteredEndpoints = Arrays.stream(Arrays.copyOf(sessionResponse.getServerEndpoints(), sessionResponse.getServerEndpoints().length, EndpointDescription[].class))
+        Stream<EndpointDescription> filteredEndpoints = sessionResponse.getServerEndpoints().stream()
+            .map(e -> (EndpointDescription) e)
             .filter(this::isEndpoint);
 
         //Determine if the requested security policy is included in the endpoint
-        filteredEndpoints.forEach(endpoint -> hasIdentity(Arrays.copyOf(endpoint.getUserIdentityTokens(), endpoint.getUserIdentityTokens().length, UserTokenPolicy[].class)));
+        filteredEndpoints.forEach(endpoint -> hasIdentity(
+            endpoint.getUserIdentityTokens().stream()
+            .map(p -> (UserTokenPolicy) p)
+            .toArray(UserTokenPolicy[]::new)
+        ));
 
         if (this.policyId == null) {
             throw new PlcRuntimeException("Unable to find endpoint - " + this.endpoints.get(0));

--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannel.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannel.java
@@ -171,7 +171,8 @@ public class SecureChannel {
             this.endpoints.add(address.getHostName());
             this.endpoints.add(address.getCanonicalHostName());
         } catch (UnknownHostException e) {
-            e.printStackTrace();
+            LOGGER.warn("Unable to resolve host name. Using original host from connection string which may cause issues connecting to server");
+            this.endpoints.add(this.configuration.getHost());
         }
     }
 

--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannel.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannel.java
@@ -1128,7 +1128,7 @@ public class SecureChannel {
      * @return true if this endpoint matches our configuration
      * @throws PlcRuntimeException - If the returned endpoint string doesn't match the format expected
      */
-    public boolean isEndpoint(EndpointDescription endpoint) throws PlcRuntimeException {
+    private boolean isEndpoint(EndpointDescription endpoint) throws PlcRuntimeException {
         // Split up the connection string into it's individual segments.
         Matcher matcher = URI_PATTERN.matcher(endpoint.getEndpointUrl().getStringValue());
         if (!matcher.matches()) {

--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/protocol/OpcuaProtocolLogic.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/protocol/OpcuaProtocolLogic.java
@@ -375,12 +375,12 @@ public class OpcuaProtocolLogic extends Plc4xProtocolBase<OpcuaAPU> implements H
                     value = IEC61131ValueHandler.of(tmpValue);
                 } else if (variant instanceof VariantByteString) {
                     PlcList plcList = new PlcList();
-                    ByteStringArray[] array = ((VariantByteString) variant).getValue();
-                    for (int k = 0; k < array.length; k++) {
-                        int length = array[k].getValue().length;
-                        Byte[] tmpValue = new Byte[length];
+                    List<ByteStringArray> array = ((VariantByteString) variant).getValue();
+                    for (int k = 0; k < array.size(); k++) {
+                        int length = array.get(k).getValue().size();
+                        Short[] tmpValue = new Short[length];
                         for (int i = 0; i < length; i++) {
-                            tmpValue[i] = byteStringArray.getValue().get(i);
+                            tmpValue[i] = array.get(k).getValue().get(i);
                         }
                         plcList.add(IEC61131ValueHandler.of(tmpValue));
                     }

--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/protocol/OpcuaProtocolLogic.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/protocol/OpcuaProtocolLogic.java
@@ -375,10 +375,10 @@ public class OpcuaProtocolLogic extends Plc4xProtocolBase<OpcuaAPU> implements H
                     value = IEC61131ValueHandler.of(tmpValue);
                 } else if (variant instanceof VariantByteString) {
                     PlcList plcList = new PlcList();
-                    List<ByteStringArray> array = ((VariantByteString) variant).getValue();
-                    for (ByteStringArray byteStringArray : array) {
-                        int length = byteStringArray.getValue().size();
-                        Short[] tmpValue = new Short[length];
+                    ByteStringArray[] array = ((VariantByteString) variant).getValue();
+                    for (int k = 0; k < array.length; k++) {
+                        int length = array[k].getValue().length;
+                        Byte[] tmpValue = new Byte[length];
                         for (int i = 0; i < length; i++) {
                             tmpValue[i] = byteStringArray.getValue().get(i);
                         }

--- a/plc4j/drivers/opcua/src/test/java/org/apache/plc4x/java/opcua/OpcuaDriverIT.java
+++ b/plc4j/drivers/opcua/src/test/java/org/apache/plc4x/java/opcua/OpcuaDriverIT.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.plc4x.java.opcua;
+
+import org.apache.plc4x.test.driver.DriverTestsuiteRunner;
+
+public class OpcuaDriverIT extends DriverTestsuiteRunner {
+
+    public OpcuaDriverIT() {
+        super("/protocols/opcua/DriverTestsuite.xml", true);
+    }
+
+}

--- a/plc4j/drivers/opcua/src/test/java/org/apache/plc4x/java/opcua/PcapReplayTests.java
+++ b/plc4j/drivers/opcua/src/test/java/org/apache/plc4x/java/opcua/PcapReplayTests.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.plc4x.java.opcua;
+
+import org.apache.plc4x.java.PlcDriverManager;
+import org.apache.plc4x.java.api.PlcConnection;
+import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
+import org.eclipse.milo.examples.server.ExampleServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.fail;
+
+public class PcapReplayTests {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpcuaPlcDriverTest.class);
+
+    @BeforeAll
+    public static void setup() {
+
+    }
+
+    @AfterAll
+    public static void tearDown() {
+
+    }
+
+    @Test
+    public void connectionNoParams(){
+
+    }
+}

--- a/protocols/opcua/src/test/resources/protocols/opcua/DriverTestsuite.xml
+++ b/protocols/opcua/src/test/resources/protocols/opcua/DriverTestsuite.xml
@@ -18,7 +18,7 @@
   under the License.
   -->
 <test:driver-testsuite xmlns:test="https://plc4x.apache.org/schemas/driver-testsuite.xsd"
-                       bigEndian="false">
+                       byteOrder="LITTLE_ENDIAN">
 
   <!-- https://base64.guru/converter/encode/hex -->
 
@@ -48,7 +48,7 @@
             <endpoint>
               <PascalString>
                 <sLength dataType="int" bitLength="32">20</sLength>
-                <stringValue dataType="string" bitLength="160" encoding="'UTF-8'">opc.test://hurz:null</stringValue>
+                <stringValue dataType="string" bitLength="160" encoding="UTF-8">opc.test://hurz:null</stringValue>
               </PascalString>
             </endpoint>
           </OpcuaHelloRequest>

--- a/protocols/opcua/src/test/resources/protocols/opcua/DriverTestsuite.xml
+++ b/protocols/opcua/src/test/resources/protocols/opcua/DriverTestsuite.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+<test:driver-testsuite xmlns:test="https://plc4x.apache.org/schemas/driver-testsuite.xsd"
+                       bigEndian="false">
+
+  <!-- https://base64.guru/converter/encode/hex -->
+
+  <name>Opcua</name>
+
+  <protocolName>opcua</protocolName>
+  <outputFlavor>read-write</outputFlavor>
+
+  <driver-name>opcua</driver-name>
+
+  <testcase>
+    <name>Hello Request Response</name>
+    <steps>
+      <outgoing-plc-message name="Send Opcua Hello Packet">
+        <parser-arguments>
+          <response>false</response>
+        </parser-arguments>
+        <MessagePDU>
+          <messageType dataType="string" bitLength="24" encoding="UTF-8">HEL</messageType>
+          <OpcuaHelloRequest>
+            <chunk dataType="string" bitLength="8" encoding="UTF-8">F</chunk>
+            <messageSize dataType="int" bitLength="32">52</messageSize>
+            <version dataType="int" bitLength="32">0</version>
+            <receiveBufferSize dataType="int" bitLength="32">65535</receiveBufferSize>
+            <sendBufferSize dataType="int" bitLength="32">65535</sendBufferSize>
+            <maxMessageSize dataType="int" bitLength="32">2097152</maxMessageSize>
+            <maxChunkCount dataType="int" bitLength="32">64</maxChunkCount>
+            <endpoint>
+              <PascalString>
+                <sLength dataType="int" bitLength="32">20</sLength>
+                <stringValue dataType="string" bitLength="160" encoding="'UTF-8'">opc.test://hurz:null</stringValue>
+              </PascalString>
+            </endpoint>
+          </OpcuaHelloRequest>
+        </MessagePDU>
+      </outgoing-plc-message>
+      <incoming-plc-message name="Receive Modbus Input-Register Read Response">
+        <parser-arguments>
+          <response>true</response>
+        </parser-arguments>
+        <MessagePDU>
+          <messageType dataType="string" bitLength="24">ACK</messageType>
+          <OpcuaAcknowledgeResponse>
+            <chunk dataType="string" bitLength="8">F</chunk>
+            <messageSize dataType="int" bitLength="32">24</messageSize>
+            <version dataType="int" bitLength="32">0</version>
+            <receiveBufferSize dataType="int" bitLength="32">65535</receiveBufferSize>
+            <sendBufferSize dataType="int" bitLength="32">65535</sendBufferSize>
+            <maxMessageSize dataType="int" bitLength="32">2097152</maxMessageSize>
+            <maxChunkCount dataType="int" bitLength="32">64</maxChunkCount>
+          </OpcuaAcknowledgeResponse>
+        </MessagePDU>
+      </incoming-plc-message>
+      <outgoing-plc-message name="Send Opcua Open Request">
+        <parser-arguments>
+          <response>false</response>
+        </parser-arguments>
+        <MessagePDU>
+          <messageType dataType="string" bitLength="24" encoding="UTF-8">OPN</messageType>
+          <OpcuaOpenRequest>
+            <chunk dataType="string" bitLength="8" encoding="UTF-8">F</chunk>
+            <messageSize dataType="int" bitLength="32">132</messageSize>
+            <secureChannelId dataType="int" bitLength="32">0</secureChannelId>
+            <endpoint>
+              <PascalString>
+                <sLength dataType="int" bitLength="32">47</sLength>
+                <stringValue dataType="string" bitLength="376" encoding="'UTF-8'">http://opcfoundation.org/UA/SecurityPolicy#None</stringValue>
+              </PascalString>
+            </endpoint>
+            <senderCertificate>
+              <PascalByteString>
+                <stringLength dataType="int" bitLength="32">-1</stringLength>
+                <stringValue isList="true">
+                </stringValue>
+              </PascalByteString>
+            </senderCertificate>
+            <receiverCertificateThumbprint>
+              <PascalByteString>
+                <stringLength dataType="int" bitLength="32">-1</stringLength>
+                <stringValue isList="true">
+                </stringValue>
+              </PascalByteString>
+            </receiverCertificateThumbprint>
+            <sequenceNumber dataType="int" bitLength="32">1</sequenceNumber>
+            <requestId dataType="int" bitLength="32">1</requestId>
+            <message isList="true">
+              <value dataType="int" bitLength="8">1</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">-66</value>
+              <value dataType="int" bitLength="8">1</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">13</value>
+              <value dataType="int" bitLength="8">-12</value>
+              <value dataType="int" bitLength="8">3</value>
+              <value dataType="int" bitLength="8">-44</value>
+              <value dataType="int" bitLength="8">-44</value>
+              <value dataType="int" bitLength="8">-41</value>
+              <value dataType="int" bitLength="8">1</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">-1</value>
+              <value dataType="int" bitLength="8">-1</value>
+              <value dataType="int" bitLength="8">-1</value>
+              <value dataType="int" bitLength="8">-1</value>
+              <value dataType="int" bitLength="8">16</value>
+              <value dataType="int" bitLength="8">39</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">1</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">-1</value>
+              <value dataType="int" bitLength="8">-1</value>
+              <value dataType="int" bitLength="8">-1</value>
+              <value dataType="int" bitLength="8">-1</value>
+              <value dataType="int" bitLength="8">0</value>
+              <value dataType="int" bitLength="8">81</value>
+              <value dataType="int" bitLength="8">37</value>
+              <value dataType="int" bitLength="8">2</value>
+            </message>
+          </OpcuaOpenRequest>
+        </MessagePDU>
+      </outgoing-plc-message>
+    </steps>
+  </testcase>
+
+</test:driver-testsuite>

--- a/protocols/opcua/src/test/resources/protocols/opcua/DriverTestsuite.xml
+++ b/protocols/opcua/src/test/resources/protocols/opcua/DriverTestsuite.xml
@@ -26,7 +26,6 @@
 
   <protocolName>opcua</protocolName>
   <outputFlavor>read-write</outputFlavor>
-
   <driver-name>opcua</driver-name>
 
   <testcase>
@@ -55,7 +54,8 @@
           </OpcuaHelloRequest>
         </MessagePDU>
       </outgoing-plc-message>
-      <incoming-plc-message name="Receive Modbus Input-Register Read Response">
+
+      <incoming-plc-message name="Receive Acknowledgement Response">
         <parser-arguments>
           <response>true</response>
         </parser-arguments>
@@ -72,6 +72,7 @@
           </OpcuaAcknowledgeResponse>
         </MessagePDU>
       </incoming-plc-message>
+<!--
       <outgoing-plc-message name="Send Opcua Open Request">
         <parser-arguments>
           <response>false</response>
@@ -104,64 +105,11 @@
             </receiverCertificateThumbprint>
             <sequenceNumber dataType="int" bitLength="32">1</sequenceNumber>
             <requestId dataType="int" bitLength="32">1</requestId>
-            <message isList="true">
-              <value dataType="int" bitLength="8">1</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">-66</value>
-              <value dataType="int" bitLength="8">1</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">13</value>
-              <value dataType="int" bitLength="8">-12</value>
-              <value dataType="int" bitLength="8">3</value>
-              <value dataType="int" bitLength="8">-44</value>
-              <value dataType="int" bitLength="8">-44</value>
-              <value dataType="int" bitLength="8">-41</value>
-              <value dataType="int" bitLength="8">1</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">-1</value>
-              <value dataType="int" bitLength="8">-1</value>
-              <value dataType="int" bitLength="8">-1</value>
-              <value dataType="int" bitLength="8">-1</value>
-              <value dataType="int" bitLength="8">16</value>
-              <value dataType="int" bitLength="8">39</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">1</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">-1</value>
-              <value dataType="int" bitLength="8">-1</value>
-              <value dataType="int" bitLength="8">-1</value>
-              <value dataType="int" bitLength="8">-1</value>
-              <value dataType="int" bitLength="8">0</value>
-              <value dataType="int" bitLength="8">81</value>
-              <value dataType="int" bitLength="8">37</value>
-              <value dataType="int" bitLength="8">2</value>
-            </message>
+            <message dataType="byte" bitLength="424">0x0100be010000f068ddb096d5d7010000000000000000ffffffff10270000000000000000000000000001000000ffffffff00512502</message>
           </OpcuaOpenRequest>
         </MessagePDU>
       </outgoing-plc-message>
+-->
     </steps>
   </testcase>
 


### PR DESCRIPTION
Add back the support for the discovery parameter so that a different host name can be used than the one returned by the server within the endpoint description.

Add initial skeleton for the XMlDriverTestSuite.

Previously no other transport could have been used with OPCUA as TCP was hard coded in the connection string regex. At least the test transport now works.
