### PR TITLE
Fix reading UTF-8 strings (from OPC UA nodes)

### DIFF
--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/generation/ReadBufferByteBased.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/generation/ReadBufferByteBased.java
@@ -475,25 +475,7 @@ public class ReadBufferByteBased implements ReadBuffer, BufferCommons {
         encoding = encoding.replaceAll("[^a-zA-Z0-9]", "");
         encoding = encoding.toUpperCase();
         switch (encoding) {
-            case "ASCII": {
-                byte[] strBytes = new byte[bitLength / 8];
-                int realLength = 0;
-                boolean finishedReading = false;
-                for (int i = 0; (i < (bitLength / 8)) && hasMore(8); i++) {
-                    try {
-                        byte b = readByte(logicalName);
-                        if (!disable0Termination() && (b == 0x00)) {
-                            finishedReading = true;
-                        } else if (!finishedReading) {
-                            strBytes[i] = b;
-                            realLength++;
-                        }
-                    } catch (Exception e) {
-                        throw new PlcRuntimeException(e);
-                    }
-                }
-                return new String(strBytes, 0, realLength, StandardCharsets.US_ASCII);
-            }
+            case "ASCII":
             case "UTF8": {
                 byte[] strBytes = new byte[bitLength / 8];
                 int realLength = 0;
@@ -511,7 +493,15 @@ public class ReadBufferByteBased implements ReadBuffer, BufferCommons {
                         throw new PlcRuntimeException(e);
                     }
                 }
-                return new String(strBytes, 0, realLength, StandardCharsets.UTF_8);
+                Charset charset;
+                switch (encoding) {
+                    case "UTF8":
+                        charset = StandardCharsets.UTF_8;
+                        break;
+                    default:
+                        charset = StandardCharsets.US_ASCII;
+                }
+                return new String(strBytes, 0, realLength, charset);
             }
             case "UTF16":
             case "UTF16LE":

--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/generation/ReadBufferByteBased.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/generation/ReadBufferByteBased.java
@@ -491,7 +491,7 @@ public class ReadBufferByteBased implements ReadBuffer, BufferCommons {
                         throw new PlcRuntimeException(e);
                     }
                 }
-                return new String(strBytes, StandardCharsets.US_ASCII).substring(0, realLength);
+                return new String(strBytes, 0, realLength, StandardCharsets.US_ASCII);
             }
             case "UTF8": {
                 byte[] strBytes = new byte[bitLength / 8];
@@ -510,7 +510,7 @@ public class ReadBufferByteBased implements ReadBuffer, BufferCommons {
                         throw new PlcRuntimeException(e);
                     }
                 }
-                return new String(strBytes, StandardCharsets.UTF_8).substring(0, realLength);
+                return new String(strBytes, 0, realLength, StandardCharsets.UTF_8);
             }
             case "UTF16":
             case "UTF16LE":
@@ -527,7 +527,7 @@ public class ReadBufferByteBased implements ReadBuffer, BufferCommons {
                         } else if (!finishedReading) {
                             strBytes[(i * 2)] = b1;
                             strBytes[(i * 2) + 1] = b2;
-                            realLength++;
+                            realLength += 2;
                         }
                     } catch (Exception e) {
                         throw new PlcRuntimeException(e);
@@ -544,7 +544,7 @@ public class ReadBufferByteBased implements ReadBuffer, BufferCommons {
                     default:
                         charset = StandardCharsets.UTF_16;
                 }
-                return new String(strBytes, charset).substring(0, realLength);
+                return new String(strBytes, 0, realLength, charset);
             }
             default:
                 throw new ParseException("Unsupported encoding: " + encoding);

--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/generation/ReadBufferByteBased.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/generation/ReadBufferByteBased.java
@@ -473,7 +473,8 @@ public class ReadBufferByteBased implements ReadBuffer, BufferCommons {
     public String readString(String logicalName, int bitLength, WithReaderArgs... readerArgs) throws ParseException {
         String encoding = extractEncoding(readerArgs).orElse("UTF-8");
         encoding = encoding.replaceAll("[^a-zA-Z0-9]", "");
-        switch (encoding.toUpperCase()) {
+        encoding = encoding.toUpperCase();
+        switch (encoding) {
             case "ASCII": {
                 byte[] strBytes = new byte[bitLength / 8];
                 int realLength = 0;

--- a/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/generation/ReadBufferTest.java
+++ b/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/generation/ReadBufferTest.java
@@ -38,4 +38,17 @@ class ReadBufferTest {
 
         assertEquals(value, answer);
     }
+
+    /**
+     * Test which makes sure that UTF8 encoding with multi-byte characters works
+     */
+    @Test
+    void readStringUtf8() throws ParseException {
+        String value = "molybdän";
+        final var serialized = value.getBytes(StandardCharsets.UTF_8);
+        final ReadBuffer buffer = new ReadBufferByteBased(serialized);
+        String answer = buffer.readString("", serialized.length * 8, WithOption.WithEncoding(StandardCharsets.UTF_8.name()));
+
+        assertEquals(value, answer);
+    }
 }


### PR DESCRIPTION
When reading string values via the OPC UA protocol a `StringIndexOutOfBoundsException` was thrown whenever the string contained non-ASCII characters. Upon further inspection, the problem could be pinned down to the logic in `readString()` of`ReadBufferByteBased`.

The `readString()` function in `ReadBufferByteBased` could result in a `StringIndexOutOfBoundsException` upon calling `substring()`. Reason is that the calculated `realLength` is in bytes and the length of the created string is the number of characters. For UTF encodings, multiple bytes can be just one character. This causes `realLength` to be longer than the actual string and thus the `substring()`-call to fail.

This PR fixes the issue by applying `realLength` to the byte-length instead of the string length: The byte array is sliced to length `realLength` and then converted to the final string. `substring()` isn't used anymore.
The fix can be verified via the included regression test and has additionally been tested locally using the OPC UA protocol.
Maybe other protocols were also affected?

Additionally I've included some other minor fixes for the logic. Check the commits for these.

Regards,
Marc
