### PR TITLE
Limit modbus quantity

### DIFF
--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagCoil.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagCoil.java
@@ -84,6 +84,10 @@ public class ModbusTagCoil extends ModbusTag {
             throw new IllegalArgumentException("Last requested address is out of range, should be between " + PROTOCOL_ADDRESS_OFFSET + " and " + REGISTER_MAXADDRESS + ". Was " + (address + PROTOCOL_ADDRESS_OFFSET + (quantity - 1)));
         }
 
+        if (quantity > 2000) {
+            throw new IllegalArgumentException("quantity may not be larger than 2000. Was " + quantity);
+        }
+
         ModbusDataType dataType = (matcher.group("datatype") != null) ? ModbusDataType.valueOf(matcher.group("datatype")) : ModbusDataType.BOOL;
 
         return new ModbusTagCoil(address, quantity, dataType);

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagDiscreteInput.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagDiscreteInput.java
@@ -84,6 +84,10 @@ public class ModbusTagDiscreteInput extends ModbusTag {
             throw new IllegalArgumentException("Last requested address is out of range, should be between " + PROTOCOL_ADDRESS_OFFSET + " and " + REGISTER_MAX_ADDRESS + ". Was " + (address + PROTOCOL_ADDRESS_OFFSET + (quantity - 1)));
         }
 
+        if (quantity > 2000) {
+            throw new IllegalArgumentException("quantity may not be larger than 2000. Was " + quantity);
+        }
+
         ModbusDataType dataType = (matcher.group("datatype") != null) ? ModbusDataType.valueOf(matcher.group("datatype")) : ModbusDataType.BOOL;
 
         return new ModbusTagDiscreteInput(address, quantity, dataType);

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagExtendedRegister.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagExtendedRegister.java
@@ -84,6 +84,10 @@ public class ModbusTagExtendedRegister extends ModbusTag {
             throw new IllegalArgumentException("Last requested address is out of range, should be between 0 and " + REGISTER_MAXADDRESS + ". Was " + (address + (quantity - 1)));
         }
 
+        if (quantity > 125) {
+            throw new IllegalArgumentException("quantity may not be larger than 125. Was " + quantity);
+        }
+
         ModbusDataType dataType = (matcher.group("datatype") != null) ? ModbusDataType.valueOf(matcher.group("datatype")) : ModbusDataType.INT;
 
         return new ModbusTagExtendedRegister(address, quantity, dataType);

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagHoldingRegister.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagHoldingRegister.java
@@ -83,6 +83,10 @@ public class ModbusTagHoldingRegister extends ModbusTag {
             throw new IllegalArgumentException("Last requested address is out of range, should be between " + PROTOCOL_ADDRESS_OFFSET + " and " + REGISTER_MAXADDRESS + ". Was " + (address + PROTOCOL_ADDRESS_OFFSET + (quantity - 1)));
         }
 
+        if (quantity > 125) {
+            throw new IllegalArgumentException("quantity may not be larger than 125. Was " + quantity);
+        }
+
         ModbusDataType dataType = (matcher.group("datatype") != null) ? ModbusDataType.valueOf(matcher.group("datatype")) : ModbusDataType.INT;
 
         return new ModbusTagHoldingRegister(address, quantity, dataType);

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagInputRegister.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagInputRegister.java
@@ -83,6 +83,10 @@ public class ModbusTagInputRegister extends ModbusTag {
             throw new IllegalArgumentException("Last requested address is out of range, should be between " + PROTOCOL_ADDRESS_OFFSET + " and " + REGISTER_MAXADDRESS + ". Was " + (address + PROTOCOL_ADDRESS_OFFSET + (quantity - 1)));
         }
 
+        if (quantity > 125) {
+            throw new IllegalArgumentException("quantity may not be larger than 125. Was " + quantity);
+        }
+
         ModbusDataType dataType = (matcher.group("datatype") != null) ? ModbusDataType.valueOf(matcher.group("datatype")) : ModbusDataType.INT;
 
         return new ModbusTagInputRegister(address, quantity, dataType);

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/rtu/config/ModbusRtuConfiguration.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/rtu/config/ModbusRtuConfiguration.java
@@ -57,7 +57,9 @@ public class ModbusRtuConfiguration implements Configuration, TcpTransportConfig
 
     @Override
     public String toString() {
-        return "Configuration{" +
+        return "ModbusRtuConfiguration{" +
+            "requestTimeout=" + requestTimeout +
+            ", unitIdentifier=" + unitIdentifier +
             '}';
     }
 

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/tcp/config/ModbusTcpConfiguration.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/tcp/config/ModbusTcpConfiguration.java
@@ -57,7 +57,9 @@ public class ModbusTcpConfiguration implements Configuration, TcpTransportConfig
 
     @Override
     public String toString() {
-        return "Configuration{" +
+        return "ModbusTcpConfiguration{" +
+            "requestTimeout=" + requestTimeout +
+            ", unitIdentifier=" + unitIdentifier +
             '}';
     }
 

--- a/plc4j/drivers/modbus/src/test/java/org/apache/plc4x/java/modbus/ModbusTagTest.java
+++ b/plc4j/drivers/modbus/src/test/java/org/apache/plc4x/java/modbus/ModbusTagTest.java
@@ -19,49 +19,73 @@
 package org.apache.plc4x.java.modbus;
 
 import org.apache.plc4x.java.modbus.base.tag.*;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ModbusTagTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ModbusTagTest {
 
     @Test
-    public void testHolding_INT_ARRAY_RANGE() {
-        for (int i = 1; i < 125; i++) {
+    void testHolding_INT_ARRAY_RANGE() {
+        for (int i = 1; i <= 125; i++) {
           final ModbusTagHoldingRegister holdingregister = ModbusTagHoldingRegister.of("400001:INT[" + i + "]");
-          Assertions.assertEquals(i, holdingregister.getNumberOfElements());
+          assertEquals(i, holdingregister.getNumberOfElements());
         }
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            ModbusTagHoldingRegister.of("400001:INT[126]");
+        });
+        assertTrue(exception.getMessage().startsWith("quantity may not be larger than "));
     }
 
     @Test
-    public void testInput_INT_ARRAY_RANGE() {
-        for (int i = 1; i < 125; i++) {
+    void testInput_INT_ARRAY_RANGE() {
+        for (int i = 1; i <= 125; i++) {
           final ModbusTagInputRegister inputregister = ModbusTagInputRegister.of("300001:INT[" + i + "]");
-          Assertions.assertEquals(i, inputregister.getNumberOfElements());
+          assertEquals(i, inputregister.getNumberOfElements());
         }
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            ModbusTagInputRegister.of("300001:INT[126]");
+        });
+        assertTrue(exception.getMessage().startsWith("quantity may not be larger than "));
     }
 
     @Test
-    public void testExtended_INT_ARRAY_RANGE() {
-        for (int i = 1; i < 125; i++) {
+    void testExtended_INT_ARRAY_RANGE() {
+        for (int i = 1; i <= 125; i++) {
           final ModbusTagExtendedRegister extendedRegister = ModbusTagExtendedRegister.of("600001:INT[" + i + "]");
-          Assertions.assertEquals(i, extendedRegister.getNumberOfElements());
+          assertEquals(i, extendedRegister.getNumberOfElements());
         }
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            ModbusTagExtendedRegister.of("600001:INT[126]");
+        });
+        assertTrue(exception.getMessage().startsWith("quantity may not be larger than "));
     }
 
     @Test
-    public void testCoil_INT_ARRAY_RANGE() {
-        for (int i = 1; i < 2000; i++) {
+    void testCoil_INT_ARRAY_RANGE() {
+        for (int i = 1; i <= 2000; i++) {
           final ModbusTagCoil coil = ModbusTagCoil.of("000001:BOOL[" + i + "]");
-          Assertions.assertEquals(i, coil.getNumberOfElements());
+          assertEquals(i, coil.getNumberOfElements());
         }
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            ModbusTagCoil.of("000001:BOOL[2001]");
+        });
+        assertTrue(exception.getMessage().startsWith("quantity may not be larger than "));
     }
 
     @Test
-    public void testDiscreteInput_INT_ARRAY_RANGE() {
-        for (int i = 1; i < 2000; i++) {
+    void testDiscreteInput_INT_ARRAY_RANGE() {
+        for (int i = 1; i <= 2000; i++) {
           final ModbusTagDiscreteInput discreteInput = ModbusTagDiscreteInput.of("100001:BOOL[" + i + "]");
-          Assertions.assertEquals(i, discreteInput.getNumberOfElements());
+          assertEquals(i, discreteInput.getNumberOfElements());
         }
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            ModbusTagDiscreteInput.of("100001:BOOL[2001]");
+        });
+        assertTrue(exception.getMessage().startsWith("quantity may not be larger than "));
     }
 
 }

--- a/plc4j/drivers/modbus/src/test/resources/logback-test.xml
+++ b/plc4j/drivers/modbus/src/test/resources/logback-test.xml
@@ -29,7 +29,7 @@
     </encoder>
   </appender>
 
-  <root level="debuc">
+  <root level="debug">
     <appender-ref ref="STDOUT" />
   </root>
 


### PR DESCRIPTION
When requesting too many registers in a single modbus request the request will fail with a very unclear modbus error from the actual device at hand.

The modbus specification ([pdf](https://www.modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf)) documents limits of at most 125 registers or 2000 coils in a single request which matches with the limits I have observed in the modbus enabled appliance I have here.

This change will simply let the application fail before making the connection instead of the actual device returning a very unclear modbus error.
