### PR TITLE
fix(plc4j/ads): Invalid size writing multiple tags

### DIFF
--- a/plc4j/drivers/ads/src/main/java/org/apache/plc4x/java/ads/protocol/AdsProtocolLogic.java
+++ b/plc4j/drivers/ads/src/main/java/org/apache/plc4x/java/ads/protocol/AdsProtocolLogic.java
@@ -1081,11 +1081,11 @@ public class AdsProtocolLogic extends Plc4xProtocolBase<AmsTCPPacket> implements
         // With multi-requests, the index-group is fixed and the index offset indicates the number of elements.
         AmsPacket amsPacket = new AdsReadWriteRequest(configuration.getTargetAmsNetId(), configuration.getTargetAmsPort(),
             configuration.getSourceAmsNetId(), configuration.getSourceAmsPort(),
-            0, getInvokeId(), ReservedIndexGroups.ADSIGRP_MULTIPLE_WRITE.getValue(), serializedSize,
+            0, getInvokeId(), ReservedIndexGroups.ADSIGRP_MULTIPLE_WRITE.getValue(), serializedTags.size(),
             (long) numTags * 4,
             directAdsTags.entrySet().stream().map(entry -> new AdsMultiRequestItemWrite(
                     entry.getKey().getIndexGroup(), entry.getKey().getIndexOffset(),
-                    entry.getValue().getEntryLength()))
+                    entry.getValue().getSize()))
                 .collect(Collectors.toList()), writeBuffer.getBytes());
         AmsTCPPacket amsTCPPacket = new AmsTCPPacket(amsPacket);
 


### PR DESCRIPTION
This fixes the issue mentioned in #1433.

When writing multiple tags via ADS, the IndexOffset and tag specific data type sizes were incorrect; the IndexOffset should indicate how many tags are being written instead of how many bytes, and the individual tag write sizes were pointing to the length of the data type table entry instead of the data type size from that entry. With these changes I was able to write multiple values without issues.