### PR TITLE
upgrade Felix maven-bundle-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1086,7 +1086,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>5.1.8</version>
+          <version>5.1.9</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
fixes a vast majority (56) of Reproducible Builds issues found in previous releases (up to 1.11.0)
see https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/plc4x/plc4x/README.md

there are other issues, but this one is causing much easy to fix noise: next release will be easier to review once this one is fixed