### PR TITLE
Site integration 3.x.x Migration - Doxia Modules 3+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1314,7 +1314,7 @@
             <!-- Add support for asciidoctor -->
             <dependency>
               <groupId>org.asciidoctor</groupId>
-              <artifactId>asciidoctor-maven-plugin</artifactId>
+              <artifactId>asciidoctor-converter-doxia-module</artifactId>
               <version>${asciidoctor.maven.plugin.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Rename the maven-site-plugin dependency from asciidoctor-maven-plugin to asciidoctor-converter-doxia-module.