### PR TITLE
fix(plc4j/ab-eth): AB-Ethernet Driver is not connecting in PLC Allen-Bradley SLC 5/05

### DIFF
--- a/plc4j/drivers/ab-eth/src/main/java/org/apache/plc4x/java/abeth/protocol/AbEthProtocolLogic.java
+++ b/plc4j/drivers/ab-eth/src/main/java/org/apache/plc4x/java/abeth/protocol/AbEthProtocolLogic.java
@@ -54,6 +54,9 @@ public class AbEthProtocolLogic extends Plc4xProtocolBase<CIPEncapsulationPacket
     private static final Logger logger = LoggerFactory.getLogger(AbEthProtocolLogic.class);
     public static final Duration REQUEST_TIMEOUT = Duration.ofMillis(10000);
 
+    private static final List<Short> connectionRequestSenderContext = Arrays.asList((short) 0x00, (short) 0x04, (short) 0x00,
+        (short) 0x05, (short) 0x00, (short) 0x00, (short) 0x00, (short) 0x00);
+
     private static final List<Short> emptySenderContext = Arrays.asList((short) 0x00, (short) 0x00, (short) 0x00,
         (short) 0x00, (short) 0x00, (short) 0x00, (short) 0x00, (short) 0x00);
 
@@ -84,7 +87,7 @@ public class AbEthProtocolLogic extends Plc4xProtocolBase<CIPEncapsulationPacket
     public void onConnect(ConversationContext<CIPEncapsulationPacket> context) {
         logger.debug("Sending Connection Request");
         CIPEncapsulationConnectionRequest connectionRequest =
-            new CIPEncapsulationConnectionRequest(0L, 0L, emptySenderContext, 0L);
+            new CIPEncapsulationConnectionRequest(0L, 0L, connectionRequestSenderContext, 0L);
         context.sendRequest(connectionRequest)
             .expectResponse(CIPEncapsulationPacket.class, REQUEST_TIMEOUT)
             .only(CIPEncapsulationConnectionResponse.class)


### PR DESCRIPTION
The request is not being sent as requested in the protocol. According to the protocol it should send the data below.

    <name>Connection Request</name>
    <raw>01010000000000000000000000**0400050000**000000000000000000000</raw>

But it is sending like below:

    <raw>01010000000000000000000000**0000000000**00000000000000000000</raw>

The test is ok! It generates the correct request but when I execute it does not.

Running the test, it gets the information of [senderContext](https://github.com/apache/plc4x/blob/aaf78d9f45b4fa65dc048c87865560d046c4b47e/plc4j/drivers/ab-eth/src/main/generated/org/apache/plc4x/java/abeth/readwrite/CIPEncapsulationPacket.java#L207) from its own test xml file [ParserSerializerTestsuite](https://github.com/apache/plc4x/blob/d45cbf3990d43834bfe617271ef61703453bc42a/protocols/ab-eth/src/test/resources/protocols/abeth/ParserSerializerTestsuite.xml#L30-L29)

Should it be like this? I did not investigate others drivers if they behaves the same way