### PR TITLE
add changes to release resources when the channel becomes inactive

### DIFF
--- a/plc4j/drivers/ab-eth/src/main/java/org/apache/plc4x/java/abeth/protocol/AbEthProtocolLogic.java
+++ b/plc4j/drivers/ab-eth/src/main/java/org/apache/plc4x/java/abeth/protocol/AbEthProtocolLogic.java
@@ -214,4 +214,9 @@ public class AbEthProtocolLogic extends Plc4xProtocolBase<CIPEncapsulationPacket
         return PlcResponseCode.NOT_FOUND;
     }
 
+    @Override
+    public void channelInactive(ConversationContext<CIPEncapsulationPacket> context) {
+        tm.shutdown();
+    }
+
 }

--- a/plc4j/drivers/ads/src/main/java/org/apache/plc4x/java/ads/protocol/AdsProtocolLogic.java
+++ b/plc4j/drivers/ads/src/main/java/org/apache/plc4x/java/ads/protocol/AdsProtocolLogic.java
@@ -1984,4 +1984,9 @@ public class AdsProtocolLogic extends Plc4xProtocolBase<AmsTCPPacket> implements
         return nullTerminatedBytes;
     }
 
+    @Override
+    public void channelInactive(ConversationContext<AmsTCPPacket> context) {
+        tm.shutdown();
+    }
+
 }

--- a/plc4j/drivers/bacnet/src/main/java/org/apache/plc4x/java/bacnetip/protocol/BacNetIpProtocolLogic.java
+++ b/plc4j/drivers/bacnet/src/main/java/org/apache/plc4x/java/bacnetip/protocol/BacNetIpProtocolLogic.java
@@ -288,4 +288,9 @@ public class BacNetIpProtocolLogic extends Plc4xProtocolBase<BVLC> implements Ha
         return tag.getDeviceIdentifier() + "/" + tag.getObjectType() + "/" + tag.getObjectInstance();
     }
 
+    @Override
+    public void channelInactive(ConversationContext<BVLC> context) {
+        // Nothing to do here ...
+    }
+
 }

--- a/plc4j/drivers/c-bus/src/main/java/org/apache/plc4x/java/cbus/protocol/CBusProtocolLogic.java
+++ b/plc4j/drivers/c-bus/src/main/java/org/apache/plc4x/java/cbus/protocol/CBusProtocolLogic.java
@@ -78,4 +78,9 @@ public class CBusProtocolLogic extends Plc4xProtocolBase<CBusCommand> {
     protected void decode(ConversationContext<CBusCommand> context, CBusCommand msg) throws Exception {
     }
 
+    @Override
+    public void channelInactive(ConversationContext<CBusCommand> context) {
+        tm.shutdown();
+    }
+
 }

--- a/plc4j/drivers/can/src/main/java/org/apache/plc4x/java/can/adapter/CANDriverAdapter.java
+++ b/plc4j/drivers/can/src/main/java/org/apache/plc4x/java/can/adapter/CANDriverAdapter.java
@@ -113,4 +113,9 @@ public class CANDriverAdapter<C, T> extends Plc4xProtocolBase<C> {
         delegate.close(new ConversationContextWrapper<>(context, wireType, adapter, frameHandler, context.getAuthentication()));
     }
 
+    @Override
+    public void channelInactive(ConversationContext<C> context) {
+        delegate.close(new ConversationContextWrapper<>(context, wireType, adapter, frameHandler, context.getAuthentication()));
+    }
+
 }

--- a/plc4j/drivers/can/src/main/java/org/apache/plc4x/java/can/generic/protocol/GenericCANProtocolLogic.java
+++ b/plc4j/drivers/can/src/main/java/org/apache/plc4x/java/can/generic/protocol/GenericCANProtocolLogic.java
@@ -233,4 +233,9 @@ public class GenericCANProtocolLogic extends Plc4xCANProtocolBase<GenericFrame> 
     public void unregister(PlcConsumerRegistration registration) {
         consumers.remove(registration);
     }
+
+    @Override
+    public void channelInactive(ConversationContext<GenericFrame> context) {
+        tm.shutdown();
+    }
 }

--- a/plc4j/drivers/canopen/src/main/java/org/apache/plc4x/java/canopen/protocol/CANOpenProtocolLogic.java
+++ b/plc4j/drivers/canopen/src/main/java/org/apache/plc4x/java/canopen/protocol/CANOpenProtocolLogic.java
@@ -453,4 +453,9 @@ public class CANOpenProtocolLogic extends Plc4xCANProtocolBase<CANOpenFrame>
         }
     }
 
+    @Override
+    public void channelInactive(ConversationContext<CANOpenFrame> context) {
+        tm.shutdown();
+    }
+
 }

--- a/plc4j/drivers/eip/src/main/java/org/apache/plc4x/java/eip/base/protocol/EipProtocolLogic.java
+++ b/plc4j/drivers/eip/src/main/java/org/apache/plc4x/java/eip/base/protocol/EipProtocolLogic.java
@@ -1355,4 +1355,9 @@ public class EipProtocolLogic extends Plc4xProtocolBase<EipPacket> implements Ha
         }
     }
 
+    @Override
+    public void channelInactive(ConversationContext<EipPacket> context) {
+        tm.shutdown();
+    }
+
 }

--- a/plc4j/drivers/firmata/src/main/java/org/apache/plc4x/java/firmata/readwrite/protocol/FirmataProtocolLogic.java
+++ b/plc4j/drivers/firmata/src/main/java/org/apache/plc4x/java/firmata/readwrite/protocol/FirmataProtocolLogic.java
@@ -320,4 +320,9 @@ public class FirmataProtocolLogic extends Plc4xProtocolBase<FirmataMessage> impl
         return BitSet.valueOf(bitSetData);
     }
 
+    @Override
+    public void channelInactive(ConversationContext<FirmataMessage> context) {
+        connected.set(false);
+    }
+
 }

--- a/plc4j/drivers/iec-60870/src/main/java/org/apache/plc4x/java/iec608705104/readwrite/protocol/Iec608705104Protocol.java
+++ b/plc4j/drivers/iec-60870/src/main/java/org/apache/plc4x/java/iec608705104/readwrite/protocol/Iec608705104Protocol.java
@@ -235,4 +235,9 @@ public class Iec608705104Protocol extends Plc4xProtocolBase<APDU> implements Has
         }
     }
 
+    @Override
+    public void channelInactive(ConversationContext<APDU> context) {
+        tm.shutdown();
+    }
+
 }

--- a/plc4j/drivers/knxnetip/src/main/java/org/apache/plc4x/java/knxnetip/protocol/KnxNetIpProtocolLogic.java
+++ b/plc4j/drivers/knxnetip/src/main/java/org/apache/plc4x/java/knxnetip/protocol/KnxNetIpProtocolLogic.java
@@ -640,4 +640,9 @@ public class KnxNetIpProtocolLogic extends Plc4xProtocolBase<KnxNetIpMessage> im
         throw new PlcRuntimeException("Unsupported Group Address Type " + groupAddress.getClass().getName());
     }
 
+    @Override
+    public void channelInactive(ConversationContext<KnxNetIpMessage> context) {
+        tm.shutdown();
+    }
+
 }

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/protocol/ModbusProtocolLogic.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/base/protocol/ModbusProtocolLogic.java
@@ -64,6 +64,11 @@ public abstract class ModbusProtocolLogic<T extends ModbusADU> extends Plc4xProt
     }
 
     @Override
+    public void channelInactive(ConversationContext<T> context) {
+        // Nothing to do here ...
+    }
+
+    @Override
     protected void decode(ConversationContext<T> context, T msg) throws Exception {
         super.decode(context, msg);
     }
@@ -417,5 +422,4 @@ public abstract class ModbusProtocolLogic<T extends ModbusADU> extends Plc4xProt
         }
         return out;
     }
-
 }

--- a/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/tcp/protocol/ModbusTcpProtocolLogic.java
+++ b/plc4j/drivers/modbus/src/main/java/org/apache/plc4x/java/modbus/tcp/protocol/ModbusTcpProtocolLogic.java
@@ -67,6 +67,11 @@ public class ModbusTcpProtocolLogic extends ModbusProtocolLogic<ModbusTcpADU> im
     }
 
     @Override
+    public void channelInactive(ConversationContext<ModbusTcpADU> context) {
+        tm.shutdown();
+    }
+
+    @Override
     public CompletableFuture<PlcPingResponse> ping(PlcPingRequest pingRequest) {
         CompletableFuture<PlcPingResponse> future = new CompletableFuture<>();
 

--- a/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/protocol/OpcuaProtocolLogic.java
+++ b/plc4j/drivers/opcua/src/main/java/org/apache/plc4x/java/opcua/protocol/OpcuaProtocolLogic.java
@@ -901,4 +901,8 @@ public class OpcuaProtocolLogic extends Plc4xProtocolBase<OpcuaAPU> implements H
         }
     }
 
+    @Override
+    public void channelInactive(ConversationContext<OpcuaAPU> context) {
+        tm.shutdown();
+    }
 }

--- a/plc4j/drivers/open-protocol/src/main/java/org/apache/plc4x/java/openprotocol/protocol/OpenProtocolProtocolLogic.java
+++ b/plc4j/drivers/open-protocol/src/main/java/org/apache/plc4x/java/openprotocol/protocol/OpenProtocolProtocolLogic.java
@@ -80,4 +80,8 @@ public class OpenProtocolProtocolLogic extends Plc4xProtocolBase<OpenProtocolMes
     public void unregister(PlcConsumerRegistration plcConsumerRegistration) {
     }
 
+    @Override
+    public void channelInactive(ConversationContext<OpenProtocolMessage> context) {
+    }
+
 }

--- a/plc4j/drivers/plc4x/src/main/java/org/apache/plc4x/java/plc4x/protocol/Plc4xProtocolLogic.java
+++ b/plc4j/drivers/plc4x/src/main/java/org/apache/plc4x/java/plc4x/protocol/Plc4xProtocolLogic.java
@@ -200,4 +200,9 @@ public class Plc4xProtocolLogic extends Plc4xProtocolBase<Plc4xMessage> implemen
         super.decode(context, msg);
     }
 
+    @Override
+    public void channelInactive(ConversationContext<Plc4xMessage> context) {
+        tm.shutdown();
+    }
+
 }

--- a/plc4j/drivers/profinet-ng/src/main/java/org/apache/plc4x/java/profinet/protocol/ProfinetProtocolLogic.java
+++ b/plc4j/drivers/profinet-ng/src/main/java/org/apache/plc4x/java/profinet/protocol/ProfinetProtocolLogic.java
@@ -905,4 +905,9 @@ public class ProfinetProtocolLogic extends Plc4xProtocolBase<Ethernet_Frame> imp
         throw new PlcRuntimeException("Length undefined");
     }
 
+    @Override
+    public void channelInactive(ConversationContext<Ethernet_Frame> context) {
+        context.getChannel().close();
+    }
+
 }

--- a/plc4j/drivers/profinet/src/main/java/org/apache/plc4x/java/profinet/protocol/ProfinetProtocolLogic.java
+++ b/plc4j/drivers/profinet/src/main/java/org/apache/plc4x/java/profinet/protocol/ProfinetProtocolLogic.java
@@ -271,4 +271,9 @@ public class ProfinetProtocolLogic extends Plc4xProtocolBase<Ethernet_Frame> imp
     protected void decode(ConversationContext<Ethernet_Frame> context, Ethernet_Frame msg) throws Exception {
         super.decode(context, msg);
     }
+
+    @Override
+    public void channelInactive(ConversationContext<Ethernet_Frame> context) {
+        // TODO:- Do something here
+    }
 }

--- a/plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7/readwrite/protocol/S7ProtocolLogic.java
+++ b/plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7/readwrite/protocol/S7ProtocolLogic.java
@@ -2494,4 +2494,8 @@ public class S7ProtocolLogic extends Plc4xProtocolBase<TPKTPacket> {
 
     }
 
+    @Override
+    public void channelInactive(ConversationContext<TPKTPacket> context) {
+        tm.shutdown();
+    }
 }

--- a/plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7light/readwrite/protocol/S7ProtocolLogic.java
+++ b/plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7light/readwrite/protocol/S7ProtocolLogic.java
@@ -89,6 +89,11 @@ public class S7ProtocolLogic extends Plc4xProtocolBase<TPKTPacket> {
     }
 
     @Override
+    public void channelInactive(ConversationContext<TPKTPacket> context) {
+        tm.shutdown();
+    }
+
+    @Override
     public void onConnect(ConversationContext<TPKTPacket> context) {
         // Only the TCP transport supports login.
         logger.info("S7 Driver running in ACTIVE mode.");
@@ -1099,5 +1104,4 @@ public class S7ProtocolLogic extends Plc4xProtocolBase<TPKTPacket> {
         }
 
     }
-
 }

--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/Plc4xNettyWrapper.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/Plc4xNettyWrapper.java
@@ -136,14 +136,14 @@ public class Plc4xNettyWrapper<T> extends MessageToMessageCodec<T, Object> {
 
     @Override
     public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
-        logger.info("close.. context: {}", ctx.name());
+        logger.trace("close.. context: {}", ctx.name());
         super.close(ctx, promise);
         timeoutManager.stop();
     }
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        logger.info("channelInactive.. context: {}", ctx.name());
+        logger.trace("channelInactive.. context: {}", ctx.name());
         super.channelInactive(ctx);
         this.protocolBase.channelInactive(new DefaultConversationContext<>(this::registerHandler, ctx, authentication, passive));
         timeoutManager.stop();

--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/Plc4xNettyWrapper.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/Plc4xNettyWrapper.java
@@ -136,7 +136,16 @@ public class Plc4xNettyWrapper<T> extends MessageToMessageCodec<T, Object> {
 
     @Override
     public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        logger.info("close.. context: {}", ctx.name());
         super.close(ctx, promise);
+        timeoutManager.stop();
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        logger.info("channelInactive.. context: {}", ctx.name());
+        super.channelInactive(ctx);
+        this.protocolBase.channelInactive(new DefaultConversationContext<>(this::registerHandler, ctx, authentication, passive));
         timeoutManager.stop();
     }
 

--- a/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/Plc4xProtocolBase.java
+++ b/plc4j/spi/src/main/java/org/apache/plc4x/java/spi/Plc4xProtocolBase.java
@@ -101,4 +101,6 @@ public abstract class Plc4xProtocolBase<T> {
 
     public abstract void close(ConversationContext<T> context);
 
+    public abstract void channelInactive(ConversationContext<T> context);
+
 }

--- a/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/DefaultNettyPlcConnectionTest.java
+++ b/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/DefaultNettyPlcConnectionTest.java
@@ -41,13 +41,14 @@ class DefaultNettyPlcConnectionTest {
     final GateKeeper connect = new GateKeeper("connect");
     final GateKeeper disconnect = new GateKeeper("disconnect");
     final GateKeeper close = new GateKeeper("close");
+    final GateKeeper channelInactive = new GateKeeper("channelInactive");
 
     @Test
     void checkInitializationSequence() throws Exception {
         ChannelFactory channelFactory = new TestChannelFactory();
 
         ProtocolStackConfigurer<Message> stackConfigurer = (configuration, pipeline, authentication, passive, listeners) -> {
-            TestProtocolBase base = new TestProtocolBase(discovery, connect, disconnect, close);
+            TestProtocolBase base = new TestProtocolBase(discovery, connect, disconnect, close, channelInactive);
             Plc4xNettyWrapper<Message> context = new Plc4xNettyWrapper<>(new NettyHashTimerTimeoutManager(), pipeline, passive, base, authentication, Message.class);
             pipeline.addLast(context);
             return base;
@@ -153,12 +154,14 @@ class DefaultNettyPlcConnectionTest {
         private final GateKeeper connect;
         private final GateKeeper close;
         private final GateKeeper disconnect;
+        private final GateKeeper channelInactive;
 
-        public TestProtocolBase(GateKeeper discover, GateKeeper connect, GateKeeper disconnect, GateKeeper close) {
+        public TestProtocolBase(GateKeeper discover, GateKeeper connect, GateKeeper disconnect, GateKeeper close, GateKeeper channelInactive) {
             this.discover = discover;
             this.connect = connect;
             this.close = close;
             this.disconnect = disconnect;
+            this.channelInactive =channelInactive;
         }
 
         @Override
@@ -210,6 +213,13 @@ class DefaultNettyPlcConnectionTest {
                 throw new RuntimeException(e);
             }
         }
-    }
 
+        @Override
+        public void channelInactive(ConversationContext<Message> context) {
+            logger.info("On ChannelInactive");
+            channelInactive.permitEntry();
+            awaitIn(channelInactive);
+            channelInactive.reportExit();
+        }
+    }
 }

--- a/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/TestProtocol.java
+++ b/plc4j/spi/src/test/java/org/apache/plc4x/java/spi/connection/TestProtocol.java
@@ -57,4 +57,9 @@ public class TestProtocol extends Plc4xProtocolBase<TestMessage> {
         context.getChannel().close();
     }
 
+    @Override
+    public void channelInactive(ConversationContext<TestMessage> context) {
+        context.getChannel().close();
+    }
+
 }


### PR DESCRIPTION
While I was looking into this issue I found out that there are two leaks. The first is related to the RequestTransactionManager and the other is from the NettyHashTimerTimeoutManager. As I was mentioning in the issue I opened last week, this leaks happens when the PLC goes offline and back online and the client tries to reconnecting to it in a cycle.

I was only able to test this on the modbus simulator which seems to work ok with the changes I made on this branch. 
Please provide me a feedback or any consideration. I am attaching also a small video which shows that the resources are freed as expected.

[Issue link](https://github.com/apache/plc4x/issues/2229)

https://github.com/user-attachments/assets/52d07125-cd87-47d7-9b96-e33f488a3039

