### PR TITLE
Add test for syncronized TransactionHandler

### DIFF
--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannelTransactionManager.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannelTransactionManager.java
@@ -36,8 +36,8 @@ public class SecureChannelTransactionManager {
     private AtomicInteger activeTransactionId = new AtomicInteger(0);
     private Map<Integer, Transaction> queue = new HashMap<>();
 
-    public void submit(Consumer<Integer> onSend, Integer transactionId) {
-        LOGGER.info("New Transaction Submitted {}", activeTransactionId.get());
+    public synchronized void submit(Consumer<Integer> onSend, Integer transactionId) {
+        LOGGER.info("Active transaction Number {}", activeTransactionId.get());
         if (activeTransactionId.get() == transactionId) {
             onSend.accept(transactionId);
             int newTransactionId = getActiveTransactionIdentifier();


### PR DESCRIPTION
If the submit function in SecureChannelTransactionHandler is called again before the previous thread has finished then a message is added to the queue. As this method relies on it being called again with a message with the active transaction number, this never happens as the message has already been added to the queue.

I have added the synchronised keyword to the method so this shouldn't happen.