### PR TITLE
fix(plc4go/codegen): Truly close connection

### DIFF
--- a/plc4go/internal/plc4go/spi/default/DefaultConnection.go
+++ b/plc4go/internal/plc4go/spi/default/DefaultConnection.go
@@ -255,10 +255,11 @@ func (d *defaultConnection) BlockingClose() {
 
 func (d *defaultConnection) Close() <-chan plc4go.PlcConnectionCloseResult {
 	log.Trace().Msg("close connection")
+	err := d.GetTransportInstance().Close()
 	d.SetConnected(false)
 	ch := make(chan plc4go.PlcConnectionCloseResult)
 	go func() {
-		ch <- NewDefaultPlcConnectionCloseResult(d.GetConnection(), nil)
+		ch <- NewDefaultPlcConnectionCloseResult(d.GetConnection(), err)
 	}()
 	return ch
 }


### PR DESCRIPTION
When closing the connection and reconnecting, it keeps reporting "Connection refused" error, and after checking, I found that the Close function does not really close the connection.