### PR TITLE
fix: Always install sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -826,6 +826,11 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <executions>
           <execution>
@@ -867,6 +872,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -1237,7 +1243,7 @@
             <outputEncoding>${project.reporting.outputencoding}</outputEncoding>
             <!--
               IntelliJ can't find the asciidoc config option in the site plugin, which is correct.
-              However, this config section is used by the asciidoctor site plugin extension. So plead
+              However, this config section is used by the asciidoctor site plugin extension. So please
               ignore this error, it's actually ok.
             -->
             <asciidoc>


### PR DESCRIPTION
The releases publish the sources.jar along side the binary jar files as can be seen here:
https://repo1.maven.org/maven2/org/apache/plc4x/plc4j-api/0.10.0/

The snapshot releases however do no have the sources.jar:
https://repository.apache.org/content/repositories/snapshots/org/apache/plc4x/plc4j-api/0.11.0-SNAPSHOT/

This makes debugging an application that uses the latest snapshot needlessly hard.

This pull request simply generates and publishes the source jar on verify/install.