### PR TITLE
Setting third parameter to emptyCollection in static of methods call to SymbolicAdsTag

### DIFF
--- a/plc4j/drivers/ads/src/main/java/org/apache/plc4x/java/ads/tag/SymbolicAdsTag.java
+++ b/plc4j/drivers/ads/src/main/java/org/apache/plc4x/java/ads/tag/SymbolicAdsTag.java
@@ -26,6 +26,7 @@ import org.apache.plc4x.java.spi.generation.SerializationException;
 import org.apache.plc4x.java.spi.generation.WriteBuffer;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -58,7 +59,7 @@ public class SymbolicAdsTag implements AdsTag {
         }
         String symbolicAddress = matcher.group("symbolicAddress");
 
-        return new SymbolicAdsTag(symbolicAddress, null, null);
+        return new SymbolicAdsTag(symbolicAddress, null, Collections.emptyList());
     }
 
     public static boolean matches(String address) {


### PR DESCRIPTION
This fixes a bug in subscription where the SymbolicAdsTag gets casted to DefaultSubscriptionTag. 
It was possible that the arrayInfo field wasn't initialized which lead to a NullpointerException. 