### PR TITLE
Upgrade Apache Camel to version 3.14.1

### DIFF
--- a/plc4j/integrations/apache-camel/pom.xml
+++ b/plc4j/integrations/apache-camel/pom.xml
@@ -33,7 +33,7 @@
   <description>Integration module for integrating PLC4X into Apache Camel.</description>
 
   <properties>
-    <camel.version>3.14.0</camel.version>
+    <camel.version>3.14.1</camel.version>
   </properties>
 
   <build>


### PR DESCRIPTION
This is just a little upgrade. We are about to release 3.14.2. 3.14.x is an LTS branch, the next LTS will be 3.17.0, so I do think PLC4X will stay on 3.14.x for a while.