### PR TITLE
Correct an invalid example in `modbus.adoc`

### DIFF
--- a/src/site/asciidoc/users/protocols/modbus.adoc
+++ b/src/site/asciidoc/users/protocols/modbus.adoc
@@ -76,11 +76,11 @@
 
 Modbus has the following connection string format:-
 ----
-modbus-tcp:{transport}://{ip-address}:{port}?{options}
+modbus:{transport}://{ip-address}:{port}?{options}
 ----
 An example connection string would look like:-
 ----
-modbus-tcp:tcp://127.0.0.1:502
+modbus:tcp://127.0.0.1:502
 ----
 Note the transport, port and option fields are optional.
 


### PR DESCRIPTION
Corrected an invalid example as follows:

`modbus-tcp:tcp://127.0.0.1:502` -> `modbus:tcp://127.0.0.1:502`