### PR TITLE
fix(plc4py):  updated aenum dependency version to resolve Python build failures  (#2201)

### DIFF
--- a/plc4py/pyproject.toml
+++ b/plc4py/pyproject.toml
@@ -32,7 +32,7 @@ description = "Plc4Py The Python Industrial IOT Adapter"
 version = "0.13"
 readme = "README.md"
 dependencies = [
-        "aenum",
+        "aenum>=3.1.15",
         "bitarray",
         "typing_extensions",
         "pluggy",


### PR DESCRIPTION
## Description
Fixes Python build failures when building with `with-python`, and `enable-all-checks` profiles active.

## Root Cause
- Unpinned `aenum` dependency was installing versions 
 Fixes #2201
