### PR TITLE
Remove SonarCloud cache and threads configuration and rely on default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,8 +96,6 @@
     <!-- Exclude all generated code -->
     <sonar.exclusions>**/generated-sources</sonar.exclusions>
     <sonar.cfamily.build-wrapper-output>${project.basedir}/plc4c/target/build-wrapper-output</sonar.cfamily.build-wrapper-output>
-    <sonar.cfamily.threads>1</sonar.cfamily.threads>
-    <sonar.cfamily.cache.enabled>false</sonar.cfamily.cache.enabled>
 
     <plc4x-code-generation.version>1.7.0-SNAPSHOT</plc4x-code-generation.version>
 


### PR DESCRIPTION
No need to configure the cache and threads anymore, SonarCloud now has automatic analysis caching and threads configuration. See: https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-cache