### PR TITLE
Revert "build(deps): bump ecj from 3.32.0 to 3.34.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1140,7 +1140,7 @@
             <dependency>
               <groupId>org.eclipse.jdt</groupId>
               <artifactId>ecj</artifactId>
-              <version>3.34.0</version>
+              <version>3.32.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
Reverts apache/plc4x#989

This build seems to fail java 11