### PR TITLE
Add support of PlcDINT for BigInteger in PlcValueHandler

### DIFF
--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/protocol/OpcuaProtocolLogic.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/protocol/OpcuaProtocolLogic.java
@@ -195,7 +195,7 @@ public class OpcuaProtocolLogic extends Plc4xProtocolBase<OpcuaAPU> implements H
                         future.complete(new DefaultPlcReadResponse(request, status));
                         return;
                     }
-                } catch (ParseException e) {
+                } catch (Exception e) {
                     future.completeExceptionally(new PlcRuntimeException(e));
                 }
             };

--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/protocol/OpcuaProtocolLogic.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/protocol/OpcuaProtocolLogic.java
@@ -195,7 +195,7 @@ public class OpcuaProtocolLogic extends Plc4xProtocolBase<OpcuaAPU> implements H
                         future.complete(new DefaultPlcReadResponse(request, status));
                         return;
                     }
-                } catch (Exception e) {
+                } catch (ParseException|PlcRuntimeException e) {
                     future.completeExceptionally(new PlcRuntimeException(e));
                 }
             };

--- a/plc4j/drivers/opcua/src/test/java/org/apache/plc4x/java/opcua/OpcuaPlcDriverTest.java
+++ b/plc4j/drivers/opcua/src/test/java/org/apache/plc4x/java/opcua/OpcuaPlcDriverTest.java
@@ -43,7 +43,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.ExecutionException;
 
-@Disabled("Currently seems to block")
 public class OpcuaPlcDriverTest {
 
     @BeforeAll

--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/values/PlcValueHandler.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/values/PlcValueHandler.java
@@ -84,7 +84,7 @@ public class PlcValueHandler implements org.apache.plc4x.java.api.value.PlcValue
             return PlcLINT.of(value);
         }
         if (value instanceof BigInteger) {
-            return PlcDINT.of(value);
+            return PlcLINT.of(value);
         }
         if (value instanceof Float) {
             return PlcREAL.of(value);

--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/values/PlcValueHandler.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/values/PlcValueHandler.java
@@ -83,6 +83,9 @@ public class PlcValueHandler implements org.apache.plc4x.java.api.value.PlcValue
         if (value instanceof Long) {
             return PlcLINT.of(value);
         }
+        if (value instanceof BigInteger) {
+            return PlcDINT.of(value);
+        }
         if (value instanceof Float) {
             return PlcREAL.of(value);
         }


### PR DESCRIPTION
1. The uncaught `PlcUnsupportedDataTypeException` from `PlcValueHandler` caused the CompletableFuture not to complete, the `OpcuaPlcDriverTest` hangs on `CompletableFuture.get()`
2. The root of the problem is the missing support of BigInteger in [PlcValueHandler.java](https://github.com/apache/plc4x/compare/develop...PatrykGala:plc4x:fix-test#diff-4a6f80d3ad2ced6c8c8bf3f146280004412c868a26cb1539b68486dce2671ba3)