### PR TITLE
fix(plc4j/ads): Fixed List serialization passing invalid datatype

### DIFF
--- a/plc4j/drivers/ads/src/main/java/org/apache/plc4x/java/ads/protocol/AdsProtocolLogic.java
+++ b/plc4j/drivers/ads/src/main/java/org/apache/plc4x/java/ads/protocol/AdsProtocolLogic.java
@@ -1144,8 +1144,9 @@ public class AdsProtocolLogic extends Plc4xProtocolBase<AmsTCPPacket> implements
                 throw new SerializationException(String.format(
                     "Expected a PlcList of size %d, but got one of size %d", curArrayLevel.getNumElements(), list.size()));
             }
+            AdsDataTypeTableEntry childDataType = dataTypeTable.get(dataType.getSimpleTypeName());
             for (PlcValue plcValue : list) {
-                serializeInternal(plcValue, dataType, arrayInfo.subList(1, arrayInfo.size()), writeBuffer);
+                serializeInternal(plcValue, childDataType, arrayInfo.subList(1, arrayInfo.size()), writeBuffer);
             }
         }
 


### PR DESCRIPTION
Fix for: #1509 

The List serialization for ADS passed the main List type to each child element when serializing them instead of determining the correct type for the children. This fix modifies the List iteration to determine the simple type from the List type, which is the actual type for each child element.

Regarding the `arrayInfo.subList()`, I'm not familiar enough to say if that should also be determined from the child type.