### PR TITLE
add timeout for gracefully shutdown of event group

### DIFF
--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/connection/NettyChannelFactory.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/connection/NettyChannelFactory.java
@@ -154,7 +154,7 @@ public abstract class NettyChannelFactory implements ChannelFactory {
             logger.info("Channel is closed, closing worker Group also");
             EventLoopGroup eventExecutors = eventLoops.get(channel);
             eventLoops.remove(channel);
-            eventExecutors.shutdownGracefully().awaitUninterruptibly();
+            eventExecutors.shutdownGracefully().awaitUninterruptibly(2000);
             logger.info("Worker Group was closed successfully!");
         } else {
             logger.warn("Trying to remove EventLoop for Channel {} but have none stored", channel);


### PR DESCRIPTION
 The shutdown of the worker group stuck at line: eventExecutors.shutdownGracefully().awaitUninterruptibly();
So add a timeout for this.