### PR TITLE
plc4j-driver-opcua: Re-enable a disabled test

### DIFF
--- a/plc4j/drivers/opcua/src/test/java/org/apache/plc4x/java/opcua/OpcuaPlcDriverTest.java
+++ b/plc4j/drivers/opcua/src/test/java/org/apache/plc4x/java/opcua/OpcuaPlcDriverTest.java
@@ -473,10 +473,9 @@ public class OpcuaPlcDriverTest {
     }
 
     /*
-        Test added to test the syncronized Trnasactionhandler.
-        The test originally failed one out of every 5 or so.
+        Test added to test the synchronized TransactionHandler.
      */
-    //@Test
+    @Test
     public void multipleThreads() throws Exception {
         class ReadWorker extends Thread {
             private final PlcConnection connection;

--- a/plc4j/drivers/opcua/src/test/java/org/apache/plc4x/java/opcua/OpcuaPlcDriverTest.java
+++ b/plc4j/drivers/opcua/src/test/java/org/apache/plc4x/java/opcua/OpcuaPlcDriverTest.java
@@ -473,7 +473,7 @@ public class OpcuaPlcDriverTest {
     }
 
     /*
-        Test added to test the synchronized TransactionHandler.
+        Test added to test the synchronized TransactionHandler. (This was disabled before being enabled again so it might be a candidate for those tests not running properly on different platforms)
      */
     @Test
     public void multipleThreads() throws Exception {


### PR DESCRIPTION
After running it 600 times in a row with success, it does not seem to be flaky anymore.