### PR TITLE
Revert "build(deps): bump ecj from 3.32.0 to 3.33.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1139,7 +1139,7 @@
             <dependency>
               <groupId>org.eclipse.jdt</groupId>
               <artifactId>ecj</artifactId>
-              <version>3.33.0</version>
+              <version>3.32.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
Reverts apache/plc4x#853

seems that this breaks the java 11 build