### PR TITLE
OPC UA priority judgment using discovery parameter

### DIFF
--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/OpcuaDriverContext.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/OpcuaDriverContext.java
@@ -117,6 +117,10 @@ public class OpcuaDriverContext implements DriverContext, HasConfiguration<Opcua
     public String getTransportEndpoint() {
         return transportEndpoint;
     }
+    
+    public void setTransportEndpoint(String transportEndpoint) {
+        this.transportEndpoint = transportEndpoint;
+    }
 
     public Boolean getEncrypted() {
         return isEncrypted;


### PR DESCRIPTION
Fixed issue where short URLs without a transportEndpoint cannot establish a connection when using the discovery=false parameter

bug:
https://github.com/apache/plc4x/issues/1144