### PR TITLE
fix(plc4j/modbus): Cleanup of ModbusTag

### DIFF
--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTag.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTag.java
@@ -48,8 +48,6 @@ public abstract class ModbusTag implements PlcTag, Serializable {
 
     private final ModbusDataType dataType;
 
-    private final String addressStringPrefix;
-
     public static ModbusTag of(String addressString) {
         if (ModbusTagCoil.matches(addressString)) {
             return ModbusTagCoil.of(addressString);
@@ -71,7 +69,7 @@ public abstract class ModbusTag implements PlcTag, Serializable {
 
     @Override
     public String getAddressString() {
-        String address = String.format("%s%05d", addressStringPrefix, getLogicalAddress());
+        String address = String.format("%s%05d", getAddressStringPrefix(), getLogicalAddress());
         if(getDataType() != null) {
             address += ":" + getDataType().name();
         }
@@ -81,13 +79,15 @@ public abstract class ModbusTag implements PlcTag, Serializable {
         return address;
     }
 
+    protected abstract String getAddressStringPrefix();
+
     /**
      * Instantiate a new ModbusTag
      * @param address The WIRE address that is to be used.
      * @param quantity The number of registers
      * @param dataType The type for the interpretation of the registers.
      */
-    protected ModbusTag(int address, Integer quantity, ModbusDataType dataType, String addressStringPrefix) {
+    protected ModbusTag(int address, Integer quantity, ModbusDataType dataType) {
         this.address = address;
         if (getLogicalAddress() <= 0) {
             throw new IllegalArgumentException("address must be greater than zero. Was " + getLogicalAddress());
@@ -97,7 +97,6 @@ public abstract class ModbusTag implements PlcTag, Serializable {
             throw new IllegalArgumentException("quantity must be greater than zero. Was " + this.quantity);
         }
         this.dataType = dataType != null ? dataType : ModbusDataType.INT;
-        this.addressStringPrefix = addressStringPrefix;
     }
 
     /**

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTag.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTag.java
@@ -40,13 +40,15 @@ public abstract class ModbusTag implements PlcTag, Serializable {
     public static final Pattern ADDRESS_PATTERN = Pattern.compile("(?<address>\\d+)(:(?<datatype>[a-zA-Z_]+))?(\\[(?<quantity>\\d+)])?");
     public static final Pattern FIXED_DIGIT_MODBUS_PATTERN = Pattern.compile("(?<address>\\d{4,5})?(:(?<datatype>[a-zA-Z_]+))?(\\[(?<quantity>\\d+)])?");
 
-    protected static final int PROTOCOL_ADDRESS_OFFSET = 1;
+    public static final int PROTOCOL_ADDRESS_OFFSET = 1;
 
     private final int address;
 
     private final int quantity;
 
     private final ModbusDataType dataType;
+
+    private final String addressStringPrefix;
 
     public static ModbusTag of(String addressString) {
         if (ModbusTagCoil.matches(addressString)) {
@@ -67,21 +69,50 @@ public abstract class ModbusTag implements PlcTag, Serializable {
         throw new PlcInvalidTagException("Unable to parse address: " + addressString);
     }
 
-    protected ModbusTag(int address, Integer quantity, ModbusDataType dataType) {
+    @Override
+    public String getAddressString() {
+        String address = String.format("%s%05d", addressStringPrefix, getLogicalAddress());
+        if(getDataType() != null) {
+            address += ":" + getDataType().name();
+        }
+        if(!getArrayInfo().isEmpty()) {
+            address += "[" + getArrayInfo().get(0).getUpperBound() + "]";
+        }
+        return address;
+    }
+
+    /**
+     * Instantiate a new ModbusTag
+     * @param address The WIRE address that is to be used.
+     * @param quantity The number of registers
+     * @param dataType The type for the interpretation of the registers.
+     */
+    protected ModbusTag(int address, Integer quantity, ModbusDataType dataType, String addressStringPrefix) {
         this.address = address;
-        if ((this.address + PROTOCOL_ADDRESS_OFFSET) <= 0) {
-            throw new IllegalArgumentException("address must be greater than zero. Was " + (this.address + PROTOCOL_ADDRESS_OFFSET));
+        if (getLogicalAddress() <= 0) {
+            throw new IllegalArgumentException("address must be greater than zero. Was " + getLogicalAddress());
         }
         this.quantity = quantity != null ? quantity : 1;
         if (this.quantity <= 0) {
             throw new IllegalArgumentException("quantity must be greater than zero. Was " + this.quantity);
         }
         this.dataType = dataType != null ? dataType : ModbusDataType.INT;
+        this.addressStringPrefix = addressStringPrefix;
     }
 
+    /**
+     * Get the technical address that must be used 'on the wire'
+     * @return The address that is to be used on the wire (shifted by 1 because of the modbus spec).
+     */
     public int getAddress() {
         return address;
     }
+
+    /**
+     * Get the logical (configured) address
+     * @return The address which was configured and is different from what is used on the wire.
+     */
+    public abstract int getLogicalAddress();
 
     public int getNumberOfElements() {
         return quantity;
@@ -122,21 +153,24 @@ public abstract class ModbusTag implements PlcTag, Serializable {
             return false;
         }
         ModbusTag that = (ModbusTag) o;
-        return address == that.address;
+        return address == that.address &&
+            quantity == that.quantity &&
+            dataType == that.dataType &&
+            getClass() == that.getClass(); // MUST be identical
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(address);
+        return Objects.hash(this.getClass(), address, quantity, dataType);
     }
 
     @Override
     public String toString() {
-        return "ModbusTag{" +
+        return this.getClass().getSimpleName() + " {" +
             "address=" + address +
-            "datatype=" + dataType +
-            "quantity=" + quantity +
-            '}';
+            ", quantity=" + quantity +
+            ", dataType=" + dataType +
+            " }";
     }
 
     @Override

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagCoil.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagCoil.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 
 public class ModbusTagCoil extends ModbusTag {
 
+    public static final String ADDRESS_PREFIX = "0x";
     public static final Pattern ADDRESS_PATTERN = Pattern.compile("coil:" + ModbusTag.ADDRESS_PATTERN);
     public static final Pattern ADDRESS_SHORTER_PATTERN = Pattern.compile("0" + ModbusTag.FIXED_DIGIT_MODBUS_PATTERN);
     public static final Pattern ADDRESS_SHORT_PATTERN = Pattern.compile("0x" + ModbusTag.FIXED_DIGIT_MODBUS_PATTERN);
@@ -33,19 +34,12 @@ public class ModbusTagCoil extends ModbusTag {
     protected static final int REGISTER_MAXADDRESS = 65535;
 
     public ModbusTagCoil(int address, Integer quantity, ModbusDataType dataType) {
-        super(address, quantity, dataType);
+        super(address, quantity, dataType, ADDRESS_PREFIX);
     }
 
     @Override
-    public String getAddressString() {
-        String address = "0x" + getAddress();
-        if(getDataType() != null) {
-            address += ":" + getDataType().name();
-        }
-        if(getArrayInfo().size() > 0) {
-            address += "[" + getArrayInfo().get(0).getUpperBound() + "]";
-        }
-        return address;
+    public int getLogicalAddress() {
+        return getAddress() + PROTOCOL_ADDRESS_OFFSET;
     }
 
     public static boolean matches(String addressString) {

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagCoil.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagCoil.java
@@ -34,7 +34,11 @@ public class ModbusTagCoil extends ModbusTag {
     protected static final int REGISTER_MAXADDRESS = 65535;
 
     public ModbusTagCoil(int address, Integer quantity, ModbusDataType dataType) {
-        super(address, quantity, dataType, ADDRESS_PREFIX);
+        super(address, quantity, dataType);
+    }
+
+    protected String getAddressStringPrefix() {
+        return ADDRESS_PREFIX;
     }
 
     @Override

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagDiscreteInput.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagDiscreteInput.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 
 public class ModbusTagDiscreteInput extends ModbusTag {
 
+    public static final String ADDRESS_PREFIX = "1x";
     public static final Pattern ADDRESS_PATTERN = Pattern.compile("discrete-input:" + ModbusTag.ADDRESS_PATTERN);
     public static final Pattern ADDRESS_SHORTER_PATTERN = Pattern.compile("1" + ModbusTag.FIXED_DIGIT_MODBUS_PATTERN);
     public static final Pattern ADDRESS_SHORT_PATTERN = Pattern.compile("1x" + ModbusTag.FIXED_DIGIT_MODBUS_PATTERN);
@@ -33,19 +34,12 @@ public class ModbusTagDiscreteInput extends ModbusTag {
     protected static final int REGISTER_MAX_ADDRESS = 65535;
 
     public ModbusTagDiscreteInput(int address, Integer quantity, ModbusDataType dataType) {
-        super(address, quantity, dataType);
+        super(address, quantity, dataType, ADDRESS_PREFIX);
     }
 
     @Override
-    public String getAddressString() {
-        String address = "1x" + getAddress();
-        if(getDataType() != null) {
-            address += ":" + getDataType().name();
-        }
-        if(getArrayInfo().size() > 0) {
-            address += "[" + getArrayInfo().get(0).getUpperBound() + "]";
-        }
-        return address;
+    public int getLogicalAddress() {
+        return getAddress() + PROTOCOL_ADDRESS_OFFSET;
     }
 
     public static boolean matches(String addressString) {
@@ -57,7 +51,7 @@ public class ModbusTagDiscreteInput extends ModbusTag {
     public static Matcher getMatcher(String addressString) {
         Matcher matcher = ADDRESS_PATTERN.matcher(addressString);
         if (matcher.matches()) {
-          return matcher;
+            return matcher;
         }
         matcher = ADDRESS_SHORT_PATTERN.matcher(addressString);
         if (matcher.matches()) {

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagDiscreteInput.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagDiscreteInput.java
@@ -34,7 +34,11 @@ public class ModbusTagDiscreteInput extends ModbusTag {
     protected static final int REGISTER_MAX_ADDRESS = 65535;
 
     public ModbusTagDiscreteInput(int address, Integer quantity, ModbusDataType dataType) {
-        super(address, quantity, dataType, ADDRESS_PREFIX);
+        super(address, quantity, dataType);
+    }
+
+    protected String getAddressStringPrefix() {
+        return ADDRESS_PREFIX;
     }
 
     @Override

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagExtendedRegister.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagExtendedRegister.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 
 public class ModbusTagExtendedRegister extends ModbusTag {
 
+    public static final String ADDRESS_PREFIX = "6x";
     public static final Pattern ADDRESS_PATTERN = Pattern.compile("extended-register:" + ModbusTag.ADDRESS_PATTERN);
     public static final Pattern ADDRESS_SHORTER_PATTERN = Pattern.compile("6" + ModbusTag.FIXED_DIGIT_MODBUS_PATTERN);
     public static final Pattern ADDRESS_SHORT_PATTERN = Pattern.compile("6x" + ModbusTag.FIXED_DIGIT_MODBUS_PATTERN);
@@ -33,19 +34,13 @@ public class ModbusTagExtendedRegister extends ModbusTag {
     protected static final int REGISTER_MAXADDRESS = 655359999;
 
     protected ModbusTagExtendedRegister(int address, Integer quantity, ModbusDataType dataType) {
-        super(address, quantity, dataType);
+        super(address, quantity, dataType, ADDRESS_PREFIX);
     }
 
     @Override
-    public String getAddressString() {
-        String address = "6x" + getAddress();
-        if(getDataType() != null) {
-            address += ":" + getDataType().name();
-        }
-        if(getArrayInfo().size() > 0) {
-            address += "[" + getArrayInfo().get(0).getUpperBound() + "]";
-        }
-        return address;
+    public int getLogicalAddress() {
+        // Addresses for extended memory start at address 0 instead of 1
+        return getAddress();
     }
 
     public static boolean matches(String addressString) {

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagExtendedRegister.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagExtendedRegister.java
@@ -34,7 +34,11 @@ public class ModbusTagExtendedRegister extends ModbusTag {
     protected static final int REGISTER_MAXADDRESS = 655359999;
 
     protected ModbusTagExtendedRegister(int address, Integer quantity, ModbusDataType dataType) {
-        super(address, quantity, dataType, ADDRESS_PREFIX);
+        super(address, quantity, dataType);
+    }
+
+    protected String getAddressStringPrefix() {
+        return ADDRESS_PREFIX;
     }
 
     @Override

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagHoldingRegister.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagHoldingRegister.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 
 public class ModbusTagHoldingRegister extends ModbusTag {
 
+    public static final String ADDRESS_PREFIX = "4x";
     public static final Pattern ADDRESS_PATTERN = Pattern.compile("holding-register:" + ModbusTag.ADDRESS_PATTERN);
     public static final Pattern ADDRESS_SHORTER_PATTERN = Pattern.compile("4" + ModbusTag.FIXED_DIGIT_MODBUS_PATTERN);
     public static final Pattern ADDRESS_SHORT_PATTERN = Pattern.compile("4x" + ModbusTag.FIXED_DIGIT_MODBUS_PATTERN);
@@ -33,19 +34,12 @@ public class ModbusTagHoldingRegister extends ModbusTag {
     protected static final int REGISTER_MAXADDRESS = 65535;
 
     protected ModbusTagHoldingRegister(int address, Integer quantity, ModbusDataType dataType) {
-        super(address, quantity, dataType);
+        super(address, quantity, dataType, ADDRESS_PREFIX);
     }
 
     @Override
-    public String getAddressString() {
-        String address = "4x" + getAddress();
-        if(getDataType() != null) {
-            address += ":" + getDataType().name();
-        }
-        if(getArrayInfo().size() > 0) {
-            address += "[" + getArrayInfo().get(0).getUpperBound() + "]";
-        }
-        return address;
+    public int getLogicalAddress() {
+        return getAddress() + PROTOCOL_ADDRESS_OFFSET;
     }
 
     public static boolean matches(String addressString) {

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagHoldingRegister.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagHoldingRegister.java
@@ -34,7 +34,11 @@ public class ModbusTagHoldingRegister extends ModbusTag {
     protected static final int REGISTER_MAXADDRESS = 65535;
 
     protected ModbusTagHoldingRegister(int address, Integer quantity, ModbusDataType dataType) {
-        super(address, quantity, dataType, ADDRESS_PREFIX);
+        super(address, quantity, dataType);
+    }
+
+    protected String getAddressStringPrefix() {
+        return ADDRESS_PREFIX;
     }
 
     @Override

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagInputRegister.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagInputRegister.java
@@ -34,7 +34,11 @@ public class ModbusTagInputRegister extends ModbusTag {
     protected static final int REGISTER_MAXADDRESS = 65535;
 
     protected ModbusTagInputRegister(int address, Integer quantity, ModbusDataType dataType) {
-        super(address, quantity, dataType, ADDRESS_PREFIX);
+        super(address, quantity, dataType);
+    }
+
+    protected String getAddressStringPrefix() {
+        return ADDRESS_PREFIX;
     }
 
     @Override

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagInputRegister.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/tag/ModbusTagInputRegister.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 
 public class ModbusTagInputRegister extends ModbusTag {
 
+    public static final String ADDRESS_PREFIX = "3x";
     public static final Pattern ADDRESS_PATTERN = Pattern.compile("input-register:" + ModbusTag.ADDRESS_PATTERN);
     public static final Pattern ADDRESS_SHORTER_PATTERN = Pattern.compile("3" + ModbusTag.FIXED_DIGIT_MODBUS_PATTERN);
     public static final Pattern ADDRESS_SHORT_PATTERN = Pattern.compile("3x" + ModbusTag.FIXED_DIGIT_MODBUS_PATTERN);
@@ -33,19 +34,12 @@ public class ModbusTagInputRegister extends ModbusTag {
     protected static final int REGISTER_MAXADDRESS = 65535;
 
     protected ModbusTagInputRegister(int address, Integer quantity, ModbusDataType dataType) {
-        super(address, quantity, dataType);
+        super(address, quantity, dataType, ADDRESS_PREFIX);
     }
 
     @Override
-    public String getAddressString() {
-        String address = "3x" + getAddress();
-        if(getDataType() != null) {
-            address += ":" + getDataType().name();
-        }
-        if(getArrayInfo().size() > 0) {
-            address += "[" + getArrayInfo().get(0).getUpperBound() + "]";
-        }
-        return address;
+    public int getLogicalAddress() {
+        return getAddress() + PROTOCOL_ADDRESS_OFFSET;
     }
 
     public static boolean matches(String addressString) {

--- a/plc4j/drivers/modbus/src/test/java/org/apache/plc4x/java/modbus/ModbusTagTest.java
+++ b/plc4j/drivers/modbus/src/test/java/org/apache/plc4x/java/modbus/ModbusTagTest.java
@@ -20,72 +20,113 @@ package org.apache.plc4x.java.modbus;
 
 import org.apache.plc4x.java.modbus.base.tag.*;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.plc4x.java.modbus.base.tag.ModbusTag.PROTOCOL_ADDRESS_OFFSET;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ModbusTagTest {
 
-    @Test
-    void testHolding_INT_ARRAY_RANGE() {
-        for (int i = 1; i <= 125; i++) {
-          final ModbusTagHoldingRegister holdingregister = ModbusTagHoldingRegister.of("400001:INT[" + i + "]");
-          assertEquals(i, holdingregister.getNumberOfElements());
+    private static final Logger LOG = LoggerFactory.getLogger(ModbusTagTest.class);
+
+    private void verifyModbusTag(List<String> tagPatterns,
+                                 int allowedMax,
+                                 Class<? extends ModbusTag> expectedClass,
+                                 int expectedAddressShift) {
+        // Ensure all tagpatterns compile to the right tag
+        for (int i = 1; i <= allowedMax; i++) {
+            List<ModbusTag> tags = new ArrayList<>();
+            for (String tagPattern : tagPatterns) {
+                final ModbusTag modbusTag = ModbusTag.of(String.format(tagPattern, i));
+                assertTrue(expectedClass.isInstance(modbusTag));
+                assertEquals(i, modbusTag.getNumberOfElements());
+                tags.add(modbusTag);
+            }
+            // All forms of defining the tag MUST result in an identical modbus tag
+            assertEquals(1, tags.stream().distinct().count());
         }
 
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            ModbusTagHoldingRegister.of("400001:INT[126]");
-        });
-        assertTrue(exception.getMessage().startsWith("quantity may not be larger than "));
-    }
-
-    @Test
-    void testInput_INT_ARRAY_RANGE() {
-        for (int i = 1; i <= 125; i++) {
-          final ModbusTagInputRegister inputregister = ModbusTagInputRegister.of("300001:INT[" + i + "]");
-          assertEquals(i, inputregister.getNumberOfElements());
+        for (String tagPattern : tagPatterns) {
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                ModbusTag.of(String.format(tagPattern, allowedMax + 1))
+            );
+            assertTrue(exception.getMessage().startsWith("quantity may not be larger than "));
         }
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            ModbusTagInputRegister.of("300001:INT[126]");
-        });
-        assertTrue(exception.getMessage().startsWith("quantity may not be larger than "));
-    }
 
-    @Test
-    void testExtended_INT_ARRAY_RANGE() {
-        for (int i = 1; i <= 125; i++) {
-          final ModbusTagExtendedRegister extendedRegister = ModbusTagExtendedRegister.of("600001:INT[" + i + "]");
-          assertEquals(i, extendedRegister.getNumberOfElements());
+        // Ensure the getAddressString yields a parseable and identical tag.
+        for (String tagPattern : tagPatterns) {
+            String addressString1 = String.format(tagPattern, 42);
+            LOG.info("Validating {}", addressString1);
+            ModbusTag modbusTag1 = ModbusTag.of(addressString1);
+            String addressString2 = modbusTag1.getAddressString();
+            ModbusTag modbusTag2 = ModbusTag.of(addressString2);
+            assertEquals(modbusTag1, modbusTag2, "From input addressString:  " + addressString1);
+
+            // We know ALL examples below request address '1'
+            // So this must return the logical address that was requested.
+            assertEquals(1, modbusTag1.getLogicalAddress());
+            assertEquals(modbusTag1.getLogicalAddress() - expectedAddressShift, modbusTag1.getAddress());
+
+            assertEquals(1, modbusTag2.getLogicalAddress());
+            assertEquals(modbusTag2.getLogicalAddress() - expectedAddressShift, modbusTag2.getAddress());
         }
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            ModbusTagExtendedRegister.of("600001:INT[126]");
-        });
-        assertTrue(exception.getMessage().startsWith("quantity may not be larger than "));
+
     }
 
     @Test
     void testCoil_INT_ARRAY_RANGE() {
-        for (int i = 1; i <= 2000; i++) {
-          final ModbusTagCoil coil = ModbusTagCoil.of("000001:BOOL[" + i + "]");
-          assertEquals(i, coil.getNumberOfElements());
-        }
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            ModbusTagCoil.of("000001:BOOL[2001]");
-        });
-        assertTrue(exception.getMessage().startsWith("quantity may not be larger than "));
+        verifyModbusTag(
+            List.of("coil:1:BOOL[%d]", "00001:BOOL[%d]", "000001:BOOL[%d]", "0x00001:BOOL[%d]"),
+            2000,
+            ModbusTagCoil.class,
+            PROTOCOL_ADDRESS_OFFSET
+        );
     }
 
     @Test
     void testDiscreteInput_INT_ARRAY_RANGE() {
-        for (int i = 1; i <= 2000; i++) {
-          final ModbusTagDiscreteInput discreteInput = ModbusTagDiscreteInput.of("100001:BOOL[" + i + "]");
-          assertEquals(i, discreteInput.getNumberOfElements());
-        }
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            ModbusTagDiscreteInput.of("100001:BOOL[2001]");
-        });
-        assertTrue(exception.getMessage().startsWith("quantity may not be larger than "));
+        verifyModbusTag(
+            List.of("discrete-input:1:BOOL[%d]", "10001:BOOL[%d]", "100001:BOOL[%d]", "1x00001:BOOL[%d]"),
+            2000,
+            ModbusTagDiscreteInput.class,
+            PROTOCOL_ADDRESS_OFFSET
+        );
+    }
+
+    @Test
+    void testHolding_INT_ARRAY_RANGE() {
+        verifyModbusTag(
+            List.of("holding-register:1:INT[%d]", "40001:INT[%d]", "400001:INT[%d]", "4x00001:INT[%d]"),
+            125,
+            ModbusTagHoldingRegister.class,
+            PROTOCOL_ADDRESS_OFFSET
+        );
+    }
+
+    @Test
+    void testInput_INT_ARRAY_RANGE() {
+        verifyModbusTag(
+            List.of("input-register:1:INT[%d]", "30001:INT[%d]", "300001:INT[%d]", "3x00001:INT[%d]"),
+            125,
+            ModbusTagInputRegister.class,
+            PROTOCOL_ADDRESS_OFFSET
+        );
+    }
+
+    @Test
+    void testExtended_INT_ARRAY_RANGE() {
+        verifyModbusTag(
+            List.of("extended-register:1:INT[%d]", "60001:INT[%d]", "600001:INT[%d]", "6x00001:INT[%d]"),
+            125,
+            ModbusTagExtendedRegister.class,
+            0 // Addresses for extended memory start at address 0 instead of 1
+        );
     }
 
 }


### PR DESCRIPTION
This is my proposed set of (what I think are) improvements for the ModbusTag code.
Summary:
- The equals and hashcode were incorrect because the name of the actual class also matters.
- My take on reducing the confusion around the -1 offset and the code complexity around all of this:
  - Simplified the code for readability
  - There is now a getLogicalAddress which returns the address the user configured.
  - The getAddressString returns a string that parses (which was not the case) AND yields an identical new tag when parsed (which was not the case: was shifted by 1 most of the time).
  - A more extensive set of tests that verifies all of this and ensures all supported formats for all tags yield the correct tag that is identical regardless of the used format.

Looking forward to your feedback.
