### PR TITLE
fix(plc4go/modbus): Delete elements in the loop, and the index is dec…

### DIFF
--- a/plc4go/spi/default/DefaultCodec.go
+++ b/plc4go/spi/default/DefaultCodec.go
@@ -268,6 +268,7 @@ func (m *defaultCodec) HandleMessages(message spi.Message) bool {
 				}
 				continue
 			}
+			m.log.Trace().Msg("message handled")
 			messageHandled = true
 			// If this is the last element of the list remove it differently than if it's before that
 			if (i + 1) == len(m.expectations) {

--- a/plc4go/spi/default/DefaultCodec.go
+++ b/plc4go/spi/default/DefaultCodec.go
@@ -251,7 +251,8 @@ func (m *defaultCodec) HandleMessages(message spi.Message) bool {
 	defer m.expectationsChangeMutex.Unlock()
 	messageHandled := false
 	m.log.Trace().Msgf("Current number of expectations: %d", len(m.expectations))
-	for index, expectation := range m.expectations {
+	for i := 0; i < len(m.expectations); i++ {
+		expectation := m.expectations[i]
 		m.log.Trace().Msgf("Checking expectation %s", expectation)
 		// Check if the current message matches the expectations
 		// If it does, let it handle the message.
@@ -269,10 +270,11 @@ func (m *defaultCodec) HandleMessages(message spi.Message) bool {
 			}
 			messageHandled = true
 			// If this is the last element of the list remove it differently than if it's before that
-			if (index + 1) == len(m.expectations) {
-				m.expectations = m.expectations[:index]
-			} else if (index + 1) < len(m.expectations) {
-				m.expectations = append(m.expectations[:index], m.expectations[index+1:]...)
+			if (i + 1) == len(m.expectations) {
+				m.expectations = m.expectations[:i]
+			} else if (i + 1) < len(m.expectations) {
+				m.expectations = append(m.expectations[:i], m.expectations[i+1:]...)
+				i--
 			}
 		} else {
 			m.log.Trace().Stringer("expectation", expectation).Msg("doesn't accept message")


### PR DESCRIPTION
In some batch read/write cases, because the element is deleted in the loop, but the index is not decremented by 1, the program freezes, and even the timeout does not work.