### PR TITLE
fix(plc4j/opcua): not to get String.length but to calculate length in…

### DIFF
--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/readwrite/utils/StaticHelper.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/readwrite/utils/StaticHelper.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, (byte) Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, (byte) WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, (byte) either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.plc4x.java.opcua.readwrite.utils;
+
+import java.nio.charset.StandardCharsets;
+
+public class StaticHelper {
+
+    // Calculating length in UTF-8
+    public static int utf8Length(String stringValue) {
+        return stringValue == null ? -1 : stringValue.getBytes(StandardCharsets.UTF_8).length;
+    }
+}

--- a/protocols/opcua/src/main/xslt/opc-manual.xsl
+++ b/protocols/opcua/src/main/xslt/opc-manual.xsl
@@ -381,9 +381,9 @@
 ]
 
 [type PascalString
-    [implicit int 32 sLength          'stringValue.length == 0 ? -1 : stringValue.length']
+    [implicit int 32 sLength          'STATIC_CALL("utf8Length", stringValue) == 0 ? -1 : STATIC_CALL("utf8Length", stringValue)']
     [simple vstring 'sLength == -1 ? 0 : sLength * 8' stringValue]
-    [virtual  int 32 stringLength     'stringValue.length == -1 ? 0 : stringValue.length']
+    [virtual  int 32 stringLength     'STATIC_CALL("utf8Length", stringValue) == -1 ? 0 : STATIC_CALL("utf8Length", stringValue)']
 ]
 
 [type PascalByteString


### PR DESCRIPTION
Not to get String.length but to calculate length in UTF-8 for Pascal string length (support node id contains unicode characters).

fix the issue [https://github.com/apache/plc4x/issues/568](https://github.com/apache/plc4x/issues/568)

Thanks for reviewing the code.