### PR TITLE
Nifi integration revision

### DIFF
--- a/plc4j/integrations/apache-nifi/README.md
+++ b/plc4j/integrations/apache-nifi/README.md
@@ -20,8 +20,9 @@ under the License.
 
 ## Common properties
 The following properties applies to all Plc4x Processors:
-* Connection String: A constant connection string such as `s7://10.105.143.7:102?remote-rack=0&remote-slot=1&controller-type=S7_1200`.
-* Read/Write/Subscribe timeout (miliseconds): Specifies the time in milliseconds for the connection to return a timeout. In case of subscription the timeout is used to renew connections.
+* Connection String: A constant connection string such as `s7://10.105.143.7:102?remote-rack=0&remote-slot=1&controller-type=S7_1200` or a valid Expression Language ([Expression Language NiFi documentation](https://nifi.apache.org/docs/nifi-docs/html/expression-language-guide.html)) such as `${plc4x.connection_string}`.
+* Timeout (miliseconds): Specifies the time in milliseconds for the connection to return a timeout. Is used to renew connections. Can be set with Expression Language.
+* Timestamp field name: It defines the name of the field that represents the time when the response from the Plc was received. It will be added to the attributes or to the record deppending on the processor used.
 * Address Access Strategy: defines how the processor obtains the PLC addresses. It can take 2 values:
   * **Properties as Addreses:** 
       For each variable, add a new property to the processor where the property name matches the variable name, and the variable value corresponds to the address tag. 
@@ -87,10 +88,6 @@ Table of data mapping between plc data and Avro types (as specified in [Avro spe
 Also, it is important to keep in mind the Processor Scheduling Configuration. Using the parameter **Run Schedule** (for example to *1 sec*), the reading frequency can be set. Note that by default, this value is defined to 0 sec (as fast as possible).
 
 
-## Plc4xSinkProcessor
-
-## Plc4xSourceProcessor
-
 ## Plc4xSinkRecordProcessor
 
 This processor is <ins>record oriented</ins>, reads from a formated input flowfile content using a Record Reader (for further information see [NiFi Documentation](https://nifi.apache.org/docs/nifi-docs/html/record-path-guide.html#overview)). 
@@ -124,6 +121,7 @@ An *example* for reading values from a S7-1200:
 - *PLC connection String:* *s7://10.105.143.7:102?remote-rack=0&remote-slot=1&controller-type=S7_1200*
 - *Record Writer:* *PLC4x Embedded - AvroRecordSetWriter*
 - *Read timeout (miliseconds):* *10000*
+- *Timestamp field name:* *timestamp*  
 - *var1:* *%DB1:DBX0.0:BOOL*
 - *var2:* *%DB1:DBX0.1:BOOL*
 - *var3:* *%DB1:DBB01:BYTE*
@@ -162,6 +160,6 @@ The output flowfile will contain the PLC read values. This information is includ
   "var3" : "\u0005",
   "var5" : 1992,
   "var4" : "4",
-  "ts" : 1628783058433
+  "timestamp" : 1628783058433
 } ]
 ```

--- a/plc4j/integrations/apache-nifi/README.md
+++ b/plc4j/integrations/apache-nifi/README.md
@@ -49,6 +49,21 @@ The following properties applies to all Plc4x Processors:
     }
     ```
     If this JSON is in an attribute `plc4x.addresses` it can be accessed with *Address Text*=`${plc4x.addresses}`. 
+  
+  * **Address File:**
+    Property *Address File* must be supplied with a path to a file in JSON format that contains variable name and address tag. Expression Language is supported.
+
+    For example a file in:
+    - *Address File*:```/home/nifi/s7addresses.json```  
+    With the following content
+    ```json
+    {
+      "var1" : "%DB1:DBX0.0:BOOL",
+      "var2" : "%DB1:DBX0.1:BOOL"
+    }
+    ```
+    If the file name is in an attribute `plc4x.addresses_file` it can be accessed with *Address File*=`${plc4x.addresses_file}`. 
+
 
 
 When reading from a PLC the response is used to create a mapping between Plc types into Avro. The mapping is done as follows:

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/BasePlc4xProcessor.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/BasePlc4xProcessor.java
@@ -57,8 +57,6 @@ import org.apache.plc4x.java.api.messages.PlcWriteResponse;
 import org.apache.plc4x.java.api.model.PlcTag;
 import org.apache.plc4x.java.api.types.PlcResponseCode;
 import org.apache.plc4x.java.utils.cache.CachedPlcConnectionManager;
-import org.apache.plc4x.nifi.BasePlc4xProcessor.Plc4xConnectionStringValidator;
-import org.apache.plc4x.nifi.BasePlc4xProcessor.Plc4xTimestampFieldValidator;
 import org.apache.plc4x.nifi.address.AddressesAccessStrategy;
 import org.apache.plc4x.nifi.address.AddressesAccessUtils;
 import org.apache.plc4x.nifi.address.DynamicPropertyAccessStrategy;

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/BasePlc4xProcessor.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/BasePlc4xProcessor.java
@@ -20,7 +20,6 @@ package org.apache.plc4x.nifi;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -29,7 +28,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.apache.nifi.annotation.lifecycle.OnScheduled;
-import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
@@ -58,6 +56,7 @@ public abstract class BasePlc4xProcessor extends AbstractProcessor {
     protected Integer cacheSize = 0;
 
     protected final SchemaCache schemaCache = new SchemaCache(0);
+    protected AddressesAccessStrategy addressAccessStrategy;
 
     private CachedPlcConnectionManager connectionManager;
 
@@ -71,12 +70,6 @@ public abstract class BasePlc4xProcessor extends AbstractProcessor {
             .withMaxWaitTime(Duration.ofSeconds(500L))
             .build();
     }
-
-
-    protected static final List<AllowableValue> addressAccessStrategy = Collections.unmodifiableList(Arrays.asList(
-        AddressesAccessUtils.ADDRESS_PROPERTY,
-        AddressesAccessUtils.ADDRESS_TEXT,
-        AddressesAccessUtils.ADDRESS_FILE));
 
 
 	public static final PropertyDescriptor PLC_CONNECTION_STRING = new PropertyDescriptor.Builder()
@@ -151,8 +144,7 @@ public abstract class BasePlc4xProcessor extends AbstractProcessor {
     }
 
     public Map<String, String> getPlcAddressMap(ProcessContext context, FlowFile flowFile) {
-        AddressesAccessStrategy strategy = AddressesAccessUtils.getAccessStrategy(context);
-        return strategy.extractAddresses(context, flowFile);
+        return addressAccessStrategy.extractAddresses(context, flowFile);
     }
     
     public String getConnectionString(ProcessContext context, FlowFile flowFile) {
@@ -204,6 +196,7 @@ public abstract class BasePlc4xProcessor extends AbstractProcessor {
         }
         refreshConnectionManager();
         debugEnabled = getLogger().isDebugEnabled();
+        addressAccessStrategy = AddressesAccessUtils.getAccessStrategy(context);
     }
 
     @Override

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/BasePlc4xProcessor.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/BasePlc4xProcessor.java
@@ -194,7 +194,7 @@ public abstract class BasePlc4xProcessor extends AbstractProcessor {
     protected PropertyDescriptor getSupportedDynamicPropertyDescriptor(final String propertyDescriptorName) {
         return new PropertyDescriptor.Builder()
                 .name(propertyDescriptorName)
-                .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+                .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
                 .addValidator(StandardValidators.ATTRIBUTE_KEY_PROPERTY_NAME_VALIDATOR)
                 .dependsOn(AddressesAccessUtils.PLC_ADDRESS_ACCESS_STRATEGY, AddressesAccessUtils.ADDRESS_PROPERTY)
                 .addValidator(new DynamicPropertyAccessStrategy.TagValidator(AddressesAccessUtils.getManager()))

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSinkProcessor.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSinkProcessor.java
@@ -50,6 +50,8 @@ import org.apache.plc4x.java.api.model.PlcTag;
 @ReadsAttributes({@ReadsAttribute(attribute="value", description="some value")})
 public class Plc4xSinkProcessor extends BasePlc4xProcessor {
 
+	public static final String EXCEPTION = "plc4x.write.exception";
+
     @Override
     public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
         FlowFile flowFile = session.get();
@@ -93,7 +95,7 @@ public class Plc4xSinkProcessor extends BasePlc4xProcessor {
 
 
         } catch (Exception e) {
-            flowFile = session.putAttribute(flowFile, "exception", e.getLocalizedMessage());
+            flowFile = session.putAttribute(flowFile, EXCEPTION, e.getLocalizedMessage());
             session.transfer(flowFile, REL_FAILURE);
             session.commitAsync();
             throw (e instanceof ProcessException) ? (ProcessException) e : new ProcessException(e);

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSinkRecordProcessor.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSinkRecordProcessor.java
@@ -74,6 +74,7 @@ public class Plc4xSinkRecordProcessor extends BasePlc4xProcessor {
 	public static final String RESULT_ROW_COUNT = "plc4x.write.row.count";
 	public static final String RESULT_QUERY_EXECUTION_TIME = "plc4x.write.query.executiontime";
 	public static final String INPUT_FLOWFILE_UUID = "input.flowfile.uuid";
+	public static final String EXCEPTION = "plc4x.write.exception";
 	
 	public static final PropertyDescriptor PLC_RECORD_READER_FACTORY = new PropertyDescriptor.Builder()
 			.name("record-reader").displayName("Record Reader")
@@ -161,7 +162,7 @@ public class Plc4xSinkRecordProcessor extends BasePlc4xProcessor {
 
 		} catch (ProcessException e) {
 			logger.error("Exception writing the data to the PLC", e);
-			session.putAttribute(fileToProcess, "exception", e.getLocalizedMessage());
+			session.putAttribute(fileToProcess, EXCEPTION, e.getLocalizedMessage());
 			session.transfer(fileToProcess, REL_FAILURE);
 			session.commitAsync();
 			throw e;

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSinkRecordProcessor.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSinkRecordProcessor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.plc4x.nifi;
 
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.nifi.annotation.behavior.InputRequirement;
@@ -52,6 +52,7 @@ import org.apache.nifi.serialization.RecordReaderFactory;
 import org.apache.nifi.serialization.record.Record;
 import org.apache.nifi.util.StopWatch;
 import org.apache.plc4x.java.api.PlcConnection;
+import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
 import org.apache.plc4x.java.api.messages.PlcWriteRequest;
 import org.apache.plc4x.java.api.messages.PlcWriteResponse;
 import org.apache.plc4x.java.api.model.PlcTag;
@@ -105,116 +106,160 @@ public class Plc4xSinkRecordProcessor extends BasePlc4xProcessor {
         }
 			
 		final ComponentLog logger = getLogger();
+
 		// Get an instance of a component able to read from a PLC.
 		final AtomicLong nrOfRows = new AtomicLong(0L);
 		final StopWatch executeTime = new StopWatch(true);
 
-		final FlowFile originalFlowFile = fileToProcess;
+		try {
+			session.read(fileToProcess, in -> {
+				Record record = null;
+			
+				try (RecordReader recordReader = context.getProperty(PLC_RECORD_READER_FACTORY)
+					.asControllerService(RecordReaderFactory.class)
+					.createRecordReader(fileToProcess, in, logger)){
 
-		InputStream in = session.read(originalFlowFile);
+					while ((record = recordReader.nextRecord()) != null) {
+						AtomicLong nrOfRowsHere = new AtomicLong(0);
+						PlcWriteRequest writeRequest;
 
-		Record record = null;
-		
-		try (RecordReader recordReader = context.getProperty(PLC_RECORD_READER_FACTORY)
-			.asControllerService(RecordReaderFactory.class)
-			.createRecordReader(originalFlowFile, in, logger)){
+						final Map<String,String> addressMap = getPlcAddressMap(context, fileToProcess);
+						final Map<String, PlcTag> tags = getSchemaCache().retrieveTags(addressMap);
 
-			while ((record = recordReader.nextRecord()) != null) {
-				long nrOfRowsHere = 0L;
-				PlcWriteResponse plcWriteResponse;
-				PlcWriteRequest writeRequest;
+						try (PlcConnection connection = getConnectionManager().getConnection(getConnectionString(context, fileToProcess))) {
+							
+							writeRequest = getWriteRequest(logger, record, nrOfRowsHere, addressMap, tags, connection);
 
-				Map<String,String> addressMap = getPlcAddressMap(context, fileToProcess);
-				final Map<String, PlcTag> tags = getSchemaCache().retrieveTags(addressMap);
+							PlcWriteResponse plcWriteResponse = writeRequest.execute().get(getTimeout(context, fileToProcess), TimeUnit.MILLISECONDS);
 
-				try (PlcConnection connection = getConnectionManager().getConnection(getConnectionString())) {
-					PlcWriteRequest.Builder builder = connection.writeRequestBuilder();
-					
-					
-					if (tags != null){
-						for (Map.Entry<String,PlcTag> tag : tags.entrySet()){
-							if (record.toMap().containsKey(tag.getKey())) {
-								builder.addTag(tag.getKey(), tag.getValue(), record.getValue(tag.getKey()));
-								nrOfRowsHere++;
-							} else {
-								if (debugEnabled)
-                    				logger.debug("PlcTag " + tag + " is declared as address but was not found on input record.");
-							}
+							// Response check if values were written
+							evaluateWriteResponse(logger, record, plcWriteResponse);
+
+						} catch (TimeoutException e) {
+							logger.error("Timeout writting the data to the PLC", e);
+							getConnectionManager().removeCachedConnection(getConnectionString(context, fileToProcess));
+							throw new ProcessException(e);
+						} catch (PlcConnectionException e) {
+							logger.error("Error getting the PLC connection", e);
+							throw new ProcessException("Got an a PlcConnectionException while trying to get a connection", e);
+						} catch (Exception e) {
+							logger.error("Exception writting the data to the PLC", e);
+							throw (e instanceof ProcessException) ? (ProcessException) e : new ProcessException(e);
 						}
-					} else {
-						if (debugEnabled)
-                   			logger.debug("Plc-Avro schema and PlcTypes resolution not found in cache and will be added with key: " + addressMap);
-						for (Map.Entry<String,String> entry: addressMap.entrySet()){
-							if (record.toMap().containsKey(entry.getKey())) {
-								builder.addTagAddress(entry.getKey(), entry.getValue(), record.getValue(entry.getKey()));
-								nrOfRowsHere++;
-							} else {
-								if (debugEnabled)
-                    				logger.debug("PlcTag " + entry.getKey() + " with address " + entry.getValue() + " was not found on input record.");
-							}
+							
+						if (tags == null){
+							addTagsToCache(logger, addressMap, writeRequest);
 						}
+						nrOfRows.getAndAdd(nrOfRowsHere.get());
+
+						
 					}
-					writeRequest = builder.build();
-
-					plcWriteResponse = writeRequest.execute().get(this.timeout, TimeUnit.MILLISECONDS);
-
 				} catch (Exception e) {
-					in.close();
-					logger.error("Exception writing the data to PLC", e);
-					session.transfer(originalFlowFile, REL_FAILURE);
-					session.commitAsync();
 					throw (e instanceof ProcessException) ? (ProcessException) e : new ProcessException(e);
-				}
+				} 
+			});
 
-				// Response check if values were written
-				if (plcWriteResponse != null){
-					PlcResponseCode code = null;
+		} catch (ProcessException e) {
+			logger.error("Exception writing the data to the PLC", e);
+			session.putAttribute(fileToProcess, "exception", e.getLocalizedMessage());
+			session.transfer(fileToProcess, REL_FAILURE);
+			session.commitAsync();
+			throw e;
+		} 
 
-					for (String tag : plcWriteResponse.getTagNames()) {
-						code = plcWriteResponse.getResponseCode(tag);
-						if (!code.equals(PlcResponseCode.OK)) {
-							logger.error("Not OK code when writing the data to PLC for tag " + tag 
-								+ " with value  " + record.getValue(tag).toString() 
-								+ " in addresss " + plcWriteResponse.getTag(tag).getAddressString());
-							throw new ProcessException("Writing response code for " + plcWriteResponse.getTag(tag).getAddressString() + "was " + code.name() + ", expected OK");
-						}
-					}
-					if (tags == null && writeRequest != null){
-						if (debugEnabled)
-							logger.debug("Adding PlcTypes resolution into cache with key: " + addressMap);
-						getSchemaCache().addSchema(
-							addressMap, 
-							writeRequest.getTagNames(),
-							writeRequest.getTags(),
-							null
-						);
-					}
-					nrOfRows.getAndAdd(nrOfRowsHere);
+		FlowFile resultSetFF = createResultFlowFile(context, session, fileToProcess, logger, nrOfRows, executeTime);
+
+		session.transfer(resultSetFF, REL_SUCCESS);
+	}
+
+	private PlcWriteRequest getWriteRequest(final ComponentLog logger, Record record, AtomicLong nrOfRowsHere,
+			final Map<String, String> addressMap, final Map<String, PlcTag> tags, final PlcConnection connection) {
+
+		PlcWriteRequest.Builder builder = connection.writeRequestBuilder();
+
+		if (tags != null){
+			for (Map.Entry<String,PlcTag> tag : tags.entrySet()){
+				if (record.toMap().containsKey(tag.getKey())) {
+					builder.addTag(tag.getKey(), tag.getValue(), record.getValue(tag.getKey()));
+					nrOfRowsHere.incrementAndGet();
+				} else {
+					if (debugEnabled)
+						logger.debug("PlcTag " + tag + " is declared as address but was not found on input record.");
 				}
 			}
-			in.close();
-		} catch (Exception e) {
-			throw new ProcessException(e);
-		} 
-		
+		} else {
+			if (debugEnabled)
+				logger.debug("Plc-Avro schema and PlcTypes resolution not found in cache and will be added with key: " + addressMap);
+			for (Map.Entry<String,String> entry: addressMap.entrySet()){
+				if (record.toMap().containsKey(entry.getKey())) {
+					builder.addTagAddress(entry.getKey(), entry.getValue(), record.getValue(entry.getKey()));
+					nrOfRowsHere.incrementAndGet();
+				} else {
+					if (debugEnabled)
+						logger.debug("PlcTag " + entry.getKey() + " with address " + entry.getValue() + " was not found on input record.");
+				}
+			}
+		}
+		return builder.build();
+	}
+
+	private void evaluateWriteResponse(final ComponentLog logger, Record record, PlcWriteResponse plcWriteResponse) {
+
+		boolean codeErrorPresent = false;
+		List<String> tagsAtError = null;
+
+		PlcResponseCode code = null;
+
+		for (String tag : plcWriteResponse.getTagNames()) {
+			code = plcWriteResponse.getResponseCode(tag);
+			if (!code.equals(PlcResponseCode.OK)) {
+				if (tagsAtError == null) {
+					tagsAtError = new ArrayList<>();
+				}
+				logger.error("Not OK code when writing the data to PLC for tag " + tag 
+					+ " with value  " + record.getValue(tag).toString() 
+					+ " in addresss " + plcWriteResponse.getTag(tag).getAddressString());
+				
+			codeErrorPresent = true;
+			tagsAtError.add(tag);
+						
+			}
+		}
+		if (codeErrorPresent) {
+			throw new ProcessException("At least one error was found when while writting tags: " + tagsAtError.toString());
+		}
+	}
+
+
+	private void addTagsToCache(final ComponentLog logger, final Map<String, String> addressMap, PlcWriteRequest writeRequest) {
+		if (debugEnabled)
+			logger.debug("Adding PlcTypes resolution into cache with key: " + addressMap);
+		getSchemaCache().addSchema(
+			addressMap, 
+			writeRequest.getTagNames(),
+			writeRequest.getTags(),
+			null
+		);
+	}
+
+	private FlowFile createResultFlowFile(final ProcessContext context, final ProcessSession session, FlowFile fileToProcess,
+			final ComponentLog logger, final AtomicLong nrOfRows, final StopWatch executeTime) {
+
 		long executionTimeElapsed = executeTime.getElapsed(TimeUnit.MILLISECONDS);
 		final Map<String, String> attributesToAdd = new HashMap<>();
 		attributesToAdd.put(RESULT_ROW_COUNT, String.valueOf(nrOfRows.get()));
 		attributesToAdd.put(RESULT_QUERY_EXECUTION_TIME, String.valueOf(executionTimeElapsed));
 		attributesToAdd.put(INPUT_FLOWFILE_UUID, fileToProcess.getAttribute(CoreAttributes.UUID.key()));
 		
-		FlowFile resultSetFF = session.putAllAttributes(originalFlowFile, attributesToAdd);
+		FlowFile resultSetFF = session.putAllAttributes(fileToProcess, attributesToAdd);
 
-		logger.info("Writing {} fields from {} records; transferring to 'success'", new Object[] { nrOfRows.get(), resultSetFF });
-		// Report a FETCH event if there was an incoming flow file, or a RECEIVE event
-		// otherwise
+		logger.info("Writing {} fields from {} records; transferring to 'success'", nrOfRows.get(), resultSetFF);
+
 		if (context.hasIncomingConnection()) {
 			session.getProvenanceReporter().fetch(resultSetFF, "Writted " + nrOfRows.get() + " rows", executionTimeElapsed);
 		} else {
 			session.getProvenanceReporter().receive(resultSetFF, "Writted " + nrOfRows.get() + " rows", executionTimeElapsed);
 		}
-
-		session.transfer(resultSetFF, BasePlc4xProcessor.REL_SUCCESS);
-		session.commitAsync();
+		return resultSetFF;
 	}
 }

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSinkRecordProcessor.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSinkRecordProcessor.java
@@ -56,7 +56,6 @@ import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
 import org.apache.plc4x.java.api.messages.PlcWriteRequest;
 import org.apache.plc4x.java.api.messages.PlcWriteResponse;
 import org.apache.plc4x.java.api.model.PlcTag;
-import org.apache.plc4x.java.api.types.PlcResponseCode;
 
 @TriggerSerially
 @Tags({"plc4x", "put", "sink", "record"})
@@ -129,12 +128,12 @@ public class Plc4xSinkRecordProcessor extends BasePlc4xProcessor {
 
 						try (PlcConnection connection = getConnectionManager().getConnection(getConnectionString(context, fileToProcess))) {
 							
-							writeRequest = getWriteRequest(logger, record, nrOfRowsHere, addressMap, tags, connection);
+							writeRequest = getWriteRequest(logger, addressMap, tags, record.toMap(), connection, nrOfRowsHere);
 
 							PlcWriteResponse plcWriteResponse = writeRequest.execute().get(getTimeout(context, fileToProcess), TimeUnit.MILLISECONDS);
 
 							// Response check if values were written
-							evaluateWriteResponse(logger, record, plcWriteResponse);
+							evaluateWriteResponse(logger, record.toMap(), plcWriteResponse);
 
 						} catch (TimeoutException e) {
 							logger.error("Timeout writting the data to the PLC", e);
@@ -149,7 +148,14 @@ public class Plc4xSinkRecordProcessor extends BasePlc4xProcessor {
 						}
 							
 						if (tags == null){
-							addTagsToCache(logger, addressMap, writeRequest);
+							if (debugEnabled)
+								logger.debug("Adding PlcTypes resolution into cache with key: " + addressMap);
+							getSchemaCache().addSchema(
+								addressMap, 
+								writeRequest.getTagNames(),
+								writeRequest.getTags(),
+								null
+							);
 						}
 						nrOfRows.getAndAdd(nrOfRowsHere.get());
 
@@ -168,83 +174,6 @@ public class Plc4xSinkRecordProcessor extends BasePlc4xProcessor {
 			throw e;
 		} 
 
-		FlowFile resultSetFF = createResultFlowFile(context, session, fileToProcess, logger, nrOfRows, executeTime);
-
-		session.transfer(resultSetFF, REL_SUCCESS);
-	}
-
-	private PlcWriteRequest getWriteRequest(final ComponentLog logger, Record record, AtomicLong nrOfRowsHere,
-			final Map<String, String> addressMap, final Map<String, PlcTag> tags, final PlcConnection connection) {
-
-		PlcWriteRequest.Builder builder = connection.writeRequestBuilder();
-
-		if (tags != null){
-			for (Map.Entry<String,PlcTag> tag : tags.entrySet()){
-				if (record.toMap().containsKey(tag.getKey())) {
-					builder.addTag(tag.getKey(), tag.getValue(), record.getValue(tag.getKey()));
-					nrOfRowsHere.incrementAndGet();
-				} else {
-					if (debugEnabled)
-						logger.debug("PlcTag " + tag + " is declared as address but was not found on input record.");
-				}
-			}
-		} else {
-			if (debugEnabled)
-				logger.debug("Plc-Avro schema and PlcTypes resolution not found in cache and will be added with key: " + addressMap);
-			for (Map.Entry<String,String> entry: addressMap.entrySet()){
-				if (record.toMap().containsKey(entry.getKey())) {
-					builder.addTagAddress(entry.getKey(), entry.getValue(), record.getValue(entry.getKey()));
-					nrOfRowsHere.incrementAndGet();
-				} else {
-					if (debugEnabled)
-						logger.debug("PlcTag " + entry.getKey() + " with address " + entry.getValue() + " was not found on input record.");
-				}
-			}
-		}
-		return builder.build();
-	}
-
-	private void evaluateWriteResponse(final ComponentLog logger, Record record, PlcWriteResponse plcWriteResponse) {
-
-		boolean codeErrorPresent = false;
-		List<String> tagsAtError = null;
-
-		PlcResponseCode code = null;
-
-		for (String tag : plcWriteResponse.getTagNames()) {
-			code = plcWriteResponse.getResponseCode(tag);
-			if (!code.equals(PlcResponseCode.OK)) {
-				if (tagsAtError == null) {
-					tagsAtError = new ArrayList<>();
-				}
-				logger.error("Not OK code when writing the data to PLC for tag " + tag 
-					+ " with value  " + record.getValue(tag).toString() 
-					+ " in addresss " + plcWriteResponse.getTag(tag).getAddressString());
-				
-			codeErrorPresent = true;
-			tagsAtError.add(tag);
-						
-			}
-		}
-		if (codeErrorPresent) {
-			throw new ProcessException("At least one error was found when while writting tags: " + tagsAtError.toString());
-		}
-	}
-
-
-	private void addTagsToCache(final ComponentLog logger, final Map<String, String> addressMap, PlcWriteRequest writeRequest) {
-		if (debugEnabled)
-			logger.debug("Adding PlcTypes resolution into cache with key: " + addressMap);
-		getSchemaCache().addSchema(
-			addressMap, 
-			writeRequest.getTagNames(),
-			writeRequest.getTags(),
-			null
-		);
-	}
-
-	private FlowFile createResultFlowFile(final ProcessContext context, final ProcessSession session, FlowFile fileToProcess,
-			final ComponentLog logger, final AtomicLong nrOfRows, final StopWatch executeTime) {
 
 		long executionTimeElapsed = executeTime.getElapsed(TimeUnit.MILLISECONDS);
 		final Map<String, String> attributesToAdd = new HashMap<>();
@@ -252,15 +181,15 @@ public class Plc4xSinkRecordProcessor extends BasePlc4xProcessor {
 		attributesToAdd.put(RESULT_QUERY_EXECUTION_TIME, String.valueOf(executionTimeElapsed));
 		attributesToAdd.put(INPUT_FLOWFILE_UUID, fileToProcess.getAttribute(CoreAttributes.UUID.key()));
 		
-		FlowFile resultSetFF = session.putAllAttributes(fileToProcess, attributesToAdd);
+		session.putAllAttributes(fileToProcess, attributesToAdd);
 
-		logger.info("Writing {} fields from {} records; transferring to 'success'", nrOfRows.get(), resultSetFF);
-
+		session.transfer(fileToProcess, REL_SUCCESS);
+		
+		logger.info("Writing {} fields from {} records; transferring to 'success'", nrOfRows.get(), fileToProcess);
 		if (context.hasIncomingConnection()) {
-			session.getProvenanceReporter().fetch(resultSetFF, "Writted " + nrOfRows.get() + " rows", executionTimeElapsed);
+			session.getProvenanceReporter().fetch(fileToProcess, "Writted " + nrOfRows.get() + " rows", executionTimeElapsed);
 		} else {
-			session.getProvenanceReporter().receive(resultSetFF, "Writted " + nrOfRows.get() + " rows", executionTimeElapsed);
+			session.getProvenanceReporter().receive(fileToProcess, "Writted " + nrOfRows.get() + " rows", executionTimeElapsed);
 		}
-		return resultSetFF;
 	}
 }

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSourceProcessor.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSourceProcessor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.plc4x.nifi;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -73,9 +72,6 @@ public class Plc4xSourceProcessor extends BasePlc4xProcessor {
 
 
             PlcReadRequest readRequest = getReadRequest(logger, addressMap, tags, connection);
-                
-
-            Map<String, String> attributes;
 
             try {
                 final PlcReadResponse response = readRequest.execute().get(getTimeout(context, incomingFlowFile), TimeUnit.MILLISECONDS);

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSourceProcessor.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSourceProcessor.java
@@ -46,6 +46,8 @@ import org.apache.plc4x.java.api.model.PlcTag;
 @WritesAttributes({@WritesAttribute(attribute="value", description="some value")})
 public class Plc4xSourceProcessor extends BasePlc4xProcessor {
 
+	public static final String EXCEPTION = "plc4x.read.exception";
+
     @Override
     public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
         
@@ -102,7 +104,7 @@ public class Plc4xSourceProcessor extends BasePlc4xProcessor {
         } catch (Exception e) {
             session.remove(flowFile);
             if (incomingFlowFile != null){
-                incomingFlowFile = session.putAttribute(incomingFlowFile, "exception", e.getLocalizedMessage());
+                incomingFlowFile = session.putAttribute(incomingFlowFile, EXCEPTION, e.getLocalizedMessage());
                 session.transfer(incomingFlowFile, REL_FAILURE);
             }
             session.commitAsync();

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSourceProcessor.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSourceProcessor.java
@@ -20,8 +20,8 @@ package org.apache.plc4x.nifi;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.WritesAttribute;
@@ -48,68 +48,109 @@ public class Plc4xSourceProcessor extends BasePlc4xProcessor {
 
     @Override
     public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        
+        FlowFile incomingFlowFile = null;
+        if (context.hasIncomingConnection()) {
+            incomingFlowFile = session.get();
+            if (incomingFlowFile == null && context.hasNonLoopConnection()) {
+                return;
+            }
+        }
 
         final ComponentLog logger = getLogger();
-        // Get an instance of a component able to read from a PLC.
-        try(PlcConnection connection = getConnectionManager().getConnection(getConnectionString())) {
+        final FlowFile flowFile = session.create();
+    
+        try(PlcConnection connection = getConnectionManager().getConnection(getConnectionString(context, incomingFlowFile))) {
 
-            // Prepare the request.
             if (!connection.getMetadata().canRead()) {
-                throw new ProcessException("Writing not supported by connection");
+                throw new ProcessException("Reading not supported by connection");
             }
 
-            FlowFile flowFile = session.create();
-            try {
-                PlcReadRequest.Builder builder = connection.readRequestBuilder();
-                Map<String,String> addressMap = getPlcAddressMap(context, flowFile);
-                final Map<String, PlcTag> tags = getSchemaCache().retrieveTags(addressMap);
+            final Map<String,String> addressMap = getPlcAddressMap(context, incomingFlowFile);
+            final Map<String, PlcTag> tags = getSchemaCache().retrieveTags(addressMap);
 
-                if (tags != null){
-                    for (Map.Entry<String,PlcTag> tag : tags.entrySet()){
-                        builder.addTag(tag.getKey(), tag.getValue());
-                    }
-                } else {
-                    if (debugEnabled)
-                        logger.debug("PlcTypes resolution not found in cache and will be added with key: " + addressMap);
-                    for (Map.Entry<String,String> entry: addressMap.entrySet()){
-                        builder.addTagAddress(entry.getKey(), entry.getValue());
-                    }
-                }
 
-                PlcReadRequest readRequest = builder.build();
-                PlcReadResponse response = readRequest.execute().get(this.timeout, TimeUnit.MILLISECONDS);
-                Map<String, String> attributes = new HashMap<>();
-                for (String tagName : response.getTagNames()) {
-                    for (int i = 0; i < response.getNumberOfValues(tagName); i++) {
-                        Object value = response.getObject(tagName, i);
-                        attributes.put(tagName, String.valueOf(value));
-                    }
-                }
-                flowFile = session.putAllAttributes(flowFile, attributes); 
+            PlcReadRequest readRequest = getReadRequest(logger, addressMap, tags, connection);
                 
-                if (tags == null){
-                    if (debugEnabled)
-                        logger.debug("Adding PlcTypes resolution into cache with key: " + addressMap);
-                    getSchemaCache().addSchema(
-                        addressMap, 
-                        readRequest.getTagNames(),
-                        readRequest.getTags(),
-                        null
-                    );
-                }
 
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+            Map<String, String> attributes;
+
+            try {
+                final PlcReadResponse response = readRequest.execute().get(getTimeout(context, incomingFlowFile), TimeUnit.MILLISECONDS);
+                
+                attributes = getNewAttributes(response);
+                
+            } catch (TimeoutException e) {
+                logger.error("Timeout reading the data from PLC", e);
+                getConnectionManager().removeCachedConnection(getConnectionString(context, incomingFlowFile));
                 throw new ProcessException(e);
-            } catch (ExecutionException e) {
-                throw new ProcessException(e);
+            } catch (Exception e) {
+                logger.error("Exception reading the data from PLC", e);
+                throw (e instanceof ProcessException) ? (ProcessException) e : new ProcessException(e);
+            }
+
+            session.putAllAttributes(flowFile, attributes);
+            if (incomingFlowFile != null) {
+                session.remove(incomingFlowFile);
             }
             session.transfer(flowFile, REL_SUCCESS);
-        } catch (ProcessException e) {
-            throw e;
+                
+            if (tags == null){
+                addTagsToCache(logger, addressMap, readRequest);
+            }
+            
         } catch (Exception e) {
-            throw new ProcessException("Got an error while trying to get a connection", e);
+            session.remove(flowFile);
+            if (incomingFlowFile != null){
+                incomingFlowFile = session.putAttribute(incomingFlowFile, "exception", e.getLocalizedMessage());
+                session.transfer(incomingFlowFile, REL_FAILURE);
+            }
+            session.commitAsync();
+            throw (e instanceof ProcessException) ? (ProcessException) e : new ProcessException(e);
         }
+    }
+
+    private PlcReadRequest getReadRequest(final ComponentLog logger, final Map<String, String> addressMap, 
+            final Map<String, PlcTag> tags , final PlcConnection connection) {
+
+        PlcReadRequest.Builder builder = connection.readRequestBuilder();
+        
+        if (tags != null){
+            for (Map.Entry<String,PlcTag> tag : tags.entrySet()){
+                builder.addTag(tag.getKey(), tag.getValue());
+            }
+        } else {
+            if (debugEnabled)
+                logger.debug("PlcTypes resolution not found in cache and will be added with key: " + addressMap);
+            for (Map.Entry<String,String> entry: addressMap.entrySet()){
+                builder.addTagAddress(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return builder.build();
+    }
+
+    private Map<String, String> getNewAttributes(PlcReadResponse response) {
+        Map<String, String> attributes = new HashMap<>();
+        for (String tagName : response.getTagNames()) {
+            for (int i = 0; i < response.getNumberOfValues(tagName); i++) {
+                Object value = response.getObject(tagName, i);
+                attributes.put(tagName, String.valueOf(value));
+            }
+        }
+        return attributes;
+    }
+
+    private void addTagsToCache(final ComponentLog logger, final Map<String, String> addressMap,
+            PlcReadRequest readRequest) {
+        if (debugEnabled)
+            logger.debug("Adding PlcTypes resolution into cache with key: " + addressMap);
+        getSchemaCache().addSchema(
+            addressMap, 
+            readRequest.getTagNames(),
+            readRequest.getTags(),
+            null
+        );
     }
 
 }

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSourceRecordProcessor.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSourceRecordProcessor.java
@@ -140,7 +140,7 @@ public class Plc4xSourceRecordProcessor extends BasePlc4xProcessor {
 
 				} catch (TimeoutException e) {
 					logger.error("Timeout reading the data from PLC", e);
-					refreshConnectionManager();
+					getConnectionManager().removeCachedConnection(getConnectionString(context, originalFlowFile));
 					throw new ProcessException(e);
 				} catch (PlcConnectionException e) {
 					logger.error("Error getting the PLC connection", e);
@@ -159,8 +159,10 @@ public class Plc4xSourceRecordProcessor extends BasePlc4xProcessor {
 			
 		} catch (Exception e) {
 			logger.error("Exception reading the data from the PLC", e);
-			session.putAttribute(fileToProcess, "exception", e.getLocalizedMessage());
-			session.transfer(fileToProcess, REL_FAILURE);
+			if (fileToProcess != null) {
+				session.putAttribute(fileToProcess, "exception", e.getLocalizedMessage());
+				session.transfer(fileToProcess, REL_FAILURE);
+			}
 			session.remove(resultSetFF);
 			session.commitAsync();
 			throw (e instanceof ProcessException) ? (ProcessException) e : new ProcessException(e);

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSourceRecordProcessor.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSourceRecordProcessor.java
@@ -70,6 +70,7 @@ public class Plc4xSourceRecordProcessor extends BasePlc4xProcessor {
 	public static final String RESULT_ROW_COUNT = "plc4x.read.row.count";
 	public static final String RESULT_QUERY_EXECUTION_TIME = "plc4x.read.query.executiontime";
 	public static final String INPUT_FLOWFILE_UUID = "input.flowfile.uuid";
+	public static final String EXCEPTION = "plc4x.read.exception";
 
 	public static final PropertyDescriptor PLC_RECORD_WRITER_FACTORY = new PropertyDescriptor.Builder()
 		.name("plc4x-record-writer").displayName("Record Writer")
@@ -160,7 +161,7 @@ public class Plc4xSourceRecordProcessor extends BasePlc4xProcessor {
 		} catch (Exception e) {
 			logger.error("Exception reading the data from the PLC", e);
 			if (fileToProcess != null) {
-				session.putAttribute(fileToProcess, "exception", e.getLocalizedMessage());
+				session.putAttribute(fileToProcess, EXCEPTION, e.getLocalizedMessage());
 				session.transfer(fileToProcess, REL_FAILURE);
 			}
 			session.remove(resultSetFF);

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSourceRecordProcessor.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/Plc4xSourceRecordProcessor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.plc4x.nifi;
 
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,7 +36,6 @@ import org.apache.nifi.annotation.behavior.WritesAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.SeeAlso;
 import org.apache.nifi.annotation.documentation.Tags;
-import org.apache.nifi.annotation.lifecycle.OnScheduled;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
@@ -71,7 +71,8 @@ public class Plc4xSourceRecordProcessor extends BasePlc4xProcessor {
 	public static final String RESULT_QUERY_EXECUTION_TIME = "plc4x.read.query.executiontime";
 	public static final String INPUT_FLOWFILE_UUID = "input.flowfile.uuid";
 
-	public static final PropertyDescriptor PLC_RECORD_WRITER_FACTORY = new PropertyDescriptor.Builder().name("plc4x-record-writer").displayName("Record Writer")
+	public static final PropertyDescriptor PLC_RECORD_WRITER_FACTORY = new PropertyDescriptor.Builder()
+		.name("plc4x-record-writer").displayName("Record Writer")
 		.description("Specifies the Controller Service to use for writing results to a FlowFile. The Record Writer may use Inherit Schema to emulate the inferred schema behavior, i.e. "
 				+ "an explicit schema need not be defined in the writer, and will be supplied by the same logic used to infer the schema from the column types.")
 		.identifiesControllerService(RecordSetWriterFactory.class)
@@ -89,36 +90,95 @@ public class Plc4xSourceRecordProcessor extends BasePlc4xProcessor {
 		this.properties = Collections.unmodifiableList(pds);
 	}
 
-	@OnScheduled
-	@Override
-	public void onScheduled(final ProcessContext context) {
-		super.onScheduled(context);
-	}
 	
 	@Override
 	public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+		
 		FlowFile fileToProcess = null;
-		// TODO: In the future the processor will be configurable to get the connection from incoming flowfile
 		if (context.hasIncomingConnection()) {
 			fileToProcess = session.get();
-			// If we have no FlowFile, and all incoming connections are self-loops then we
-			// can continue on.
-			// However, if we have no FlowFile and we have connections coming from other
-			// Processors, then we know that we should run only if we have a FlowFile.
+			
 			if (fileToProcess == null && context.hasNonLoopConnection()) {
 				return;
 			}
 		}
-		
-		Plc4xWriter plc4xWriter = new RecordPlc4xWriter(context.getProperty(PLC_RECORD_WRITER_FACTORY).asControllerService(RecordSetWriterFactory.class), fileToProcess == null ? Collections.emptyMap() : fileToProcess.getAttributes());
+
 		final ComponentLog logger = getLogger();
+		
+		
 		// Get an instance of a component able to read from a PLC.
-		// TODO: Change this to use NiFi service instead of direct connection
 		final AtomicLong nrOfRows = new AtomicLong(0L);
 		final StopWatch executeTime = new StopWatch(true);
 
 		String inputFileUUID = fileToProcess == null ? null : fileToProcess.getAttribute(CoreAttributes.UUID.key());
+		final FlowFile resultSetFF = createResultFlowFile(session, fileToProcess);
+
+		final FlowFile originalFlowFile = fileToProcess;
+
+		Plc4xWriter plc4xWriter = new RecordPlc4xWriter(context.getProperty(PLC_RECORD_WRITER_FACTORY).asControllerService(RecordSetWriterFactory.class), 
+			fileToProcess == null ? Collections.emptyMap() : fileToProcess.getAttributes());
+
+
+		try {
+			session.write(resultSetFF, out -> {
+
+			
+
+				final Map<String,String> addressMap = getPlcAddressMap(context, originalFlowFile);
+				final RecordSchema recordSchema = getSchemaCache().retrieveSchema(addressMap);
+				final Map<String, PlcTag> tags = getSchemaCache().retrieveTags(addressMap);
+				PlcReadRequest readRequest;
+				Long nrOfRowsHere;
+
+				try (PlcConnection connection = getConnectionManager().getConnection(getConnectionString(context, originalFlowFile))) {
+					
+					readRequest =  getReadRequest(logger, addressMap, tags, connection);
+					
+					PlcReadResponse readResponse = readRequest.execute().get(getTimeout(context, originalFlowFile), TimeUnit.MILLISECONDS);
+							
+					nrOfRowsHere = evaluateReadResponse(context, logger, originalFlowFile, plc4xWriter, out, recordSchema, readResponse);
+
+				} catch (TimeoutException e) {
+					logger.error("Timeout reading the data from PLC", e);
+					refreshConnectionManager();
+					throw new ProcessException(e);
+				} catch (PlcConnectionException e) {
+					logger.error("Error getting the PLC connection", e);
+					throw new ProcessException("Got an a PlcConnectionException while trying to get a connection", e);
+				} catch (Exception e) {
+					logger.error("Exception reading the data from PLC", e);
+					throw (e instanceof ProcessException) ? (ProcessException) e : new ProcessException(e);
+				}
+
+				if (recordSchema == null){
+					addTagsToCache(logger, addressMap, readRequest, plc4xWriter.getRecordSchema());
+				}
+				nrOfRows.set(nrOfRowsHere);
+
+			});
+			
+		} catch (Exception e) {
+			logger.error("Exception reading the data from the PLC", e);
+			session.putAttribute(fileToProcess, "exception", e.getLocalizedMessage());
+			session.transfer(fileToProcess, REL_FAILURE);
+			session.remove(resultSetFF);
+			session.commitAsync();
+			throw (e instanceof ProcessException) ? (ProcessException) e : new ProcessException(e);
+		}
+
+		completeResultFlowFile(context, session, logger, nrOfRows, executeTime, inputFileUUID, resultSetFF,
+				plc4xWriter);
+		
+		if (fileToProcess != null) {
+			session.remove(fileToProcess);
+		}
+		session.transfer(resultSetFF, REL_SUCCESS);
+	}
+
+	private FlowFile createResultFlowFile(final ProcessSession session, FlowFile fileToProcess) {
+
 		Map<String, String> inputFileAttrMap = fileToProcess == null ? null : fileToProcess.getAttributes();
+		
 		FlowFile resultSetFF;
 		if (fileToProcess == null) {
 			resultSetFF = session.create();
@@ -128,91 +188,74 @@ public class Plc4xSourceRecordProcessor extends BasePlc4xProcessor {
 		if (inputFileAttrMap != null) {
 			resultSetFF = session.putAllAttributes(resultSetFF, inputFileAttrMap);
 		}
+		return resultSetFF;
+	}
 
-		try (PlcConnection connection = getConnectionManager().getConnection(getConnectionString())) {
-			PlcReadRequest.Builder builder = connection.readRequestBuilder();
-			Map<String,String> addressMap = getPlcAddressMap(context, fileToProcess);
-			final RecordSchema recordSchema = getSchemaCache().retrieveSchema(addressMap);
-			final Map<String, PlcTag> tags = getSchemaCache().retrieveTags(addressMap);
+	private PlcReadRequest getReadRequest(final ComponentLog logger, final Map<String, String> addressMap,
+			final Map<String, PlcTag> tags, final PlcConnection connection) {
 
-			if (tags != null){
-				for (Map.Entry<String,PlcTag> tag : tags.entrySet()){
-					builder.addTag(tag.getKey(), tag.getValue());
-				}
-			} else {
-				if (debugEnabled)
-                    logger.debug("Plc-Avro schema and PlcTypes resolution not found in cache and will be added with key: " + addressMap);
-				for (Map.Entry<String,String> entry: addressMap.entrySet()){
-					builder.addTagAddress(entry.getKey(), entry.getValue());
-				}
-			}
-            
-			PlcReadRequest readRequest = builder.build();
-			final FlowFile originalFlowFile = fileToProcess;
-			resultSetFF = session.write(resultSetFF, out -> {
-				try {
-					PlcReadResponse readResponse = readRequest.execute().get(this.timeout, TimeUnit.MILLISECONDS);
-					
-					if(originalFlowFile == null) //there is no inherit attributes to use in writer service 
-						nrOfRows.set(plc4xWriter.writePlcReadResponse(readResponse, out, logger, null, recordSchema));
-					else 
-						nrOfRows.set(plc4xWriter.writePlcReadResponse(readResponse, out, logger, null, recordSchema, originalFlowFile));
-				} catch (InterruptedException e) {
-					logger.error("InterruptedException reading the data from PLC", e);
-		            Thread.currentThread().interrupt();
-		            throw new ProcessException(e);
-				} catch (TimeoutException e) {
-					logger.error("Timeout reading the data from PLC", e);
-					throw new ProcessException(e);
-				} catch (Exception e) {
-					logger.error("Exception reading the data from PLC", e);
-					throw (e instanceof ProcessException) ? (ProcessException) e : new ProcessException(e);
-				}
-			});
+		PlcReadRequest.Builder builder = connection.readRequestBuilder();
 
-			if (recordSchema == null){
-				if (debugEnabled)
-                    logger.debug("Adding Plc-Avro schema and PlcTypes resolution into cache with key: " + addressMap);
-				getSchemaCache().addSchema(
-					addressMap, 
-					readRequest.getTagNames(),
-					readRequest.getTags(),
-					plc4xWriter.getRecordSchema()
-				);
+		if (tags != null){
+			for (Map.Entry<String,PlcTag> tag : tags.entrySet()){
+				builder.addTag(tag.getKey(), tag.getValue());
 			}
-			long executionTimeElapsed = executeTime.getElapsed(TimeUnit.MILLISECONDS);
-			final Map<String, String> attributesToAdd = new HashMap<>();
-			attributesToAdd.put(RESULT_ROW_COUNT, String.valueOf(nrOfRows.get()));
-			attributesToAdd.put(RESULT_QUERY_EXECUTION_TIME, String.valueOf(executionTimeElapsed));
-			if (inputFileUUID != null) {
-				attributesToAdd.put(INPUT_FLOWFILE_UUID, inputFileUUID);
+		} else {
+			if (debugEnabled)
+				logger.debug("Plc-Avro schema and PlcTypes resolution not found in cache and will be added with key: " + addressMap);
+			for (Map.Entry<String,String> entry: addressMap.entrySet()){
+				builder.addTagAddress(entry.getKey(), entry.getValue());
 			}
-			attributesToAdd.putAll(plc4xWriter.getAttributesToAdd());
-			resultSetFF = session.putAllAttributes(resultSetFF, attributesToAdd);
-			plc4xWriter.updateCounters(session);
-			logger.info("{} contains {} records; transferring to 'success'", new Object[] { resultSetFF, nrOfRows.get() });
-			// Report a FETCH event if there was an incoming flow file, or a RECEIVE event
-			// otherwise
-			if (context.hasIncomingConnection()) {
-				session.getProvenanceReporter().fetch(resultSetFF, "Retrieved " + nrOfRows.get() + " rows", executionTimeElapsed);
-			} else {
-				session.getProvenanceReporter().receive(resultSetFF, "Retrieved " + nrOfRows.get() + " rows", executionTimeElapsed);
-			}
-			
-			session.transfer(resultSetFF, BasePlc4xProcessor.REL_SUCCESS);
-			// Need to remove the original input file if it exists
-			if (fileToProcess != null) {
-				session.remove(fileToProcess);
-				fileToProcess = null;
-			}
-			session.commitAsync();
-			
-		} catch (PlcConnectionException e) {
-			logger.error("Error getting the PLC connection", e);
-			throw new ProcessException("Got an a PlcConnectionException while trying to get a connection", e);
-		} catch (Exception e) {
-			logger.error("Got an error while trying to get a connection", e);
-			throw new ProcessException("Got an error while trying to get a connection", e);
+		}
+		return builder.build();
+	}
+
+
+	private long evaluateReadResponse(final ProcessContext context, final ComponentLog logger, final FlowFile originalFlowFile,
+			Plc4xWriter plc4xWriter, OutputStream out, final RecordSchema recordSchema, PlcReadResponse readResponse)
+			throws Exception {
+
+		if(originalFlowFile == null) //there is no inherit attributes to use in writer service 
+			return plc4xWriter.writePlcReadResponse(readResponse, out, logger, null, recordSchema, getTimestampField(context));
+		else 
+			return plc4xWriter.writePlcReadResponse(readResponse, out, logger, null, recordSchema, originalFlowFile, getTimestampField(context));
+	}
+
+	private void addTagsToCache(final ComponentLog logger, final Map<String, String> addressMap,
+			PlcReadRequest readRequest, RecordSchema schema) {
+		if (debugEnabled)
+			logger.debug("Adding Plc-Avro schema and PlcTypes resolution into cache with key: " + addressMap);
+		getSchemaCache().addSchema(
+			addressMap, 
+			readRequest.getTagNames(),
+			readRequest.getTags(),
+			schema
+		);
+	}
+
+	private void completeResultFlowFile(final ProcessContext context, final ProcessSession session,
+			final ComponentLog logger, final AtomicLong nrOfRows, final StopWatch executeTime, String inputFileUUID,
+			FlowFile resultSetFF, Plc4xWriter plc4xWriter) {
+		
+		long executionTimeElapsed = executeTime.getElapsed(TimeUnit.MILLISECONDS);
+		final Map<String, String> attributesToAdd = new HashMap<>();
+		attributesToAdd.put(RESULT_ROW_COUNT, String.valueOf(nrOfRows.get()));
+		attributesToAdd.put(RESULT_QUERY_EXECUTION_TIME, String.valueOf(executionTimeElapsed));
+		if (inputFileUUID != null) {
+			attributesToAdd.put(INPUT_FLOWFILE_UUID, inputFileUUID);
+		}
+		attributesToAdd.putAll(plc4xWriter.getAttributesToAdd());
+
+		resultSetFF = session.putAllAttributes(resultSetFF, attributesToAdd);
+		plc4xWriter.updateCounters(session);
+		
+		logger.info("{} contains {} records; transferring to 'success'", resultSetFF, nrOfRows.get());
+
+		if (context.hasIncomingConnection()) {
+			session.getProvenanceReporter().fetch(resultSetFF, "Retrieved " + nrOfRows.get() + " rows", executionTimeElapsed);
+		} else {
+			session.getProvenanceReporter().receive(resultSetFF, "Retrieved " + nrOfRows.get() + " rows", executionTimeElapsed);
 		}
 	}
+
 }

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/address/AddressesAccessStrategy.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/address/AddressesAccessStrategy.java
@@ -16,11 +16,32 @@
  */
 package org.apache.plc4x.nifi.address;
 
+import org.apache.nifi.components.AllowableValue;
+import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessContext;
 
+import java.util.List;
 import java.util.Map;
 
 public interface AddressesAccessStrategy {
+    /**
+     * Returns the allowable value associated with the strategy.
+     * @return AllowableValue the allowable value associated
+     */
+    AllowableValue getAllowableValue();
+
+    /**
+     * Returns a list of property descriptors needed in for the strategy.
+     * @return List of PropertyDescriptor needed for the strategy
+     */
+    List<PropertyDescriptor> getPropertyDescriptors();
+    
+    /**
+     * Returns a map with the names and addresses of the tags.
+     * @param context the context of the processor
+     * @param flowFile the FlowFile being processed
+     * @return Map with the tag names and addresses
+     */
     Map<String, String> extractAddresses(final ProcessContext context, final FlowFile flowFile);
 }

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/address/AddressesAccessUtils.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/address/AddressesAccessUtils.java
@@ -22,46 +22,75 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.util.JsonValidator;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.plc4x.java.DefaultPlcDriverManager;
 
 public class AddressesAccessUtils {
-    public static final AllowableValue ADDRESS_PROPERTY = new AllowableValue(
-            "property-address",
-            "Use Properties as Addresses",
-            "Each property will be treated as tag-address pairs after Expression Language is evaluated.");
 
-    public static final AllowableValue ADDRESS_TEXT = new AllowableValue(
-            "text-address",
-            "Use 'Address Text' Property",
-            "Addresses will be obtained from 'Address Text' Property. It's content must be a valid JSON " +
-                    "after Expression Language is evaluated. ");
+	private static DefaultPlcDriverManager manager = new DefaultPlcDriverManager();
 
-    public static final PropertyDescriptor PLC_ADDRESS_ACCESS_STRATEGY = new PropertyDescriptor.Builder()
-            .name("plc4x-address-access-strategy")
-            .displayName("Address Access Strategy")
-            .description("Strategy used to obtain the PLC addresses")
-            .allowableValues(ADDRESS_PROPERTY, ADDRESS_TEXT)
-            .defaultValue(ADDRESS_PROPERTY.getValue())
-            .required(true)
-            .build();
-
-    public static final PropertyDescriptor ADDRESS_TEXT_PROPERTY = new PropertyDescriptor.Builder()
-            .name("text-address-property")
-            .displayName("Address Text")
-            .description("Must contain a valid JSON object after Expression Language is evaluated. "
-                    + "Each field-value is treated as tag-address.")
-            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
-            .addValidator(new JsonValidator())
-            .addValidator(new TextPropertyAccessStrategy.TagValidator())
-            .dependsOn(PLC_ADDRESS_ACCESS_STRATEGY, ADDRESS_TEXT)
-            .required(true)
-            .build();
-
-    public static AddressesAccessStrategy getAccessStrategy(final ProcessContext context) {
-        String value = context.getProperty(PLC_ADDRESS_ACCESS_STRATEGY).getValue();
-        if (ADDRESS_PROPERTY.getValue().equalsIgnoreCase(value))
-            return new DynamicPropertyAccessStrategy();
-        else if (ADDRESS_TEXT.getValue().equalsIgnoreCase(value))
-            return new TextPropertyAccessStrategy();
-        return null;
+    public static DefaultPlcDriverManager getManager() {
+        return manager;
     }
+	
+	public static final AllowableValue ADDRESS_PROPERTY = new AllowableValue(
+		"property-address",
+		"Use Properties as Addresses",
+		"Each property will be treated as tag-address pairs after Expression Language is evaluated.");
+
+	public static final AllowableValue ADDRESS_TEXT = new AllowableValue(
+		"text-address",
+		"Use 'Address Text' Property",
+		"Addresses will be obtained from 'Address Text' Property. It's content must be a valid JSON " +
+			"after Expression Language is evaluated. ");
+
+	public static final AllowableValue ADDRESS_FILE = new AllowableValue(
+		"file-address",
+		"Use 'Address File' Property",
+		"Addresses will be obtained from the file in 'Address File' Property. It's content must be a valid JSON " +
+			"after Expression Language is evaluated. ");
+
+	public static final PropertyDescriptor PLC_ADDRESS_ACCESS_STRATEGY = new PropertyDescriptor.Builder()
+		.name("plc4x-address-access-strategy")
+		.displayName("Address Access Strategy")
+		.description("Strategy used to obtain the PLC addresses")
+		.allowableValues(ADDRESS_PROPERTY, ADDRESS_TEXT, ADDRESS_FILE)
+		.defaultValue(ADDRESS_PROPERTY.getValue())
+		.required(true)
+		.build();
+
+	public static final PropertyDescriptor ADDRESS_TEXT_PROPERTY = new PropertyDescriptor.Builder()
+		.name("text-address-property")
+		.displayName("Address Text")
+		.description("Must contain a valid JSON object after Expression Language is evaluated. "
+			+ "Each field-value is treated as tag-address.")
+		.expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+		.addValidator(new JsonValidator())
+		.addValidator(new TextPropertyAccessStrategy.TagValidator(manager))
+		.dependsOn(PLC_ADDRESS_ACCESS_STRATEGY, ADDRESS_TEXT)
+		.required(true)
+		.build();
+
+	public static final PropertyDescriptor ADDRESS_FILE_PROPERTY = new PropertyDescriptor.Builder()
+		.name("file-address-property")
+		.displayName("Address File")
+		.description("Must contain a valid path after Expression Language is evaluated. "
+			+ "The file content must be a valid JSON and each field-value is treated as tag-address.")
+		.expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+		.addValidator(StandardValidators.FILE_EXISTS_VALIDATOR)
+		.addValidator(new FilePropertyAccessStrategy.TagValidator(manager))
+		.dependsOn(PLC_ADDRESS_ACCESS_STRATEGY, ADDRESS_FILE)
+		.required(true)
+		.build();
+
+	public static AddressesAccessStrategy getAccessStrategy(final ProcessContext context) {
+		String value = context.getProperty(PLC_ADDRESS_ACCESS_STRATEGY).getValue();
+		if (ADDRESS_PROPERTY.getValue().equalsIgnoreCase(value))
+			return new DynamicPropertyAccessStrategy();
+		else if (ADDRESS_TEXT.getValue().equalsIgnoreCase(value))
+			return new TextPropertyAccessStrategy();
+		else if (ADDRESS_FILE.getValue().equalsIgnoreCase(value))
+			return new FilePropertyAccessStrategy();
+		return null;
+	}
 }

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/address/AddressesAccessUtils.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/address/AddressesAccessUtils.java
@@ -51,6 +51,7 @@ public class AddressesAccessUtils {
                     + "Each field-value is treated as tag-address.")
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .addValidator(new JsonValidator())
+            .addValidator(new TextPropertyAccessStrategy.TagValidator())
             .dependsOn(PLC_ADDRESS_ACCESS_STRATEGY, ADDRESS_TEXT)
             .required(true)
             .build();

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/address/BaseAccessStrategy.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/address/BaseAccessStrategy.java
@@ -54,7 +54,7 @@ public abstract class BaseAccessStrategy implements AddressesAccessStrategy{
     @Override
     public Map<String, String> extractAddresses(final ProcessContext context, final FlowFile flowFile) {
         if (!isInitializated) {
-            propertyDescriptors.forEach(prop -> {
+            getPropertyDescriptors().forEach(prop -> {
                 if (context.isExpressionLanguagePresent(prop)){
                     isDynamic = true;
                 }

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/address/BaseAccessStrategy.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/address/BaseAccessStrategy.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.plc4x.nifi.address;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.nifi.components.AllowableValue;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.Validator;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.plc4x.java.DefaultPlcDriverManager;
+import org.apache.plc4x.java.api.PlcDriver;
+import org.apache.plc4x.nifi.BasePlc4xProcessor;
+
+
+public abstract class BaseAccessStrategy implements AddressesAccessStrategy{
+    private boolean isInitializated = false;
+    private boolean isDynamic;
+    protected Map<String,String> cachedAddresses = null;
+
+    protected AllowableValue allowableValue;
+    protected List<PropertyDescriptor> propertyDescriptors = new ArrayList<>();
+
+    protected Map<String, String> getCachedAddresses() {
+        return cachedAddresses;
+    }
+
+    public Map<String,String> extractAddressesFromResources(final ProcessContext context, final FlowFile flowFile) {
+        throw new UnsupportedOperationException("Method 'extractAddressesFromResources' not implemented");
+    }
+
+
+    @Override
+    public Map<String, String> extractAddresses(final ProcessContext context, final FlowFile flowFile) {
+        if (!isInitializated) {
+            propertyDescriptors.forEach(prop -> {
+                if (context.isExpressionLanguagePresent(prop)){
+                    isDynamic = true;
+                }
+            });
+            isInitializated = true;
+        }
+
+        Map<String, String> result = getCachedAddresses();
+        if (result == null) {
+            result = extractAddressesFromResources(context, flowFile);
+            if (!isDynamic) {
+                cachedAddresses = result;
+            }
+        }
+        return result;
+    }
+
+    public static class TagValidator implements Validator {
+        
+        private DefaultPlcDriverManager manager;
+
+        public TagValidator(DefaultPlcDriverManager manager) {
+            this.manager = manager;
+        }
+
+        protected void checkTags(PlcDriver driver, Collection<String> tags) {
+            for (String tag : tags) {
+                driver.prepareTag(tag);
+            }
+        }
+
+        protected Collection<String> getTags(String input) throws Exception {
+            throw new UnsupportedOperationException("Method 'getTags' not implemented");
+        } 
+
+        @Override
+        public ValidationResult validate(String subject, String input, ValidationContext context) {
+            String connectionString = context.getProperty(BasePlc4xProcessor.PLC_CONNECTION_STRING).getValue();
+
+            if (context.isExpressionLanguageSupported(subject) && context.isExpressionLanguagePresent(input) || 
+                context.isExpressionLanguagePresent(connectionString)) {
+                return new ValidationResult.Builder().subject(subject).input(input)
+                    .explanation("Expression Language Present").valid(true).build();
+            }
+
+            try {
+                PlcDriver driver = manager.getDriverForUrl(connectionString);
+
+                if (!context.isExpressionLanguagePresent(input)) {
+                    checkTags(driver, getTags(input));
+                } 
+                
+            }catch (Exception e) {
+                    return new ValidationResult.Builder().subject(subject)
+                        .explanation(e.getLocalizedMessage())
+                        .valid(false)
+                        .build();
+            }
+            
+            return new ValidationResult.Builder().subject(subject)
+                .explanation("")
+                .valid(true)
+                .build();
+        }
+    }
+    
+}

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/address/FilePropertyAccessStrategy.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/address/FilePropertyAccessStrategy.java
@@ -57,7 +57,7 @@ public class FilePropertyAccessStrategy extends BaseAccessStrategy {
         }
     }
 
-    private static  Map<String,String> extractAddressesFromFile(String fileName) throws IOException {
+    public static Map<String,String> extractAddressesFromFile(String fileName) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
 
         Path filePath = Path.of(fileName);

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/address/TextPropertyAccessStrategy.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/address/TextPropertyAccessStrategy.java
@@ -19,19 +19,25 @@ package org.apache.plc4x.nifi.address;
 
 import java.util.Map;
 
+import org.apache.nifi.components.ValidationContext;
+import org.apache.nifi.components.ValidationResult;
+import org.apache.nifi.components.Validator;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.plc4x.java.DefaultPlcDriverManager;
+import org.apache.plc4x.java.api.PlcDriver;
+import org.apache.plc4x.nifi.BasePlc4xProcessor;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class TextPropertyAccessStrategy implements AddressesAccessStrategy{
+
     private Map<String,String> extractAddressesFromText(String input) throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
 
-        return mapper.readValue(input, Map.class);
+        return mapper.readerForMapOf(String.class).readValue(input);
     }
 
     @Override
@@ -42,5 +48,45 @@ public class TextPropertyAccessStrategy implements AddressesAccessStrategy{
             throw new ProcessException(e.toString());
         }
         
+    }
+
+    public static class TagValidator implements Validator {
+        @Override
+        public ValidationResult validate(String subject, String input, ValidationContext context) {
+
+            String connectionString = context.getProperty(BasePlc4xProcessor.PLC_CONNECTION_STRING).getValue();
+
+            if (context.isExpressionLanguageSupported(subject) && context.isExpressionLanguagePresent(input) || 
+                context.isExpressionLanguagePresent(connectionString)) {
+                return new ValidationResult.Builder().subject(subject).input(input).explanation("Expression Language Present").valid(true).build();
+            }
+            
+            try {
+                DefaultPlcDriverManager manager = new DefaultPlcDriverManager();
+                PlcDriver driver =  manager.getDriverForUrl(connectionString);
+
+                if (!context.isExpressionLanguagePresent(input)) {
+                    ObjectMapper mapper = new ObjectMapper();
+
+                    
+                    Map<String, String> tags = mapper.readerForMapOf(String.class).readValue(input);
+                    
+                    for(String value : tags.values()){
+                        driver.prepareTag(value);
+                    }
+                } 
+                
+            }catch (Exception e) {
+                    return new ValidationResult.Builder().subject(subject)
+                        .explanation(e.getLocalizedMessage())
+                        .valid(false)
+                        .build();
+            }
+            
+            return new ValidationResult.Builder().subject(subject)
+                .explanation("")
+                .valid(true)
+                .build();
+        }
     }
 }

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/record/Plc4xWriter.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/record/Plc4xWriter.java
@@ -39,8 +39,8 @@ public interface Plc4xWriter {
      * @return the number of rows written to the output stream
      * @throws Exception if any errors occur during the writing of the result set to the output stream
      */
-    long writePlcReadResponse(PlcReadResponse response, OutputStream outputStream, ComponentLog logger,  Plc4xReadResponseRowCallback callback, RecordSchema recordSchema) throws Exception;
-    long writePlcReadResponse(PlcReadResponse response, OutputStream outputStream, ComponentLog logger,  Plc4xReadResponseRowCallback callback, RecordSchema recordSchema, FlowFile originalFlowFile) throws Exception;
+    long writePlcReadResponse(PlcReadResponse response, OutputStream outputStream, ComponentLog logger,  Plc4xReadResponseRowCallback callback, RecordSchema recordSchema, String timestampFieldName) throws Exception;
+    long writePlcReadResponse(PlcReadResponse response, OutputStream outputStream, ComponentLog logger,  Plc4xReadResponseRowCallback callback, RecordSchema recordSchema, FlowFile originalFlowFile, String timestampFieldName) throws Exception;
 
     /**
      * Returns a map of attribute key/value pairs to be added to any outgoing flow file(s). The default implementation is to return an empty map.

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/record/RecordPlc4xWriter.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/record/RecordPlc4xWriter.java
@@ -55,9 +55,11 @@ public class RecordPlc4xWriter implements Plc4xWriter {
     }
 
     @Override
-    public long writePlcReadResponse(PlcReadResponse response, OutputStream outputStream, ComponentLog logger, Plc4xReadResponseRowCallback callback, RecordSchema recordSchema) throws Exception {
-        if (fullRecordSet == null) {
-            fullRecordSet = new Plc4xReadResponseRecordSetWithCallback(response, callback, recordSchema);
+    public long writePlcReadResponse(PlcReadResponse response, OutputStream outputStream, ComponentLog logger, 
+                Plc4xReadResponseRowCallback callback, RecordSchema recordSchema, String timestampFieldName) throws Exception {
+        
+                    if (fullRecordSet == null) {
+            fullRecordSet = new Plc4xReadResponseRecordSetWithCallback(response, callback, recordSchema, timestampFieldName);
             writeSchema = recordSetWriterFactory.getSchema(originalAttributes, fullRecordSet.getSchema());
         }
         Map<String, String> empty = new HashMap<>();
@@ -73,9 +75,11 @@ public class RecordPlc4xWriter implements Plc4xWriter {
     }
 
     @Override
-    public long writePlcReadResponse(PlcReadResponse response, OutputStream outputStream, ComponentLog logger, Plc4xReadResponseRowCallback callback, RecordSchema recordSchema, FlowFile originalFlowFile) throws Exception {
-        if (fullRecordSet == null) {
-            fullRecordSet = new Plc4xReadResponseRecordSetWithCallback(response, callback, recordSchema);
+    public long writePlcReadResponse(PlcReadResponse response, OutputStream outputStream, ComponentLog logger, 
+            Plc4xReadResponseRowCallback callback, RecordSchema recordSchema, FlowFile originalFlowFile, String timestampFieldName) throws Exception {
+        
+                if (fullRecordSet == null) {
+            fullRecordSet = new Plc4xReadResponseRecordSetWithCallback(response, callback, recordSchema, timestampFieldName);
             writeSchema = recordSetWriterFactory.getSchema(originalAttributes, fullRecordSet.getSchema());
         }
 
@@ -158,8 +162,10 @@ public class RecordPlc4xWriter implements Plc4xWriter {
     private static class Plc4xReadResponseRecordSetWithCallback extends Plc4xReadResponseRecordSet {
         private final Plc4xReadResponseRowCallback callback;
 
-        public Plc4xReadResponseRecordSetWithCallback(final PlcReadResponse readResponse, Plc4xReadResponseRowCallback callback, RecordSchema recordSchema) throws IOException {
-            super(readResponse, recordSchema);
+        public Plc4xReadResponseRecordSetWithCallback(final PlcReadResponse readResponse, Plc4xReadResponseRowCallback callback, 
+                RecordSchema recordSchema, String timestampFieldName) {
+
+            super(readResponse, recordSchema, timestampFieldName);
             this.callback = callback;
         }
 

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/record/SchemaCache.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/record/SchemaCache.java
@@ -19,9 +19,9 @@
 package org.apache.plc4x.nifi.record;
 
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -60,7 +60,7 @@ public class SchemaCache {
      * @param tagsList list of PlcTag's
      * @param schema record schema used for PlcResponse serialization. Can be null
      */
-    public void addSchema(final Map<String,String> schemaIdentifier, final LinkedHashSet<String> tagsNames, final List<? extends PlcTag> tagsList,  final RecordSchema schema) {        
+    public void addSchema(final Map<String,String> schemaIdentifier, final Set<String> tagsNames, final List<? extends PlcTag> tagsList,  final RecordSchema schema) {        
         if (!schemaMap.containsKey(schemaIdentifier.toString())){
             if (nextSchemaPosition.get() == cacheSize.get()){
                 nextSchemaPosition.set(0);

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/subscription/Plc4xListenerDispatcher.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/subscription/Plc4xListenerDispatcher.java
@@ -45,7 +45,6 @@ public class Plc4xListenerDispatcher implements Runnable {
     private ComponentLog logger;
     private boolean running = false;
     private BlockingQueue<PlcSubscriptionEvent> events;
-    private PlcSubscriptionResponse subscriptionResponse;
     private PlcConnection connection;
     private Long timeout;
     private BlockingQueue<PlcSubscriptionEvent> queuedEvents;
@@ -95,7 +94,7 @@ public class Plc4xListenerDispatcher implements Runnable {
             }
         }
         PlcSubscriptionRequest subscriptionRequest = builder.build();
-
+        PlcSubscriptionResponse subscriptionResponse;
         try {
             subscriptionResponse = subscriptionRequest.execute().get(timeout, TimeUnit.MILLISECONDS);
             

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/util/Plc4xCommon.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/main/java/org/apache/plc4x/nifi/util/Plc4xCommon.java
@@ -53,9 +53,6 @@ import org.apache.plc4x.java.spi.values.PlcWORD;
 
 public class Plc4xCommon {
 
-	
-	public static final String PLC4X_RECORD_TIMESTAMP_FIELD_NAME = "ts";
-	
 	/**
 	 * This method is used to infer output AVRO schema directly from the PlcReadResponse object. 
 	 * It is directly used from the RecordPlc4xWriter.writePlcReadResponse() method.
@@ -66,7 +63,7 @@ public class Plc4xCommon {
 	 * @param responseDataStructure: a map that reflects the structure of the answer given by the PLC when making a Read Request.
 	 * @return AVRO Schema built from responseDataStructure.
 	 */
-	public static Schema createSchema(Map<String, ? extends PlcValue> responseDataStructure){
+	public static Schema createSchema(Map<String, ? extends PlcValue> responseDataStructure, String timestampFieldName){
 		//plc and record datatype map
 		final FieldAssembler<Schema> builder = SchemaBuilder.record("PlcReadResponse").namespace("any.data").fields();	
 		String fieldName = null;
@@ -108,7 +105,7 @@ public class Plc4xCommon {
 		}
 		
 		//add timestamp tag to schema
-		builder.name(PLC4X_RECORD_TIMESTAMP_FIELD_NAME).type().longType().noDefault();
+		builder.name(timestampFieldName).type().longType().noDefault();
 		
 		
 		return builder.endRecord();

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/Plc4xSinkProcessorTest.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/Plc4xSinkProcessorTest.java
@@ -41,7 +41,7 @@ public class Plc4xSinkProcessorTest {
         testRunner.setValidateExpressionUsage(false);
 
         testRunner.setProperty(Plc4xSinkProcessor.PLC_CONNECTION_STRING, "simulated://127.0.0.1");
-        testRunner.setProperty(Plc4xSinkRecordProcessor.PLC_FUTURE_TIMEOUT_MILISECONDS, "1000");
+        testRunner.setProperty(Plc4xSinkProcessor.PLC_FUTURE_TIMEOUT_MILISECONDS, "1000");
 
         testRunner.addConnection(Plc4xSinkProcessor.REL_SUCCESS);
         testRunner.addConnection(Plc4xSinkProcessor.REL_FAILURE);

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/Plc4xSinkProcessorTest.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/Plc4xSinkProcessorTest.java
@@ -19,12 +19,16 @@ package org.apache.plc4x.nifi;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.apache.plc4x.nifi.address.AddressesAccessUtils;
+import org.apache.plc4x.nifi.address.FilePropertyAccessStrategy;
 import org.apache.plc4x.nifi.util.Plc4xCommonTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -71,6 +75,19 @@ public class Plc4xSinkProcessorTest {
         testRunner.setProperty(AddressesAccessUtils.PLC_ADDRESS_ACCESS_STRATEGY, AddressesAccessUtils.ADDRESS_TEXT);
         testRunner.setProperty(AddressesAccessUtils.ADDRESS_TEXT_PROPERTY, new ObjectMapper().writeValueAsString(Plc4xCommonTest.getAddressMap()));
         testProcessor();
+    }
+
+    // Test addressess file property access strategy
+    @Test
+    public void testWithAdderessFile() throws InitializationException {
+        testRunner.setProperty(AddressesAccessUtils.ADDRESS_FILE_PROPERTY, "file");
+
+        try (MockedStatic<FilePropertyAccessStrategy> staticMock = Mockito.mockStatic(FilePropertyAccessStrategy.class)) {
+            staticMock.when(() -> FilePropertyAccessStrategy.extractAddressesFromFile("file"))
+                .thenReturn(Plc4xCommonTest.getAddressMap());
+
+            testProcessor();
+        }
     }
 
 }

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/Plc4xSinkRecordProcessorTest.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/Plc4xSinkRecordProcessorTest.java
@@ -25,9 +25,12 @@ import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.apache.plc4x.nifi.address.AddressesAccessUtils;
+import org.apache.plc4x.nifi.address.FilePropertyAccessStrategy;
 import org.apache.plc4x.nifi.util.Plc4xCommonTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -91,4 +94,17 @@ public class Plc4xSinkRecordProcessorTest {
 		testRunner.setProperty(AddressesAccessUtils.ADDRESS_TEXT_PROPERTY, new ObjectMapper().writeValueAsString(Plc4xCommonTest.getAddressMap()).toString());
 		testAvroRecordReaderProcessor();
 	}
+
+	// Test addressess file property access strategy
+    @Test
+    public void testWithAdderessFile() throws InitializationException {
+        testRunner.setProperty(AddressesAccessUtils.ADDRESS_FILE_PROPERTY, "file");
+
+        try (MockedStatic<FilePropertyAccessStrategy> staticMock = Mockito.mockStatic(FilePropertyAccessStrategy.class)) {
+            staticMock.when(() -> FilePropertyAccessStrategy.extractAddressesFromFile("file"))
+                .thenReturn(Plc4xCommonTest.getAddressMap());
+
+            testAvroRecordReaderProcessor();
+        }
+    }
 }

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/Plc4xSourceProcessorTest.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/Plc4xSourceProcessorTest.java
@@ -39,8 +39,8 @@ public class Plc4xSourceProcessorTest {
         testRunner.setIncomingConnection(false);
         testRunner.setValidateExpressionUsage(false);
 
-        testRunner.setProperty(Plc4xSourceProcessor.PLC_CONNECTION_STRING, "simulated://127.0.0.1");
-        testRunner.setProperty(Plc4xSinkRecordProcessor.PLC_FUTURE_TIMEOUT_MILISECONDS, "1000");
+        testRunner.setProperty(Plc4xSourceProcessor.PLC_CONNECTION_STRING, "${literal(\"simulated\")}://127.0.0.1");
+        testRunner.setProperty(Plc4xSourceProcessor.PLC_FUTURE_TIMEOUT_MILISECONDS, "1000");
 
         testRunner.addConnection(Plc4xSourceProcessor.REL_SUCCESS);
         testRunner.addConnection(Plc4xSourceProcessor.REL_FAILURE);

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/Plc4xSourceRecordProcessorTest.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/Plc4xSourceRecordProcessorTest.java
@@ -61,7 +61,7 @@ public class Plc4xSourceRecordProcessorTest {
     	testRunner.assertTransferCount(Plc4xSourceRecordProcessor.REL_FAILURE, 0);
     	testRunner.assertTransferCount(Plc4xSourceRecordProcessor.REL_SUCCESS, NUMBER_OF_CALLS);
 
-		Plc4xCommonTest.assertAvroContent(testRunner.getFlowFilesForRelationship(Plc4xSourceProcessor.REL_SUCCESS), false, true);
+		Plc4xCommonTest.assertAvroContent(testRunner.getFlowFilesForRelationship(Plc4xSourceRecordProcessor.REL_SUCCESS), false, true);
     }
 
 	// Test dynamic properties addressess access strategy

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/Plc4xSourceRecordProcessorTest.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/Plc4xSourceRecordProcessorTest.java
@@ -23,9 +23,12 @@ import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
 import org.apache.plc4x.nifi.address.AddressesAccessUtils;
+import org.apache.plc4x.nifi.address.FilePropertyAccessStrategy;
 import org.apache.plc4x.nifi.util.Plc4xCommonTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -78,5 +81,18 @@ public class Plc4xSourceRecordProcessorTest {
         testRunner.setProperty(AddressesAccessUtils.PLC_ADDRESS_ACCESS_STRATEGY, AddressesAccessUtils.ADDRESS_TEXT);
         testRunner.setProperty(AddressesAccessUtils.ADDRESS_TEXT_PROPERTY, new ObjectMapper().writeValueAsString(Plc4xCommonTest.getAddressMap()).toString());
         testAvroRecordWriterProcessor();
+    }
+
+    // Test addressess file property access strategy
+    @Test
+    public void testWithAdderessFile() throws InitializationException {
+        testRunner.setProperty(AddressesAccessUtils.ADDRESS_FILE_PROPERTY, "file");
+
+        try (MockedStatic<FilePropertyAccessStrategy> staticMock = Mockito.mockStatic(FilePropertyAccessStrategy.class)) {
+            staticMock.when(() -> FilePropertyAccessStrategy.extractAddressesFromFile("file"))
+                .thenReturn(Plc4xCommonTest.getAddressMap());
+
+            testAvroRecordWriterProcessor();
+        }
     }
 }

--- a/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/address/AccessStrategyTest.java
+++ b/plc4j/integrations/apache-nifi/nifi-plc4x-processors/src/test/java/org/apache/plc4x/nifi/address/AccessStrategyTest.java
@@ -1,0 +1,92 @@
+package org.apache.plc4x.nifi.address;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Map;
+
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.apache.nifi.util.TestRunners;
+import org.apache.plc4x.nifi.Plc4xSourceProcessor;
+import org.apache.plc4x.nifi.util.Plc4xCommonTest;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class AccessStrategyTest {
+
+    private TestRunner testRunner; 
+
+    // Test correct cacheing of addresses in case 
+    @Test
+    public void testDynamicPropertyAccessStrategy() {
+
+        DynamicPropertyAccessStrategy testObject = new DynamicPropertyAccessStrategy();
+        testRunner = TestRunners.newTestRunner(Plc4xSourceProcessor.class);
+        
+        assert testObject.getAllowableValue().equals(AddressesAccessUtils.ADDRESS_PROPERTY);
+        assert testObject.getPropertyDescriptors().isEmpty();
+        
+        Plc4xCommonTest.getAddressMap().forEach((k,v) -> testRunner.setProperty(k, v));
+		
+        FlowFile flowFile = testRunner.enqueue("");
+        
+        Map<String, String> values = testObject.extractAddresses(testRunner.getProcessContext(), flowFile);
+
+        System.out.println(values);
+        assertTrue(testObject.getCachedAddresses().equals(values));
+        assertTrue(testObject.getCachedAddresses().equals(Plc4xCommonTest.getAddressMap()));
+    }
+
+    @Test
+    public void testDynamicPropertyAccessStrategyIncorrect() {
+
+        DynamicPropertyAccessStrategy testObject = new DynamicPropertyAccessStrategy();
+        testRunner = TestRunners.newTestRunner(Plc4xSourceProcessor.class);
+        
+        assert testObject.getAllowableValue().equals(AddressesAccessUtils.ADDRESS_PROPERTY);
+        assert testObject.getPropertyDescriptors().isEmpty();
+        
+        Plc4xCommonTest.getAddressMap().forEach((k,v) -> testRunner.setProperty(k, "no an correct address"));
+
+        testRunner.assertNotValid();
+    }
+
+    @Test
+    public void testTextPropertyAccessStrategy() throws JsonProcessingException {
+
+        TextPropertyAccessStrategy testObject = new TextPropertyAccessStrategy();
+        testRunner = TestRunners.newTestRunner(Plc4xSourceProcessor.class);
+        
+        assert testObject.getAllowableValue().equals(AddressesAccessUtils.ADDRESS_TEXT);
+        assert testObject.getPropertyDescriptors().contains(AddressesAccessUtils.ADDRESS_TEXT_PROPERTY);
+        
+        testRunner.setProperty(AddressesAccessUtils.ADDRESS_TEXT_PROPERTY, new ObjectMapper().writeValueAsString(Plc4xCommonTest.getAddressMap()).toString());
+		
+        FlowFile flowFile = testRunner.enqueue("");
+        
+        Map<String, String> values = testObject.extractAddresses(testRunner.getProcessContext(), flowFile);
+
+        System.out.println(values);
+        assertTrue(testObject.getCachedAddresses().equals(values));
+        assertTrue(testObject.getCachedAddresses().equals(Plc4xCommonTest.getAddressMap()));
+    }
+
+    @Test
+    public void testTextPropertyAccessStrategyIncorrect() {
+
+        TextPropertyAccessStrategy testObject = new TextPropertyAccessStrategy();
+        testRunner = TestRunners.newTestRunner(Plc4xSourceProcessor.class);
+        
+        assert testObject.getAllowableValue().equals(AddressesAccessUtils.ADDRESS_TEXT);
+        assert testObject.getPropertyDescriptors().contains(AddressesAccessUtils.ADDRESS_TEXT_PROPERTY);
+        
+        Plc4xCommonTest.getAddressMap().forEach((k,v) -> testRunner.setProperty(AddressesAccessUtils.ADDRESS_TEXT_PROPERTY.getName(), "no an correct address"));
+
+        testRunner.assertNotValid();
+
+        Plc4xCommonTest.getAddressMap().forEach((k,v) -> testRunner.setProperty(AddressesAccessUtils.ADDRESS_TEXT_PROPERTY.getName(), "{\"neither\":\"this one\"}"));
+
+        testRunner.assertNotValid();
+    }
+}


### PR DESCRIPTION
# NiFi integration revision
As we aim for a new release I bring a revision of the NiFi integration with a couple of improvements:

* #900: this made the processors be able to auto-reconnect with small changes. And allowed to make:
    * #593 : this was already done for the addresses. But the connection string had to be constant. Expression Language is now supported on the connection string.
    * #629 : this was an old TODO. I have added validation for the connection string (if not EL in use) and to the addresses (if not EL in use in neither of them as we need the driver).

* Add FilePropertyAccessStrategy: now we can read the addresses from a file in JSON format. Same as 'Address Text' property but in a file. Expression Language can be used and validation for the tags also works.
*  Processors code revision: rewrote the onTrigger methods of the processors so they look more similar between them. To make them more maintainable.
* Complete FlowFlile transfer: some FlowFiles did not transfer to failure correctly. Now the incoming FlowFile is sent to failure and one attribute is added with the localized message in case of any exception.
* Timestamp field name: It was a fixed `ts` field/attribute we added. I have made a property that defines this field's name. 
* Update Readme to reflect changes.

Closes #593
Closes #629 

