### PR TITLE
Removed the space before double quote

### DIFF
--- a/website/resources/index.html
+++ b/website/resources/index.html
@@ -346,7 +346,7 @@
         <footer class="pt-4 my-md-5 pt-md-5 w-100 border-top">
             <div class="row justify-content-md-center" style="font-size: 13px">
                 <div class="col col-6 text-center">
-                    Copyright &#169; 2017&#x2013;2024 <a href="https://www.apache.org/">The Apache Software
+                    Copyright &#169; 2017&#x2013;2025 <a href="https://www.apache.org/">The Apache Software
                     Foundation</a>.
                     All rights reserved.<br/>
                     Apache PLC4X, PLC4?, Apache, the Apache feather logo, and the Apache PLC4X project logo are either

--- a/website/resources/index.html
+++ b/website/resources/index.html
@@ -115,8 +115,7 @@
                                         communicating with
                                         industrial
                                         programmable logic controllers (PLCs) using a variety of protocols but with a
-                                        shared API.
-                                    </div>
+                                        shared API.</div>
                                     <div class="center text-center">
                                         <a href="plc4x/latest/users/getting-started/index.html"
                                            class="plc4x-button plc4x-button-large plc4x-button-primary text-center"><i


### PR DESCRIPTION
![Monosnap Apache PLC4X 2025-01-28 12-47-23](https://github.com/user-attachments/assets/5c1627f4-0fa3-4368-b6c1-ba1310c0b364)

