### PR TITLE
fix(plc4go/codegen): DefaultPlcWriteRequest interface conversion, cau…

### DIFF
--- a/plc4go/internal/plc4go/spi/model/DefaultPlcWriteRequest.go
+++ b/plc4go/internal/plc4go/spi/model/DefaultPlcWriteRequest.go
@@ -165,6 +165,14 @@ func (m DefaultPlcWriteRequest) Execute() <-chan model.PlcWriteRequestResult {
 	return resultChannel
 }
 
+func (m DefaultPlcWriteRequest) GetWriter() spi.PlcWriter {
+	return m.writer
+}
+
+func (m DefaultPlcWriteRequest) GetWriteRequestInterceptor() interceptors.WriteRequestInterceptor {
+	return m.writeRequestInterceptor
+}
+
 func (m DefaultPlcWriteRequest) GetValue(name string) values.PlcValue {
 	return m.values[name]
 }


### PR DESCRIPTION
…se it not implement
1. Description: When I try to write more than one data, the program panic.
> `...
writeRequest, err := connection.WriteRequestBuilder().AddQuery("field1", "400005:UINT", uint16(9900)).AddQuery("field2", "400006:UINT", uint16(9988)).Build()
...`

3. Error message:
> (1) panic: interface conversion: model.DefaultPlcWriteRequest is not interceptors.WriterExposer: missing method GetWriter
> (2)panic: interface conversion: model.DefaultPlcWriteRequest is not interceptors.WriteRequestInterceptorExposer: missing method GetWriteRequestInterceptor

4. Result: So I implemented them, and multiple writes to the data were successful!

