### PR TITLE
Update Dockerfile inline with requirments script changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN apt install -y dotnet-sdk-6.0
 RUN apt install -y golang
 
 # Required for "with-python" profile
-RUN apt install -y python-setuptools python
+RUN apt install -y python-setuptools python3 python-is-python3
 
 # Required for running on Windows systems
 RUN apt install -y dos2unix

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apt install -y software-properties-common
 RUN add-apt-repository universe -y
 RUN apt install -y apt-transport-https
 RUN apt update -y
-RUN apt install -y dotnet-sdk-3.1
+RUN apt install -y dotnet-sdk-6.0
 
 # Required for "with-go" profile
 RUN apt install -y golang


### PR DESCRIPTION
As I was using Dockerbased build to validate work on [PR386](https://github.com/apache/plc4x/pull/386), I noticed build stuck on requirements script checks that were not being met. 

This PR helps gets more up to date requirements installed, however it does fail in the same place PR check and my local builds.

But it seem worth sharing as it get Dockerfile based build farther than it is now