### PR TITLE
fix(docs): Updated the pcap docs for when setting up a developer env

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See the PLC4J user guide on the website to start using PLC4X in your Java applic
 Currently, the project is configured to require the following software:
 
 1. Java 11 JDK: For running Maven in general as well as compiling the Java and Scala modules `JAVA_HOME` configured to point to that.
-2. libpcap/WinPcap for raw socket tests in Java or use of `passive-mode` drivers
+2. libpcap/Npcap for raw socket tests in Java or use of `passive-mode` drivers
 3. (Optional) [Graphviz](https://www.graphviz.org/) : For generating the graphs in the documentation
 4. Git (even when working on the source distribution)
 
@@ -156,7 +156,7 @@ Some tools need to be installed before being able to build on Windows:
 * Flex (for `with-cpp` profiles)
 * Python 2.7 (for `with-python`, `with-proxies` profiles)
 * Dotnet (for `with-dotnet` profiles)
-* WinPCAP
+* Npcap
 * OpenSSL
 
 We have tested `WinBuilds` with the bundle of: http://win-builds.org/doku.php/download_and_installation_from_windows
@@ -185,9 +185,9 @@ For `.Net`, you need the `Developer Pack` in order to build .Net applications. S
 
 If you're building a source-distribution and haven't installed git yet, be sure to do so.
 
-The Windows version of the PCAP library can be found here: https://sourceforge.net/projects/winpcap413-176/
-(In order to read PCAPNG files we require a libpcap version 1.1.0 or greater. The default
-Windows version is 1.0. At this location there is a patched version based on libpcap 1.7.4)
+The Windows version of the PCAP library can be found here: https://npcap.com/ . 
+Additional tasks to enable Java to find the pcap executables may need to be done.
+Follow the instructions here https://github.com/kaitoy/pcap4j#about-native-library-loading
 
 Last not least we need to install OpenSSL, which is available from here: https://indy.fulgan.com/SSL/
 The letter at the end of the version is sort of a "sub-minor" version, so I usually just take the version with the highest letter.

--- a/plc4j/protocols/src/site/asciidoc/developers/implementing-drivers.adoc
+++ b/plc4j/protocols/src/site/asciidoc/developers/implementing-drivers.adoc
@@ -150,7 +150,7 @@ It is what comes with Netty out of the box and should be used if possible.
 This is a special form of connector that allows implementing protocols below the TCP level.
 This is also where things start getting a little more complicated.
 As Java doesn't support communication below TCP and UDP, this option makes use of the `Java Native Interface (JNI)` to access native libs that then implement the functionality on OS level.
-The library used for this is called `libpcap` (for Linux and Mac) or `winpcap` for Windows.
+The library used for this is called `libpcap` (for Linux and Mac) or `npcap` for Windows.
 Also as creating of raw sockets requires elevated user permissions the application has to be run as `root` or (preferred option) the library has to be setup to run with root privileges (`setuid`).
 
 When setup correctly the raw socket connector allows implementing protocols right down to manually constructing `Ehternet` frames.

--- a/plc4j/utils/test-utils/src/main/java/org/apache/plc4x/test/RequirePcapCondition.java
+++ b/plc4j/utils/test-utils/src/main/java/org/apache/plc4x/test/RequirePcapCondition.java
@@ -47,7 +47,7 @@ public class RequirePcapCondition implements ExecutionCondition {
             logger.info("Error detecting libpcap version.", e);
         }
         if (SystemUtils.IS_OS_WINDOWS) {
-            return ConditionEvaluationResult.disabled("Test disabled due to missing or invalid WinPcap version. Please install from here: https://sourceforge.net/projects/winpcap413-176/ as this version supports all needed features.");
+            return ConditionEvaluationResult.disabled("Test disabled due to missing or invalid Npcap version. Please install from here: https://npcap.com/ as this version supports all needed features.");
         } else {
             return ConditionEvaluationResult.disabled("Test disabled due to missing or invalid libpcap version. Please install at least version 1.1.0 to support all features.");
         }

--- a/plc4j/utils/test-utils/src/main/java/org/apache/plc4x/test/RequirePcapNgCondition.java
+++ b/plc4j/utils/test-utils/src/main/java/org/apache/plc4x/test/RequirePcapNgCondition.java
@@ -38,7 +38,7 @@ public class RequirePcapNgCondition implements ExecutionCondition {
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
         // Mac:     libpcap version 1.8.1 -- Apple version 79.200.4
         // Linux:
-        // Windows: WinPcap version 4.1.3 (packet.dll version 4.1.0.2980), based on libpcap version 1.0 branch 1_0_rel0b (20091008)
+        // Windows: NPcap version 1.6.0
         try {
             String libVersion = Pcaps.libVersion();
             Pattern pattern = Pattern.compile("^.*libpcap version (?<version>\\d+\\.\\d+(?:\\.\\d+)?)[^\\d]?.*$");
@@ -50,7 +50,7 @@ public class RequirePcapNgCondition implements ExecutionCondition {
                 if (curVersion.compareTo(minVersion) >= 0) {
                     return ConditionEvaluationResult.enabled("Found libpcap version " + versionString);
                 } else if (SystemUtils.IS_OS_WINDOWS) {
-                    return ConditionEvaluationResult.disabled("Test disabled due to too old WinPcap version. Please install at least version 1.1.0 to support all features. Please install from here: https://sourceforge.net/projects/winpcap413-176/ as this version supports all needed features.");
+                    return ConditionEvaluationResult.disabled("Test disabled due to too old Npcap version. Please install from here: https://npcap.com/ as this version supports all needed features.");
                 } else {
                     return ConditionEvaluationResult.disabled("Test disabled due to too old libpcap version. Please install at least version 1.1.0 to support all features.");
                 }
@@ -59,7 +59,7 @@ public class RequirePcapNgCondition implements ExecutionCondition {
             logger.info("Error detecting libpcap version.", e);
         }
         if(SystemUtils.IS_OS_WINDOWS) {
-            return ConditionEvaluationResult.disabled("Test disabled due to missing or invalid WinPcap version. Please install from here: https://sourceforge.net/projects/winpcap413-176/ as this version supports all needed freatures.");
+            return ConditionEvaluationResult.disabled("Test disabled due to missing or invalid Npcap version. Please install from here: https://npcap.com/ as this version supports all needed freatures.");
         } else {
             return ConditionEvaluationResult.disabled("Test disabled due to missing or invalid libpcap version. Please install at least version 1.1.0 to support all features.");
         }

--- a/src/main/script/prerequisiteCheck.groovy
+++ b/src/main/script/prerequisiteCheck.groovy
@@ -607,5 +607,5 @@ println ""
 
 // Things we could possibly check:
 // - DNS Providers that return a default ip on unknown host-names
-// - Availability and version of LibPCAP/WinPCAP
+// - Availability and version of LibPCAP/NPCAP
 

--- a/src/site/asciidoc/developers/preparing/index.adoc
+++ b/src/site/asciidoc/developers/preparing/index.adoc
@@ -45,7 +45,7 @@ TIP: Currently Maven 3.6 and above is required for being able to build all parts
 | Profile        | Description                                              | Requirements
 |                | Builds Java API, drivers, integrations, examples        a|
 * Git
-* LibPCAP (Optional)
+* LibPCAP
 | `with-cpp`     | Builds C++ API, drivers, integrations, examples         a|
 * gcc
 * g++

--- a/src/site/asciidoc/developers/preparing/windows.adoc
+++ b/src/site/asciidoc/developers/preparing/windows.adoc
@@ -29,19 +29,11 @@ In order to install it, please download end execute the installer from https://g
 
 === LibPCAP
 
-A special version of LibPCAP is available for Windows, which is called WinPCAP.
-It is available from https://www.winpcap.org/[here].
+A special version of LibPCAP is available for Windows, which is called Npcap.
+It is available from https://npcap.com/[here].
 
-However this is a based on a very old version (1.0) of LibPCAP and in order to read PCAPNG files we require a libpcap version 1.1.0 or greater.
-A patched windows version can be found here: https://sourceforge.net/projects/winpcap413-176/
-(At this location is a patched version based on libpcap 1.7.4)
-
-So in order to install things correctly:
-
-1. install the version WinPCP from above location.
-2. Then download the patched version from the sourceforge link and unpack it somewhere.
-3. After that copy bin\x64\wpcap.dll from archive to \Windows\System32
-4. Copy bin\wpcap.dll from archive to \Windows\SysWOW64
+Additional tasks to enable Java to find the pcap executables may need to be done.
+Follow the instructions https://github.com/kaitoy/pcap4j#about-native-library-loading[here]
 
 After this all should be working.
 


### PR DESCRIPTION
The Npcap library seems to be maintained, however it looks like the license is a bit odd so we shouldn't use it.
This PR was to replace any comments about WinPcap with Npcap.