### PR TITLE
fixed copy-paste error in s7 config options

### DIFF
--- a/plc4go/internal/s7/Configuration.go
+++ b/plc4go/internal/s7/Configuration.go
@@ -20,9 +20,10 @@
 package s7
 
 import (
+	"strconv"
+
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
-	"strconv"
 )
 
 type Configuration struct {
@@ -54,7 +55,7 @@ func ParseFromOptions(options map[string][]string) (Configuration, error) {
 		}
 		configuration.localRack = int32(parsedInt)
 	}
-	if localSlotString := getFromOptions(options, "local-rack"); localSlotString != "" {
+	if localSlotString := getFromOptions(options, "local-slot"); localSlotString != "" {
 		parsedInt, err := strconv.ParseInt(localSlotString, 10, 32)
 		if err != nil {
 			return Configuration{}, errors.Wrap(err, "Error parsing local-slot")
@@ -68,7 +69,7 @@ func ParseFromOptions(options map[string][]string) (Configuration, error) {
 		}
 		configuration.remoteRack = int32(parsedInt)
 	}
-	if remoteSlotString := getFromOptions(options, "remote-rack"); remoteSlotString != "" {
+	if remoteSlotString := getFromOptions(options, "remote-slot"); remoteSlotString != "" {
 		parsedInt, err := strconv.ParseInt(remoteSlotString, 10, 32)
 		if err != nil {
 			return Configuration{}, errors.Wrap(err, "Error parsing remote-slot")


### PR DESCRIPTION
There has been a copy-paste bug in s7 options factory. "local-rack" option has been used for rack & slot variable. same with "remote-rack". 

I'm not a big go developer, auto formatter messed up formatting in import statement...