### PR TITLE
Fix/plc4j-protocol-ads

### DIFF
--- a/plc4j/protocols/ads/src/main/java/org/apache/plc4x/java/ads/protocol/util/LittleEndianEncoder.java
+++ b/plc4j/protocols/ads/src/main/java/org/apache/plc4x/java/ads/protocol/util/LittleEndianEncoder.java
@@ -187,20 +187,16 @@ public class LittleEndianEncoder {
     }
 
     private static Stream<byte[]> encodeBigInteger(AdsDataType adsDataType, Stream<BigInteger> bigIntegerStream) {
-        // TODO: add boundchecks and add optional extension
         return bigIntegerStream
+            .peek(value -> {
+                if (value.longValue() < adsDataType.getLowerBound().longValue() || value.longValue() > adsDataType.getUpperBound().longValue())
+                    throw new PlcRuntimeException(value + " not within bounds of " + adsDataType);
+            })
             .map(bigIntValue -> {
                 byte[] bytes = bigIntValue.toByteArray();
-                if (bytes.length > 1 && bytes[0] == 0x0) {
-                    byte[] subArray = Arrays.copyOf(ArrayUtils.subarray(bytes, 1, bytes.length), adsDataType.getTargetByteSize());
-                    ArrayUtils.reverse(subArray);
-                    return subArray;
-                } else {
-                    ArrayUtils.reverse(Arrays.copyOf(bytes, adsDataType.getTargetByteSize()));
-                    return bytes;
-                }
-            })
-            .map(bytes -> Arrays.copyOf(bytes, adsDataType.getTargetByteSize()));
+                ArrayUtils.reverse(bytes); /* reverse first, so we don't truncate the wrong end */
+                return Arrays.copyOf(bytes, adsDataType.getTargetByteSize());
+            });
     }
 
     private static Stream<byte[]> encodeLocalTime(AdsDataType adsDataType, Stream<LocalTime> localTimeStream) {


### PR DESCRIPTION
Hi,
writing some WORDs with ADS gave me odd results. This is how I've tested my fix:

```
byte[] convertToByteArrayLE(BigInteger bigIntValue, int targetSize){
	byte[] bytes = bigIntValue.toByteArray();
	ArrayUtils.reverse(bytes);
	return Arrays.copyOf(bytes, targetSize);
}
@Test
void encodeBigInteger(){
	assertArrayEquals(new byte[]{1, 0}, convertToByteArrayLE(BigInteger.valueOf(1), 2)); /* one byte input */
	assertArrayEquals(new byte[]{-128, 0,}, convertToByteArrayLE(BigInteger.valueOf(128), 2)); /* one byte plus sign byte */
	assertArrayEquals(new byte[]{0, 2}, convertToByteArrayLE(BigInteger.valueOf((512)), 2)); /* two bytes, no sign byte */
	assertArrayEquals(new byte[]{-1, -1}, convertToByteArrayLE(BigInteger.valueOf((65535)), 2)); /* end of 16 bit range */
	assertArrayEquals(new byte[]{0, 0}, convertToByteArrayLE(BigInteger.valueOf((65536)), 2)); /* three byte input -> overflow */
	assertArrayEquals(new byte[]{1, 0}, convertToByteArrayLE(BigInteger.valueOf((65537)), 2)); /* three byte input -> overflow */
	assertArrayEquals(new byte[]{1, 0, 1, 0}, convertToByteArrayLE(BigInteger.valueOf((65537)), 4)); /* three bytes, expanded to four */
}

```


Best regards,
Richard