### PR TITLE
fix(plc4j/drivers/s7): fix NPE when Camel can not establish connection

### DIFF
--- a/plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7/readwrite/protocol/S7HMuxImpl.java
+++ b/plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7/readwrite/protocol/S7HMuxImpl.java
@@ -235,7 +235,8 @@ public class S7HMuxImpl extends MessageToMessageCodec<ByteBuf, ByteBuf> implemen
             embededChannel.pipeline().fireUserEventTriggered(new DisconnectedEvent());
         }
 
-        logger.info(embedCtx.executor().toString());
+        if (embedCtx != null)
+            logger.info(embedCtx.executor().toString());
 
         if ((tcpChannel == primaryChannel) &&
             (primaryChannel == ctx.channel()))


### PR DESCRIPTION
Add if statement to fix NullPointerException.

Steps to reproduce:
- Add Camel route with S7 driver
- PLC is not available
- Connection failure
- Follow up code produces NullPointerException

Logfile:
```
2024-11-05T08:14:03.201+01:00  INFO 9332 --- [application] [ntLoopGroup-2-1] o.a.p.j.s.c.NettyChannelFactory          : Unable to connect, shutting down worker thread.
2024-11-05T08:14:03.201+01:00  INFO 9332 --- [application] [           main] o.a.p.j.s.r.protocol.S7HPlcConnection    : org.apache.plc4x.java.api.exceptions.PlcConnectionException: Error creating channel.
2024-11-05T08:14:03.224+01:00  INFO 9332 --- [application] [           main] o.a.p.j.s.readwrite.protocol.S7HMuxImpl  : Unregistered of channel: PRIMARY
2024-11-05T08:14:03.225+01:00  INFO 9332 --- [application] [cessor-thread-1] o.a.p.j.s.r.p.S7ProtocolEventLogic       : ObjectProcessor Bye!
2024-11-05T08:14:03.225+01:00 ERROR 9332 --- [application] [           main] o.a.p.j.s.c.DefaultNettyPlcConnection    : unknown error, close the connection

java.lang.NullPointerException: Cannot invoke "io.netty.channel.ChannelHandlerContext.executor()" because "this.embedCtx" is null
	at org.apache.plc4x.java.s7.readwrite.protocol.S7HMuxImpl.channelUnregistered(S7HMuxImpl.java:240) ~[main/:0.12.0]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelUnregistered(AbstractChannelHandlerContext.java:217) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelUnregistered(AbstractChannelHandlerContext.java:195) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelUnregistered(AbstractChannelHandlerContext.java:188) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelUnregistered(DefaultChannelPipeline.java:1335) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelUnregistered(AbstractChannelHandlerContext.java:215) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelUnregistered(AbstractChannelHandlerContext.java:195) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelUnregistered(DefaultChannelPipeline.java:770) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe$7.run(AbstractChannel.java:819) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.embedded.EmbeddedEventLoop.runTasks(EmbeddedEventLoop.java:74) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.embedded.EmbeddedChannel.runPendingTasks(EmbeddedChannel.java:814) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.embedded.EmbeddedChannel.maybeRunPendingTasks(EmbeddedChannel.java:804) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.embedded.EmbeddedChannel.close(EmbeddedChannel.java:618) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.embedded.EmbeddedChannel.close(EmbeddedChannel.java:599) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at org.apache.plc4x.java.s7.readwrite.protocol.S7ProtocolLogic.onDisconnect(S7ProtocolLogic.java:252) ~[plc4j-driver-s7-0.12.0.jar:0.12.0]
	at org.apache.plc4x.java.spi.Plc4xNettyWrapper.userEventTriggered(Plc4xNettyWrapper.java:201) ~[plc4j-spi-0.12.0.jar:0.12.0]
	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:398) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:376) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:368) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.ChannelInboundHandlerAdapter.userEventTriggered(ChannelInboundHandlerAdapter.java:117) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at org.apache.plc4x.java.spi.connection.DefaultNettyPlcConnection$1$1.userEventTriggered(DefaultNettyPlcConnection.java:251) ~[plc4j-spi-0.12.0.jar:0.12.0]
	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:398) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:376) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:368) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.handler.logging.LoggingHandler.userEventTriggered(LoggingHandler.java:222) ~[netty-handler-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:398) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:376) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:368) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.ChannelInboundHandlerAdapter.userEventTriggered(ChannelInboundHandlerAdapter.java:117) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at org.apache.plc4x.java.s7.readwrite.protocol.S7HMuxImpl.userEventTriggered(S7HMuxImpl.java:177) ~[main/:0.12.0]
	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:398) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:376) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:368) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.userEventTriggered(DefaultChannelPipeline.java:1375) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:396) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:376) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at io.netty.channel.DefaultChannelPipeline.fireUserEventTriggered(DefaultChannelPipeline.java:862) ~[netty-transport-4.1.114.Final.jar:4.1.114.Final]
	at org.apache.plc4x.java.s7.readwrite.protocol.S7HPlcConnection.sendChannelDisconectEvent(S7HPlcConnection.java:292) ~[plc4j-driver-s7-0.12.0.jar:0.12.0]
	at org.apache.plc4x.java.s7.readwrite.protocol.S7HPlcConnection.connect(S7HPlcConnection.java:170) ~[plc4j-driver-s7-0.12.0.jar:0.12.0]
	at org.apache.plc4x.java.DefaultPlcDriverManager.getConnection(DefaultPlcDriverManager.java:80) ~[plc4j-api-0.12.0.jar:0.12.0]
	at org.apache.camel.component.plc4x.Plc4XEndpoint.setupConnection(Plc4XEndpoint.java:125) ~[main/:na]
	at org.apache.camel.component.plc4x.Plc4XProducer.doStart(Plc4XProducer.java:51) ~[main/:na]
	at org.apache.camel.support.service.BaseService.start(BaseService.java:123) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:126) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.impl.engine.InternalServiceManager.doAddService(InternalServiceManager.java:144) ~[camel-base-engine-4.8.1.jar:4.8.1]
	at org.apache.camel.impl.engine.AbstractCamelContext.addService(AbstractCamelContext.java:1364) ~[camel-base-engine-4.8.1.jar:4.8.1]
	at org.apache.camel.processor.SendProcessor.doStart(SendProcessor.java:318) ~[camel-core-processor-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.BaseService.start(BaseService.java:123) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:126) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:113) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:153) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.processor.errorhandler.RedeliveryErrorHandler.doStart(RedeliveryErrorHandler.java:1668) ~[camel-core-processor-4.8.1.jar:4.8.1]
	at org.apache.camel.support.ChildServiceSupport.start(ChildServiceSupport.java:61) ~[camel-support-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:126) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:113) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:153) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.impl.engine.DefaultChannel.doStart(DefaultChannel.java:130) ~[camel-base-engine-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.BaseService.start(BaseService.java:123) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:126) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:113) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:139) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:115) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:153) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.processor.Pipeline.doStart(Pipeline.java:205) ~[camel-core-processor-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.BaseService.start(BaseService.java:123) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:126) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:113) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.support.processor.DelegateAsyncProcessor.doStart(DelegateAsyncProcessor.java:89) ~[camel-support-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.BaseService.start(BaseService.java:123) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.ServiceHelper.startService(ServiceHelper.java:126) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.impl.engine.RouteService.startChildServices(RouteService.java:408) ~[camel-base-engine-4.8.1.jar:4.8.1]
	at org.apache.camel.impl.engine.RouteService.doWarmUp(RouteService.java:202) ~[camel-base-engine-4.8.1.jar:4.8.1]
	at org.apache.camel.impl.engine.RouteService.warmUp(RouteService.java:123) ~[camel-base-engine-4.8.1.jar:4.8.1]
	at org.apache.camel.impl.engine.InternalRouteStartupManager.doWarmUpRoutes(InternalRouteStartupManager.java:327) ~[camel-base-engine-4.8.1.jar:4.8.1]
	at org.apache.camel.impl.engine.InternalRouteStartupManager.safelyStartRouteServices(InternalRouteStartupManager.java:198) ~[camel-base-engine-4.8.1.jar:4.8.1]
	at org.apache.camel.impl.engine.InternalRouteStartupManager.doStartOrResumeRoutes(InternalRouteStartupManager.java:132) ~[camel-base-engine-4.8.1.jar:4.8.1]
	at org.apache.camel.impl.engine.AbstractCamelContext.doStartCamel(AbstractCamelContext.java:2898) ~[camel-base-engine-4.8.1.jar:4.8.1]
	at org.apache.camel.impl.engine.AbstractCamelContext.doStartContext(AbstractCamelContext.java:2528) ~[camel-base-engine-4.8.1.jar:4.8.1]
	at org.apache.camel.impl.engine.AbstractCamelContext.doStart(AbstractCamelContext.java:2483) ~[camel-base-engine-4.8.1.jar:4.8.1]
	at org.apache.camel.spring.boot.SpringBootCamelContext.doStart(SpringBootCamelContext.java:43) ~[camel-spring-boot-4.8.1.jar:4.8.1]
	at org.apache.camel.support.service.BaseService.start(BaseService.java:123) ~[camel-api-4.8.1.jar:4.8.1]
	at org.apache.camel.impl.engine.AbstractCamelContext.start(AbstractCamelContext.java:2087) ~[camel-base-engine-4.8.1.jar:4.8.1]
	at org.apache.camel.impl.DefaultCamelContext.start(DefaultCamelContext.java:211) ~[camel-core-engine-4.8.1.jar:4.8.1]
	at org.apache.camel.spring.SpringCamelContext.start(SpringCamelContext.java:121) ~[camel-spring-4.8.1.jar:4.8.1]
	at org.apache.camel.spring.SpringCamelContext.onApplicationEvent(SpringCamelContext.java:153) ~[camel-spring-4.8.1.jar:4.8.1]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:185) ~[spring-context-6.1.14.jar:6.1.14]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:178) ~[spring-context-6.1.14.jar:6.1.14]
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:156) ~[spring-context-6.1.14.jar:6.1.14]
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:452) ~[spring-context-6.1.14.jar:6.1.14]
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:385) ~[spring-context-6.1.14.jar:6.1.14]
	at org.springframework.context.support.AbstractApplicationContext.finishRefresh(AbstractApplicationContext.java:993) ~[spring-context-6.1.14.jar:6.1.14]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:628) ~[spring-context-6.1.14.jar:6.1.14]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:754) ~[spring-boot-3.3.5.jar:3.3.5]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:456) ~[spring-boot-3.3.5.jar:3.3.5]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:335) ~[spring-boot-3.3.5.jar:3.3.5]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1363) ~[spring-boot-3.3.5.jar:3.3.5]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1352) ~[spring-boot-3.3.5.jar:3.3.5]
	...
```