### PR TITLE
URLDecoder.decode compatible with JDK 8

### DIFF
--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/configuration/ConfigurationFactory.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/configuration/ConfigurationFactory.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.plc4x.java.spi.configuration.annotations.*;
 import org.apache.plc4x.java.spi.configuration.annotations.defaults.*;
 
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;
@@ -106,6 +107,8 @@ public class ConfigurationFactory {
             }
         } catch (IllegalAccessException e) {
             throw new IllegalArgumentException("Unable to access all fields from Configuration Class '" + pClazz.getSimpleName() + "'", e);
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalArgumentException("Unsupported encoding");
         }
         return instance;
     }

--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/configuration/ConfigurationFactory.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/configuration/ConfigurationFactory.java
@@ -87,7 +87,7 @@ public class ConfigurationFactory {
                 if (paramStringValues.containsKey(configName)) {
                     String stringValue = paramStringValues.get(configName).get(0);
                     // As the arguments might be URL encoded, be sure it's decoded.
-                    stringValue = URLDecoder.decode(stringValue, StandardCharsets.UTF_8);
+                    stringValue = URLDecoder.decode(stringValue, "UTF-8");
                     FieldUtils.writeField(instance, field.getName(), toFieldValue(field, stringValue), true);
                     missingFieldNames.remove(configName);
                 } else {


### PR DESCRIPTION
public static String decode​(String s, Charset charset) since 10 (https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/net/URLDecoder.html#decode(java.lang.String,java.nio.charset.Charset)) , in Android throws java.lang.NoSuchMethodError.