### PR TITLE
fix(plc4j/ads): Fixed connection hang on exception

### DIFF
--- a/plc4j/drivers/ads/src/main/java/org/apache/plc4x/java/ads/protocol/AdsProtocolLogic.java
+++ b/plc4j/drivers/ads/src/main/java/org/apache/plc4x/java/ads/protocol/AdsProtocolLogic.java
@@ -221,7 +221,7 @@ public class AdsProtocolLogic extends Plc4xProtocolBase<AmsTCPPacket> implements
                                                 CompletableFuture<Void> readSymbolTableFuture = readSymbolTableAndDatatypeTable(context);
                                                 readSymbolTableFuture.whenComplete((unused2, throwable2) -> {
                                                     if (throwable2 != null) {
-                                                        LOGGER.error("Error fetching symbol and datatype table sizes");
+                                                        context.getChannel().pipeline().fireExceptionCaught(new PlcConnectionException("Error fetching symbol and datatype table sizes", throwable2));
                                                     } else {
                                                         context.fireConnected();
                                                     }


### PR DESCRIPTION
When getting a new ADS connection, the connection could hang indefinitely if the final symbol reading future threw an exception, causing only an error log to be written, leaving the context without a completion call. This situation happened when everything aside from the Target AMS Port were correct, the connection retrieval would never return due to this error.

Since the other exceptions in previous steps terminated the connection, I determined that this should also simply fail the connection attempt.