### PR TITLE
Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/c-platform.yml
+++ b/.github/workflows/c-platform.yml
@@ -38,7 +38,7 @@ on:
         default: 'false'
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   test:

--- a/.github/workflows/c-platform.yml
+++ b/.github/workflows/c-platform.yml
@@ -38,7 +38,7 @@ on:
         default: 'false'
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   test:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
     - cron: '17 19 * * 3'
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
     - cron: '17 19 * * 3'
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   analyze:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -27,7 +27,7 @@ name: 'Dependency Review'
 on: [pull_request]
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -27,7 +27,7 @@ name: 'Dependency Review'
 on: [pull_request]
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 permissions:
   contents: read

--- a/.github/workflows/go-platform-test-report.yml
+++ b/.github/workflows/go-platform-test-report.yml
@@ -25,7 +25,7 @@ on:
       - completed
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   report:

--- a/.github/workflows/go-platform-test-report.yml
+++ b/.github/workflows/go-platform-test-report.yml
@@ -25,7 +25,7 @@ on:
       - completed
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   report:

--- a/.github/workflows/go-platform.yml
+++ b/.github/workflows/go-platform.yml
@@ -78,7 +78,7 @@ env:
   PLC4X_TEST_TRACE_DEFAULT_MESSAGE_CODEC_WORKER: ${{ github.event.inputs.traceDefaultMessageCodecWorker }}
   PLC4X_TEST_TRACE_EXECUTOR_WORKERS: ${{ github.event.inputs.traceExecutorWorkers }}
   PLC4X_TEST_TEST_TRANSPORT_INSTANCE: ${{ github.event.inputs.traceTestTransportInstance }}
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   test:

--- a/.github/workflows/go-platform.yml
+++ b/.github/workflows/go-platform.yml
@@ -78,7 +78,7 @@ env:
   PLC4X_TEST_TRACE_DEFAULT_MESSAGE_CODEC_WORKER: ${{ github.event.inputs.traceDefaultMessageCodecWorker }}
   PLC4X_TEST_TRACE_EXECUTOR_WORKERS: ${{ github.event.inputs.traceExecutorWorkers }}
   PLC4X_TEST_TEST_TRANSPORT_INSTANCE: ${{ github.event.inputs.traceTestTransportInstance }}
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   test:

--- a/.github/workflows/java-platform-test-report.yml
+++ b/.github/workflows/java-platform-test-report.yml
@@ -25,7 +25,7 @@ on:
       - completed
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   report:

--- a/.github/workflows/java-platform-test-report.yml
+++ b/.github/workflows/java-platform-test-report.yml
@@ -25,7 +25,7 @@ on:
       - completed
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   report:

--- a/.github/workflows/java-platform.yml
+++ b/.github/workflows/java-platform.yml
@@ -40,7 +40,7 @@ on:
         default: 'false'
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   test:

--- a/.github/workflows/java-platform.yml
+++ b/.github/workflows/java-platform.yml
@@ -40,7 +40,7 @@ on:
         default: 'false'
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   test:

--- a/.github/workflows/python-platform.yml
+++ b/.github/workflows/python-platform.yml
@@ -42,7 +42,7 @@ permissions:
   contents: read
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   test:

--- a/.github/workflows/python-platform.yml
+++ b/.github/workflows/python-platform.yml
@@ -42,7 +42,7 @@ permissions:
   contents: read
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   test:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -34,7 +34,7 @@ permissions:
   contents: read
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -34,7 +34,7 @@ permissions:
   contents: read
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   update_release_draft:

--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -25,7 +25,7 @@ on:
   pull_request:
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   build:

--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -25,7 +25,7 @@ on:
   pull_request:
 
 env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -201,6 +201,7 @@ DartConfiguration.tcl
 
 # Develocity
 .mvn/.gradle-enterprise/
+.mvn/.develocity/
 
 # UI
 /plc4j/tools/ui/frontend/project/node/

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -20,6 +20,7 @@
 <develocity xmlns="https://www.gradle.com/develocity-maven"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <projectId>plc4x</projectId>
   <server>
     <url>https://develocity.apache.org</url>
     <allowUntrusted>false</allowUntrusted>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -17,22 +17,20 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-<gradleEnterprise xmlns="https://www.gradle.com/gradle-enterprise-maven"
+<develocity xmlns="https://www.gradle.com/develocity-maven"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/gradle-enterprise-maven.xsd">
+                  xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/develocity-maven.xsd">
   <server>
     <url>https://develocity.apache.org</url>
     <allowUntrusted>false</allowUntrusted>
   </server>
   <buildScan>
-    <capture>
-      <goalInputFiles>true</goalInputFiles>
-      <buildLogging>true</buildLogging>
-      <testLogging>true</testLogging>
-    </capture>
     <backgroundBuildScanUpload>#{isFalse(env['GITHUB_ACTIONS'])}</backgroundBuildScanUpload>
-    <publish>ALWAYS</publish>
-    <publishIfAuthenticated>true</publishIfAuthenticated>
+    <publishing>
+      <onlyIf>
+        <![CDATA[authenticated]]>
+      </onlyIf>
+    </publishing>
     <obfuscation>
       <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
     </obfuscation>
@@ -45,4 +43,4 @@
       <enabled>false</enabled>
     </remote>
   </buildCache>
-</gradleEnterprise>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -20,8 +20,8 @@
             xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
   <extension>
     <groupId>com.gradle</groupId>
-    <artifactId>gradle-enterprise-maven-extension</artifactId>
-    <version>1.20.1</version>
+    <artifactId>develocity-maven-extension</artifactId>
+    <version>1.22.2</version>
   </extension>
   <extension>
     <groupId>com.gradle</groupId>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -21,7 +21,7 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/gradle-enterprise-maven.xsd">
   <server>
-    <url>https://ge.apache.org</url>
+    <url>https://develocity.apache.org</url>
     <allowUntrusted>false</allowUntrusted>
   </server>
   <buildScan>


### PR DESCRIPTION
This PR migrates the PLC4X project to publish Build Scans to the the new Develocity instance at develocity.apache.org.

Additionally, this PR migrates from the legacy Gradle Enterprise extension to the renamed Develocity extension and sets a projectId for use by Develocity.