### PR TITLE
fix(plc4j): Adjust encoding/decoding logic to support mixed key lengths.

### DIFF
--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/AsymmetricEncryptionHandler.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/AsymmetricEncryptionHandler.java
@@ -68,7 +68,7 @@ public class AsymmetricEncryptionHandler extends BaseEncryptionHandler {
         for (int block = 0; block < blockCount; block++) {
             int pos = block * chunk.getCipherTextBlockSize();
 
-            bodyLength += cipher.doFinal(encrypted, pos, chunk.getCipherTextBlockSize(), plainText, pos);
+            bodyLength += cipher.doFinal(encrypted, pos, chunk.getCipherTextBlockSize(), plainText, bodyLength);
         }
 
         chunkBuffer.setPos(bodyStart);

--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/BaseEncryptionHandler.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/context/BaseEncryptionHandler.java
@@ -223,9 +223,10 @@ abstract class BaseEncryptionHandler {
         int paddingEnd = messageLength - chunk.getSignatureSize() - encryptionOverhead - chunk.getPaddingOverhead();
         byte[] padding = chunkBuffer.getBytes(paddingEnd, paddingEnd + chunk.getPaddingOverhead());
         if (padding.length > 2) { // cipher block size exceeds 256 bytes
-            return (short)(((padding[1] & 0xFF) << 8) | (padding[0] & 0xFF));
+            int paddingSize = ((padding[1] & 0xFF) << 8) | (padding[0] & 0xFF);
+            return (short) (paddingSize & 0xFFFF);
         }
-        return padding[0];
+        return (short) (padding[0] & 0xFF);
     }
 
     protected abstract void verify(WriteBufferByteBased buffer, Chunk chunk, int messageLength) throws Exception;

--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/protocol/chunk/ChunkFactory.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/protocol/chunk/ChunkFactory.java
@@ -71,8 +71,8 @@ public class ChunkFactory {
         int serverCertificateThumbprint = asymmetric ? certificateThumbprint(remoteCertificate).length : 0;
 
         int asymmetricSecurityHarderSize = (12 + securityPolicy.getSecurityPolicyUri().length() + localCertificateSize + serverCertificateThumbprint);
-        int asymmetricCipherTextBlockSize = asymmetric ? (localAsymmetricKeyLength + 7) / 8 : 0;
-        int plainTextTextBlockSize = asymmetric ? (localAsymmetricKeyLength + 7) / 8 : 0;
+        int asymmetricCipherTextBlockSize = asymmetric ? (remoteAsymmetricKeyLength + 7) / 8 : 0;
+        int plainTextBlockSize = asymmetric ? (remoteAsymmetricKeyLength + 7) / 8 : 0;
 
         int cipherTextBlockSize = asymmetric ? asymmetricCipherTextBlockSize : (encrypted ? securityPolicy.getEncryptionBlockSize() : 1);
 
@@ -81,8 +81,8 @@ public class ChunkFactory {
             return new Chunk(
                 asymmetric ? asymmetricSecurityHarderSize : SYMMETRIC_SECURITY_HEADER_SIZE,
                 cipherTextBlockSize,
-                asymmetric ? plainTextTextBlockSize - 11 : (encrypted ? securityPolicy.getEncryptionBlockSize() : 1),
-                asymmetric ? ((remoteAsymmetricKeyLength + 7) / 8) : securityPolicy.getSymmetricSignatureSize(),
+                asymmetric ? plainTextBlockSize - 11 : (encrypted ? securityPolicy.getEncryptionBlockSize() : 1),
+                asymmetric ? ((localAsymmetricKeyLength + 7) / 8) : securityPolicy.getSymmetricSignatureSize(),
                 (int) limits.getSendBufferSize(),
                 asymmetric,
                 encryption,
@@ -93,8 +93,8 @@ public class ChunkFactory {
                 // 12 + 56 + 674 + 20
                 asymmetric ? asymmetricSecurityHarderSize : SYMMETRIC_SECURITY_HEADER_SIZE,
                 cipherTextBlockSize,
-                asymmetric ? plainTextTextBlockSize - 42 : (encrypted ? securityPolicy.getEncryptionBlockSize() : 1),
-                asymmetric ? ((remoteAsymmetricKeyLength + 7) / 8) : securityPolicy.getSymmetricSignatureSize(),
+                asymmetric ? plainTextBlockSize - 42 : (encrypted ? securityPolicy.getEncryptionBlockSize() : 1),
+                asymmetric ? ((localAsymmetricKeyLength + 7) / 8) : securityPolicy.getSymmetricSignatureSize(),
                 (int) limits.getSendBufferSize(),
                 asymmetric,
                 encryption,
@@ -104,8 +104,8 @@ public class ChunkFactory {
             return new Chunk(
                 asymmetric ? asymmetricSecurityHarderSize : SYMMETRIC_SECURITY_HEADER_SIZE,
                 cipherTextBlockSize,
-                asymmetric ? plainTextTextBlockSize - 42 : (encrypted ? securityPolicy.getEncryptionBlockSize() : 1),
-                asymmetric ? ((remoteAsymmetricKeyLength + 7) / 8) : securityPolicy.getSymmetricSignatureSize(),
+                asymmetric ? plainTextBlockSize - 42 : (encrypted ? securityPolicy.getEncryptionBlockSize() : 1),
+                asymmetric ? ((localAsymmetricKeyLength + 7) / 8) : securityPolicy.getSymmetricSignatureSize(),
                 (int) limits.getSendBufferSize(),
                 asymmetric,
                 encryption,
@@ -115,8 +115,8 @@ public class ChunkFactory {
             return new Chunk(
                 asymmetric ? asymmetricSecurityHarderSize : SYMMETRIC_SECURITY_HEADER_SIZE,
                 cipherTextBlockSize,
-                asymmetric ? plainTextTextBlockSize - 42 : (encrypted ? securityPolicy.getEncryptionBlockSize() : 1),
-                asymmetric ? ((remoteAsymmetricKeyLength + 7) / 8) : securityPolicy.getSymmetricSignatureSize(),
+                asymmetric ? plainTextBlockSize - 42 : (encrypted ? securityPolicy.getEncryptionBlockSize() : 1),
+                asymmetric ? ((localAsymmetricKeyLength + 7) / 8) : securityPolicy.getSymmetricSignatureSize(),
                 (int) limits.getSendBufferSize(),
                 asymmetric,
                 encryption,
@@ -126,8 +126,8 @@ public class ChunkFactory {
             return new Chunk(
                 asymmetric ? asymmetricSecurityHarderSize : SYMMETRIC_SECURITY_HEADER_SIZE,
                 cipherTextBlockSize,
-                asymmetric ? plainTextTextBlockSize - 66 : (encrypted ? securityPolicy.getEncryptionBlockSize() : 1),
-                asymmetric ? ((remoteAsymmetricKeyLength + 7) / 8) : securityPolicy.getSymmetricSignatureSize(),
+                asymmetric ? plainTextBlockSize - 66 : (encrypted ? securityPolicy.getEncryptionBlockSize() : 1),
+                asymmetric ? ((localAsymmetricKeyLength + 7) / 8) : securityPolicy.getSymmetricSignatureSize(),
                 (int) limits.getSendBufferSize(),
                 asymmetric,
                 encryption,


### PR DESCRIPTION
As found during the tests of MX OPC server, our encoding logic did not work properly when client and server used different key lengths. Changes introduced in this commit address this issue, and add few additional tests to confirm valid behavior.

Relates to #1682 and #1802, whereas second issue lead to discovery of the bug.