### PR TITLE
plc4j-driver-opcua: Move back to using session lifetime * 75% as keepalive period

### DIFF
--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannel.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannel.java
@@ -1105,7 +1105,7 @@ public class SecureChannel {
                     }
 
                     try {
-                        Thread.sleep((long) Math.ceil(this.sessionTimeout * 0.25f));
+                        Thread.sleep((long) Math.ceil(this.lifetime * 0.75f));
                     } catch (InterruptedException e) {
                         LOGGER.trace("Interrupted Exception");
                         currentThread().interrupt();


### PR DESCRIPTION
As per discussion on PR: https://github.com/apache/plc4x/pull/1147