### PR TITLE
fix(plc4j/spi) Make sure OPC UA discover event is fired prior connected event

### DIFF
--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/OpcuaPlcDriver.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/OpcuaPlcDriver.java
@@ -86,9 +86,18 @@ public class OpcuaPlcDriver extends GeneratedDriverBase<OpcuaAPU> {
         return new PlcValueHandler();
     }
 
+    protected boolean fireDiscoverEvent() {
+        return true;
+    }
+
     protected boolean awaitDisconnectComplete() {
         return true;
     }
+
+    protected boolean awaitDiscoverComplete() {
+        return true;
+    }
+
 
     @Override
     protected ProtocolStackConfigurer<OpcuaAPU> getStackConfigurer() {

--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannel.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/SecureChannel.java
@@ -745,6 +745,7 @@ public class SecureChannel {
     public void onDiscover(ConversationContext<OpcuaAPU> context) {
         if (!driverContext.getEncrypted()) {
             LOGGER.debug("not encrypted, ignoring onDiscover");
+            context.fireDiscovered(configuration);
             return;
         }
         // Only the TCP transport supports login.

--- a/plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7/readwrite/protocol/S7HSingleProtocolStackConfigurer.java
+++ b/plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7/readwrite/protocol/S7HSingleProtocolStackConfigurer.java
@@ -25,6 +25,7 @@ import io.netty.handler.codec.MessageToMessageCodec;
 import org.apache.plc4x.java.api.authentication.PlcAuthentication;
 import org.apache.plc4x.java.api.exceptions.PlcRuntimeException;
 import org.apache.plc4x.java.api.listener.EventListener;
+import org.apache.plc4x.java.spi.EventListenerMessageCodec;
 import org.apache.plc4x.java.spi.Plc4xNettyWrapper;
 import org.apache.plc4x.java.spi.Plc4xProtocolBase;
 import org.apache.plc4x.java.spi.configuration.Configuration;
@@ -108,7 +109,7 @@ public class S7HSingleProtocolStackConfigurer<BASE_PACKET_CLASS extends Message>
     @Override
     public Plc4xProtocolBase<BASE_PACKET_CLASS> configurePipeline(Configuration configuration, ChannelPipeline pipeline,
                                                                   PlcAuthentication authentication, boolean passive,
-                                                                  List<EventListener> ignore) {
+                                                                  List<EventListener> listeners) {
         if (null == protocol) {
             if (this.encryptionHandler != null) {
                 pipeline.addLast("ENCRYPT", this.encryptionHandler);
@@ -118,6 +119,7 @@ public class S7HSingleProtocolStackConfigurer<BASE_PACKET_CLASS extends Message>
             if (driverContextClass != null) {
                 protocol.setDriverContext(configure(configuration, createInstance(driverContextClass)));
             }
+            pipeline.addLast(new EventListenerMessageCodec(listeners));
             Plc4xNettyWrapper<BASE_PACKET_CLASS> context = new Plc4xNettyWrapper<>(new NettyHashTimerTimeoutManager(), pipeline, passive, protocol,
                 authentication, basePacketClass);
             pipeline.addLast("WRAPPER", context);

--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/connection/CustomProtocolStackConfigurer.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/connection/CustomProtocolStackConfigurer.java
@@ -27,6 +27,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.MessageToMessageCodec;
 import org.apache.plc4x.java.api.authentication.PlcAuthentication;
 import org.apache.plc4x.java.api.listener.EventListener;
+import org.apache.plc4x.java.spi.EventListenerMessageCodec;
 import org.apache.plc4x.java.spi.Plc4xNettyWrapper;
 import org.apache.plc4x.java.spi.Plc4xProtocolBase;
 import org.apache.plc4x.java.spi.configuration.Configuration;
@@ -92,7 +93,7 @@ public class CustomProtocolStackConfigurer<BASE_PACKET_CLASS extends Message> im
     @Override
     public Plc4xProtocolBase<BASE_PACKET_CLASS> configurePipeline(Configuration configuration, ChannelPipeline pipeline,
                                                                   PlcAuthentication authentication, boolean passive,
-                                                                  List<EventListener> ignore) {
+                                                                  List<EventListener> listeners) {
         if (this.encryptionHandler != null) {
             pipeline.addLast(this.encryptionHandler);
         }
@@ -102,6 +103,7 @@ public class CustomProtocolStackConfigurer<BASE_PACKET_CLASS extends Message> im
         if (driverContext != null) {
             protocol.setDriverContext(driverContext);
         }
+        pipeline.addLast(new EventListenerMessageCodec(listeners));
         Plc4xNettyWrapper<BASE_PACKET_CLASS> context = new Plc4xNettyWrapper<>(new NettyHashTimerTimeoutManager(), pipeline, passive, protocol, authentication, basePacketClass);
         pipeline.addLast(context);
         return protocol;

--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/connection/DefaultNettyPlcConnection.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/connection/DefaultNettyPlcConnection.java
@@ -222,7 +222,7 @@ public class DefaultNettyPlcConnection extends AbstractPlcConnection implements 
         return new ChannelInitializer<>() {
             @Override
             protected void initChannel(Channel channel) {
-                // Build the protocol stack for communicating with the s7 protocol.
+                // Build the protocol stack for communicating with desired protocol.
                 ChannelPipeline pipeline = channel.pipeline();
                 pipeline.addLast(new ChannelInboundHandlerAdapter() {
                     @Override
@@ -239,7 +239,7 @@ public class DefaultNettyPlcConnection extends AbstractPlcConnection implements 
                             super.userEventTriggered(ctx, evt);
                         } else if (evt instanceof DiscoveredEvent) {
                             sessionDiscoverCompleteFuture.complete(((DiscoveredEvent) evt).getConfiguration());
-                        } else if (evt instanceof ConnectEvent) {
+                        } else if (evt instanceof ConnectEvent || evt instanceof DiscoverEvent) {
                             // Fix for https://github.com/apache/plc4x/issues/801
                             if (!sessionSetupCompleteFuture.isCompletedExceptionally()) {
                                 if (awaitSessionSetupComplete) {
@@ -248,7 +248,8 @@ public class DefaultNettyPlcConnection extends AbstractPlcConnection implements 
                                                     configuration,
                                                     pipeline,
                                                     getAuthentication(),
-                                                    channelFactory.isPassive()
+                                                    channelFactory.isPassive(),
+                                                    listeners
                                             )
                                     );
                                 }
@@ -275,7 +276,7 @@ public class DefaultNettyPlcConnection extends AbstractPlcConnection implements 
                 // Fix for https://github.com/apache/plc4x/issues/801
                 if (!awaitSessionSetupComplete) {
                     setProtocol(stackConfigurer.configurePipeline(configuration, pipeline, getAuthentication(),
-                            channelFactory.isPassive()));
+                            channelFactory.isPassive(), listeners));
                 }
             }
         };

--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/connection/SingleProtocolStackConfigurer.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/connection/SingleProtocolStackConfigurer.java
@@ -27,6 +27,7 @@ import io.netty.handler.codec.MessageToMessageCodec;
 import org.apache.plc4x.java.api.authentication.PlcAuthentication;
 import org.apache.plc4x.java.api.exceptions.PlcRuntimeException;
 import org.apache.plc4x.java.api.listener.EventListener;
+import org.apache.plc4x.java.spi.EventListenerMessageCodec;
 import org.apache.plc4x.java.spi.Plc4xNettyWrapper;
 import org.apache.plc4x.java.spi.Plc4xProtocolBase;
 import org.apache.plc4x.java.spi.configuration.Configuration;
@@ -103,7 +104,7 @@ public class SingleProtocolStackConfigurer<BASE_PACKET_CLASS extends Message> im
     @Override
     public Plc4xProtocolBase<BASE_PACKET_CLASS> configurePipeline(Configuration configuration, ChannelPipeline pipeline,
                                                                   PlcAuthentication authentication, boolean passive,
-                                                                  List<EventListener> ignore) {
+                                                                  List<EventListener> listeners) {
         if (this.encryptionHandler != null) {
             pipeline.addLast(this.encryptionHandler);
         }
@@ -112,6 +113,7 @@ public class SingleProtocolStackConfigurer<BASE_PACKET_CLASS extends Message> im
         if (driverContextClass != null) {
             protocol.setDriverContext(configure(configuration, createInstance(driverContextClass)));
         }
+        pipeline.addLast(new EventListenerMessageCodec(listeners));
         Plc4xNettyWrapper<BASE_PACKET_CLASS> context = new Plc4xNettyWrapper<>(new NettyHashTimerTimeoutManager(), pipeline, passive, protocol,
             authentication, basePacketClass);
         pipeline.addLast(context);

--- a/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/DefaultNettyPlcConnectionTest.java
+++ b/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/DefaultNettyPlcConnectionTest.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.plc4x.java.spi.connection;
+
+import static java.util.concurrent.ForkJoinPool.commonPool;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.netty.channel.ChannelPipeline;
+import java.util.List;
+import org.apache.plc4x.java.api.authentication.PlcAuthentication;
+import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
+import org.apache.plc4x.java.api.listener.EventListener;
+import org.apache.plc4x.java.spi.ConversationContext;
+import org.apache.plc4x.java.spi.Plc4xNettyWrapper;
+import org.apache.plc4x.java.spi.Plc4xProtocolBase;
+import org.apache.plc4x.java.spi.configuration.Configuration;
+import org.apache.plc4x.java.spi.generation.Message;
+import org.apache.plc4x.java.spi.netty.NettyHashTimerTimeoutManager;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class DefaultNettyPlcConnectionTest {
+
+    private final Logger logger = LoggerFactory.getLogger(DefaultNettyPlcConnectionTest.class);
+
+    @Test
+    void checkInitializationSequence() throws Exception {
+        ChannelFactory channelFactory = new TestChannelFactory();
+
+        final GateKeeper discovery = new GateKeeper("discovery");
+        final GateKeeper connect = new GateKeeper("connect");
+        final GateKeeper disconnect = new GateKeeper("disconnect");
+        final GateKeeper close = new GateKeeper("close");
+
+        ProtocolStackConfigurer<Message> stackConfigurer = new ProtocolStackConfigurer<>() {
+            @Override
+            public Plc4xProtocolBase<Message> configurePipeline(Configuration configuration, ChannelPipeline pipeline, PlcAuthentication authentication, boolean passive, List<EventListener> listeners) {
+                TestProtocolBase base = new TestProtocolBase(discovery, connect, disconnect, close);
+                Plc4xNettyWrapper<Message> context = new Plc4xNettyWrapper<>(new NettyHashTimerTimeoutManager(), pipeline, passive, base, authentication, Message.class);
+                pipeline.addLast(context);
+                return base;
+            }
+        };
+
+        DefaultNettyPlcConnection connection = new PlcConnectionFactory().withDiscovery().create(channelFactory, stackConfigurer);
+        commonPool().submit(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    logger.info("Activating connection");
+                    connection.connect();
+                } catch (PlcConnectionException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+
+        logger.info("Warming up");
+        expect(false, false, false, false, discovery, connect, disconnect, close);
+        discovery.permitIn();
+
+        discovery.awaitOut();
+        logger.info("Verify discovery phase completion");
+        expect(true, false, false, false, discovery, connect, disconnect, close);
+        connect.permitIn();
+
+        connect.awaitOut();
+        logger.info("Verify connection completion");
+        expect(true, true, false, false, discovery, connect, disconnect, close);
+
+        logger.info("Close connection");
+        commonPool().submit(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    logger.info("Closing connection");
+                    connection.close();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+
+        disconnect.permitIn();
+        expect(true, true, true, false, discovery, connect, disconnect, close);
+        disconnect.awaitOut();
+
+        logger.info("Verify connection termination");
+        close.permitIn();
+        expect(true, true, true, true, discovery, connect, disconnect, close);
+        close.awaitOut();
+
+        logger.info("Connection lifecycle sequence has been confirmed");
+    }
+
+    private static void expect(boolean discovered, boolean connected, boolean disconnected, boolean closed,
+        GateKeeper discovery, GateKeeper connect, GateKeeper disconnect, GateKeeper close) {
+
+        assertEquals(
+            discovered + "," + connected + "," +  disconnected + "," +  closed,
+            (discovery.entered()) + "," +
+            (connect.entered()) + "," +
+            (disconnect.entered() + "," +
+            (close.entered())),
+            "Expectation for state flags (discover, connect, disconnect, close) failed"
+        );
+    }
+
+    static class TestProtocolBase extends Plc4xProtocolBase<Message> {
+
+        private final Logger logger = LoggerFactory.getLogger(TestProtocolBase.class);;
+        private final GateKeeper discover;
+        private final GateKeeper connect;
+        private final GateKeeper close;
+        private final GateKeeper disconnect;
+
+        public TestProtocolBase(GateKeeper discover, GateKeeper connect, GateKeeper disconnect, GateKeeper close) {
+            this.discover = discover;
+            this.connect = connect;
+            this.close = close;
+            this.disconnect = disconnect;
+        }
+
+        @Override
+        public void onDiscover(ConversationContext<Message> context) {
+            logger.info("On Discover");
+            await(discover);
+            context.fireDiscovered(null);
+            discover.permitOut();
+        }
+
+
+        @Override
+        public void onConnect(ConversationContext<Message> context) {
+            logger.info("On Connect");
+            await(connect);
+            super.onConnect(context);
+            context.fireConnected();
+            connect.permitOut();
+        }
+
+        @Override
+        public void onDisconnect(ConversationContext<Message> context) {
+            logger.info("On Disconnect");
+            await(disconnect);
+            super.onDisconnect(context);
+            context.fireDisconnected();
+            disconnect.permitOut();
+        }
+
+        @Override
+        public void close(ConversationContext<Message> context) {
+            logger.info("On Close");
+            await(close);
+            close.permitOut();
+        }
+
+        private void await(GateKeeper signal) {
+            try {
+                if (!signal.awaitIn()) {
+                    throw new RuntimeException("Await for " + signal.gate() + " lock failed");
+                }
+            } catch (InterruptedException e) {
+                logger.error("Failed to await for a signal " + signal.gate());
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+}

--- a/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/GateKeeper.java
+++ b/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/GateKeeper.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.plc4x.java.spi.connection;
+
+import java.util.concurrent.CountDownLatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class to control entry and exit points.
+ */
+class GateKeeper {
+
+    private final Logger logger = LoggerFactory.getLogger(GateKeeper.class);
+    private final String gate;
+    private final CountDownLatch in = new CountDownLatch(1);
+    private final CountDownLatch out = new CountDownLatch(1);
+
+    GateKeeper(String gate) {
+        this.gate = gate;
+    }
+
+    boolean awaitIn() throws InterruptedException {
+        logger.debug("Awaiting entry permit for {}", gate);
+        in.await();
+        return true;
+    }
+
+    boolean awaitOut() throws InterruptedException {
+        logger.debug("Awaiting exit permit for {}", gate);
+        out.await();
+        return true;
+    }
+
+    boolean entered() {
+        return in.getCount() == 0;
+    }
+
+    boolean exited() {
+        return out.getCount() == 0;
+    }
+
+    void permitIn() {
+        logger.info("Allowing permit for {}", gate);
+        in.countDown();
+    }
+
+    public void permitOut() {
+        logger.info("Allowing exit for {}", gate);
+        out.countDown();
+    }
+
+    public String gate() {
+        return gate;
+    }
+
+    @Override
+    public String toString() {
+        return "GateKeeper [" + gate + ", entered=" + entered() + ", exited=" + exited() + "]";
+    }
+}

--- a/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/PlcConnectionFactory.java
+++ b/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/PlcConnectionFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.plc4x.java.spi.connection;
+
+import org.apache.plc4x.java.spi.generation.Message;
+
+public class PlcConnectionFactory {
+
+    private boolean awaitDiscovery = false;
+    private boolean fireDiscovery = false;
+    private boolean awaitDisconnect;
+
+    PlcConnectionFactory withDiscovery() {
+        awaitDiscovery = true;
+        fireDiscovery = true;
+        return this;
+    }
+
+    PlcConnectionFactory doNotAwaitForDisconnect() {
+        awaitDisconnect = false;
+        return this;
+    }
+
+    <T extends Message> DefaultNettyPlcConnection create(ChannelFactory channelFactory, ProtocolStackConfigurer<T> stackConfigurer) {
+        return new DefaultNettyPlcConnection(
+            true, true, true, true, true,
+            null, null, null, channelFactory,
+            fireDiscovery, // force discovery
+            true, // await setup
+            awaitDisconnect, // await disconnect
+            awaitDiscovery, // await discovery
+            stackConfigurer,
+            null,
+            null
+        );
+    }
+
+}

--- a/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/SingleProtocolStackConfigurerTest.java
+++ b/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/SingleProtocolStackConfigurerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.plc4x.java.spi.connection;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.util.function.ToIntFunction;
+import org.apache.plc4x.java.api.EventPlcConnection;
+import org.apache.plc4x.java.api.listener.ConnectionStateListener;
+import org.apache.plc4x.java.api.listener.MessageExchangeListener;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SingleProtocolStackConfigurerTest {
+
+    @Mock
+    private MessageExchangeListener messageListener;
+    @Mock
+    private ConnectionStateListener connectionListener;
+
+    @Test
+    void testConnectionStateListener() throws Exception {
+        TestChannelFactory channelFactory = new TestChannelFactory();
+
+        SingleProtocolStackConfigurer<TestMessage> stackConfigurer = SingleProtocolStackConfigurer.builder(TestMessage.class, TestMessage::staticParse)
+            .withProtocol(TestProtocol.class)
+            .build();
+
+        EventPlcConnection connection = new PlcConnectionFactory().create(channelFactory, stackConfigurer);
+        connection.addEventListener(connectionListener);
+
+        connection.connect();
+        verify(connectionListener).connected();
+
+        connection.close();
+        verify(connectionListener).disconnected();
+    }
+
+    @Test
+    void testConnectionStateListenerAppended() throws Exception {
+        TestChannelFactory channelFactory = new TestChannelFactory();
+
+        SingleProtocolStackConfigurer<TestMessage> stackConfigurer = SingleProtocolStackConfigurer.builder(TestMessage.class, TestMessage::staticParse)
+            .withProtocol(TestProtocol.class)
+            .build();
+
+        EventPlcConnection connection = new PlcConnectionFactory().create(channelFactory, stackConfigurer);
+        connection.addEventListener(connectionListener);
+
+        connection.connect();
+        verify(connectionListener).connected();
+
+        // append listener after connection been made
+        ConnectionStateListener dynamicListener = mock(ConnectionStateListener.class);
+        connection.addEventListener(dynamicListener);
+
+        connection.close();
+        verify(connectionListener).disconnected();
+        verify(dynamicListener).disconnected();
+    }
+
+    @Test
+    void testMessageExchangeListener() throws Exception {
+        TestChannelFactory channelFactory = new TestChannelFactory();
+
+        SingleProtocolStackConfigurer<TestMessage> stackConfigurer = SingleProtocolStackConfigurer.builder(TestMessage.class, TestMessage::staticParse)
+            .withProtocol(TestProtocol.class)
+            .withPacketSizeEstimator(Estimator.class)
+            .build();
+
+        EventPlcConnection connection = new PlcConnectionFactory().doNotAwaitForDisconnect()
+            .create(channelFactory, stackConfigurer);
+        connection.addEventListener(messageListener);
+
+        connection.connect();
+
+        ByteBuf buffer = Unpooled.wrappedBuffer(new byte[] {0x00});
+        EmbeddedChannel channel = channelFactory.getChannel();
+        // send dummy message with 0x00
+        channel.writeInbound(buffer.retain());
+        assertTrue(channel.finish());
+
+        // await completion of handshake
+        connection.close();
+
+        verify(messageListener).received(eq(new TestMessage(0)));
+        verify(messageListener).sending(eq(new TestMessage(1)));
+    }
+
+    static class Estimator implements ToIntFunction<ByteBuf> {
+        @Override
+        public int applyAsInt(ByteBuf value) {
+            return 1;
+        }
+    }
+}

--- a/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/TestChannelFactory.java
+++ b/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/TestChannelFactory.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,20 +16,31 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.plc4x.java.spi.connection;
 
-import io.netty.channel.ChannelPipeline;
-import org.apache.plc4x.java.api.authentication.PlcAuthentication;
-import org.apache.plc4x.java.api.listener.EventListener;
-import org.apache.plc4x.java.spi.Plc4xProtocolBase;
-import org.apache.plc4x.java.spi.configuration.Configuration;
-import org.apache.plc4x.java.spi.generation.Message;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
 
-import java.util.Collections;
-import java.util.List;
+public class TestChannelFactory implements ChannelFactory {
 
-public interface ProtocolStackConfigurer<T extends Message> {
+    private EmbeddedChannel channel;
 
-    Plc4xProtocolBase<T> configurePipeline(Configuration configuration, ChannelPipeline pipeline, PlcAuthentication authentication, boolean passive, List<EventListener> listeners);
+    @Override
+    public Channel createChannel(ChannelHandler channelHandler) throws PlcConnectionException {
+        this.channel = new EmbeddedChannel(channelHandler);
+        return channel;
+    }
+
+    @Override
+    public boolean isPassive() {
+        return false;
+    }
+
+    public EmbeddedChannel getChannel() {
+        return channel;
+    }
 
 }

--- a/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/TestMessage.java
+++ b/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/TestMessage.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.plc4x.java.spi.connection;
+
+import java.util.Objects;
+import org.apache.plc4x.java.spi.generation.Message;
+import org.apache.plc4x.java.spi.generation.ParseException;
+import org.apache.plc4x.java.spi.generation.ReadBuffer;
+import org.apache.plc4x.java.spi.generation.SerializationException;
+import org.apache.plc4x.java.spi.generation.WriteBuffer;
+
+public class TestMessage implements Message {
+
+    int value;
+
+    public TestMessage(int value) {
+        this.value = value;
+    }
+
+    @Override
+    public int getLengthInBytes() {
+        return 1;
+    }
+
+    @Override
+    public int getLengthInBits() {
+        return 8;
+    }
+
+    @Override
+    public void serialize(WriteBuffer writeBuffer) throws SerializationException {
+        writeBuffer.writeUnsignedInt(8, value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TestMessage)) {
+            return false;
+        }
+        TestMessage that = (TestMessage) o;
+        return value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return "TestMessage [" + value + "]";
+    }
+
+    public static TestMessage staticParse(ReadBuffer readBuffer, Object ... args) throws ParseException {
+        return new TestMessage(readBuffer.readUnsignedInt(8));
+    }
+}

--- a/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/TestProtocol.java
+++ b/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/TestProtocol.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.plc4x.java.spi.connection;
+
+import java.time.Duration;
+import org.apache.plc4x.java.spi.ConversationContext;
+import org.apache.plc4x.java.spi.Plc4xProtocolBase;
+
+public class TestProtocol extends Plc4xProtocolBase<TestMessage> {
+
+    @Override
+    public void onDiscover(ConversationContext<TestMessage> context) {
+        context.fireDiscovered(null);
+    }
+
+    @Override
+    public void onConnect(ConversationContext<TestMessage> context) {
+        context.expectRequest(TestMessage.class, Duration.ofSeconds(15))
+            .onTimeout(e -> onDisconnect(context))
+            .handle(msg -> {
+                // a dummy handshake - just add one to packet counter
+                context.sendToWire(new TestMessage(msg.value + 1));
+            });
+        context.fireConnected();
+    }
+
+    @Override
+    public void onDisconnect(ConversationContext<TestMessage> context) {
+        context.fireDisconnected();
+    }
+
+    @Override
+    public void close(ConversationContext<TestMessage> context) {
+        // do nothing
+        context.getChannel().close();
+    }
+
+}


### PR DESCRIPTION
This is rather small change but it adjusts initialization sequence of driver needed by #1007 and present until 0.10 (and most of v0.11 prior release). 

I did rebase #1007 changes and had to fix this part. Given that this is part of SPI I would like to separate it. Changes and unit tests within mentioned pull request will cover it through discovery of OPC UA server certificate (which is done after `DiscoverEvent` is fired).