### PR TITLE
fix: Improve java example

### DIFF
--- a/plc4j/examples/hello-world-plc4x-read/src/main/java/org/apache/plc4x/java/examples/helloplc4x/read/HelloPlc4xRead.java
+++ b/plc4j/examples/hello-world-plc4x-read/src/main/java/org/apache/plc4x/java/examples/helloplc4x/read/HelloPlc4xRead.java
@@ -26,8 +26,6 @@ import org.apache.plc4x.java.api.types.PlcResponseCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.TimeUnit;
-
 public class HelloPlc4xRead {
 
     private static final Logger logger = LoggerFactory.getLogger(HelloPlc4xRead.class);
@@ -77,21 +75,21 @@ public class HelloPlc4xRead {
             //////////////////////////////////////////////////////////
             // Read asynchronously ...
             // Register a callback executed as soon as a response arrives.
-            /*logger.info("Asynchronous request ...");
-            CompletionStage<? extends PlcReadResponse> asyncResponse = readRequest.execute();
-            asyncResponse.whenComplete((readResponse, throwable) -> {
-                if (readResponse != null) {
-                    printResponse(readResponse);
-                } else {
-                    logger.error("An error occurred: " + throwable.getMessage(), throwable);
-                }
-            });*/
-
-            // Give the async request a little time...
-            TimeUnit.MILLISECONDS.sleep(1000);
-            plcConnection.close();
-            System.exit(0);
+//            logger.info("Asynchronous request ...");
+//            CompletableFuture<? extends PlcReadResponse> asyncResponse = readRequest.execute();
+//            asyncResponse.whenComplete((readResponse, throwable) -> {
+//                if (readResponse != null) {
+//                    printResponse(readResponse);
+//                } else {
+//                    logger.error("An error occurred: " + throwable.getMessage(), throwable);
+//                }
+//              });
+//
+//            // Wait until the async request has finished
+//            asyncResponse.get();
         }
+        // This is needed to avoid a known problem that an application may hang indefinitely.
+        System.exit(0);
     }
 
     private static void printResponse(PlcReadResponse response) {


### PR DESCRIPTION
Some improvements in the example:
- No need for close in a try-with-resources block.
- Move the exit outside the try-with-resources block. 
- Use the CompletableFuture (which is the actual return type of execute) which has a `get()` that waits for the completion --> no need for an unreliable sleep.
- Document the need for the exit explicitly