### PR TITLE
plc4j-driver-opcua: Fix keepalive threads are never shut down

### DIFF
--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannel.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannel.java
@@ -18,6 +18,7 @@
  */
 package org.apache.plc4x.java.opcua.context;
 
+import static java.lang.Thread.currentThread;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 
 import org.apache.commons.lang3.RandomStringUtils;
@@ -1072,9 +1073,7 @@ public class SecureChannel {
                             .unwrap(p -> (OpcuaOpenResponse) p.getMessage())
                             .check(p -> {
                                 if (p.getRequestId() == transactionId) {
-                                    if (!(senderSequenceNumber.incrementAndGet() == (p.getSequenceNumber()))) {
-                                        LOGGER.error("Sequence number isn't as expected, we might have missed a packet. - {} != {}", senderSequenceNumber.get(), p.getSequenceNumber());
-                                    }
+                                    senderSequenceNumber.incrementAndGet();
                                     return true;
                                 } else {
                                     return false;
@@ -1109,6 +1108,7 @@ public class SecureChannel {
                         Thread.sleep((long) Math.ceil(this.sessionTimeout * 0.25f));
                     } catch (InterruptedException e) {
                         LOGGER.trace("Interrupted Exception");
+                        currentThread().interrupt();
                     }
                 }
                 return null;

--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/protocol/OpcuaSubscriptionHandle.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/protocol/OpcuaSubscriptionHandle.java
@@ -18,6 +18,8 @@
  */
 package org.apache.plc4x.java.opcua.protocol;
 
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+
 import org.apache.plc4x.java.api.messages.PlcSubscriptionEvent;
 import org.apache.plc4x.java.api.messages.PlcSubscriptionRequest;
 import org.apache.plc4x.java.api.model.PlcConsumerRegistration;
@@ -332,7 +334,8 @@ public class OpcuaSubscriptionHandle extends DefaultPlcSubscriptionHandle {
                 LOGGER.error("Failed to start subscription", e);
             }
             return null;
-        });
+        },
+        newSingleThreadExecutor());
     }
 
 


### PR DESCRIPTION
Attempts to fix #1138 

* OPC-UA keepalive threads now have an exit condition.
* Both keepalive and subscription loops are now executed in their own, dedicated thread, instead of using the `ForkJoin` common pool.
* Keepalive thread now uses the more sensible session timeout, instead of the 10 hour `CONNECTION_LIFETIME`. The keepalive messages are now actually sent, checked with Wireshark.
* Swapped the sleep & communication logics in the keepalive thread.
* Keepalive responses now increment the `senderSequenceNumber`.
* Smoke tests added to verify the solution.