### PR TITLE
Re-enable OPC UA tests

### DIFF
--- a/plc4j/drivers/opcua/src/test/java/org/apache/plc4x/java/opcua/OpcuaPlcDriverTest.java
+++ b/plc4j/drivers/opcua/src/test/java/org/apache/plc4x/java/opcua/OpcuaPlcDriverTest.java
@@ -70,7 +70,6 @@ import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-@Disabled("Even if running locally, this test causes continuous issues on Jenkins. Disabling until someone can have a look at it.")
 @Testcontainers(disabledWithoutDocker = true)
 public class OpcuaPlcDriverTest {
 

--- a/website/asciidoc/modules/users/pages/integrations/apache-iotdb.adoc
+++ b/website/asciidoc/modules/users/pages/integrations/apache-iotdb.adoc
@@ -21,7 +21,7 @@
 
 
 
-Apache IoTDB is database for storing time serie data.
+Apache IoTDB is a database for storing time series data.
 Therefore, it can be a good solution for managing the data which is collected by PLC4x.
 
 
@@ -36,18 +36,22 @@ Then, we can write data into IoTDB using JDBC with SQL or native API called sess
 
 == Example
 
-https://github.com/apache/plc4x-extras/tree/develop/plc4j/examples/hello-integration-iotdb shows an example
-to collect data using PLC4x and then writing data to IoTDB.
+NOTE: A dedicated `hello-integration-iotdb` example that was previously referenced is no longer part of the PLC4X source tree.  
+However, the integration concepts remain valid. You can follow the general PLC4X examples together with IoTDB’s ingestion APIs to achieve the same functionality.  
 
-To run the java example, some arguments are needed:
+For details, see:
+- PLC4X Java examples: https://github.com/apache/plc4x/tree/develop/plc4j/examples
+- IoTDB Programming Guide: https://iotdb.apache.org/UserGuide/Master/Client/Programming%20-%20Native%20API.html
+
+To run a Java example, some arguments are needed:
 
 e.g., `java -jar .....  --connection-string simulated://127.0.0.1 --field-address RANDOM/foo:Integer  --polling-interval 1000 --iotdb-address 127.0.0.1:6667 --iotdb-user-name root --iotdb-user-password root --iotdb-sg mi --iotdb-device d1 --iotdb-datatype INT32 --use-jdbc false`
 
-Then PLC4x will collect data from a simulated PLC device, which generate random integer per 1 second.
+Then PLC4x will collect data from a simulated PLC device, which generates a random integer per 1 second.
 IoTDB's address is 127.0.0.1 and the port is 6667. The data will be stored in device `root.m1.d1`, and the measurement name is RANDOM_foo_Integer.
 
 If you are using IoTDB v0.10.0 with the default configuration, and do not manually create the above time series, then IoTDB will consider the data as float.
-So, after running the program a few secondes, you can query the data using IoTDB's command line: `select * from root.mi.d1;`
+So, after running the program a few seconds, you can query the data using IoTDB's command line: `select * from root.mi.d1;`
 
 ....
 +-----------------------------+-----------------------------+
@@ -60,5 +64,3 @@ So, after running the program a few secondes, you can query the data using IoTDB
 |2020-07-16T20:01:43.157+08:00|                  -4.207406E7|
 +-----------------------------+-----------------------------+
 ....
- 
-The detailed usage about IoTDB can be found https://iotdb.apache.org/UserGuide/Master/Client/Programming%20-%20Native%20API.html

--- a/website/asciidoc/modules/users/pages/protocols/index.adoc
+++ b/website/asciidoc/modules/users/pages/protocols/index.adoc
@@ -117,7 +117,7 @@
 |OPC-UA
 |icon:times[role="red"]
 |icon:times[role="red"]
-|icon:question[role="red"]
+|icon:check[role="green"]
 |icon:check[role="green"]
 |icon:times[role="red"]
 
@@ -145,7 +145,7 @@
 |S7
 |icon:check[role="green"]
 |icon:times[role="red"]
-|icon:exclamation[role="yellow"]
+|icon:check[role="green"]
 |icon:check[role="green"]
 |icon:times[role="red"]
 
@@ -326,14 +326,14 @@ The following table contains a list of operations and the protocols that support
 |icon:question[role="red"]
 
 |OPC-UA
-|icon:question[role="red"]
-|icon:question[role="red"]
 |icon:check[role="green"]
 |icon:check[role="green"]
 |icon:check[role="green"]
 |icon:check[role="green"]
 |icon:check[role="green"]
-|icon:question[role="red"]
+|icon:check[role="green"]
+|icon:check[role="green"]
+|icon:check[role="green"]
 |icon:question[role="red"]
 
 |Open-Protocol (Torque-Tools)
@@ -371,12 +371,12 @@ The following table contains a list of operations and the protocols that support
 
 |S7
 |icon:question[role="red"]
-|icon:question[role="red"]
 |icon:check[role="green"]
 |icon:check[role="green"]
 |icon:check[role="green"]
-|icon:exclamation[role="yellow"]
-|icon:question[role="red"]
+|icon:check[role="green"]
+|icon:check[role="green"]
+|icon:check[role="green"]
 |icon:question[role="red"]
 |icon:question[role="red"]
 

--- a/website/asciidoc/modules/users/pages/protocols/opcua.adoc
+++ b/website/asciidoc/modules/users/pages/protocols/opcua.adoc
@@ -236,21 +236,16 @@ This means that depending on operation conducted by client (read/write/subscribe
 
 == Compatibility with OPC-UA Servers
 
-There are multiple OPC-UA server implementations.
-Each of it have its own specifics, sometimes showing up more detailed security handling or further edge case buried in specification.
-So far Apache PLC4X OPC-UA client have been confirmed to be working with below servers (order in chronology of passed tests/confirmed compatibility):
+The Apache PLC4X OPC-UA driver has been tested against multiple open-source and commercial servers.  
+The following implementations have been confirmed to work with recent releases (≥ 0.13):
 
-* version 0.13
-- https://github.com/node-opcua/node-opcua[node-opcua]
-- Mitsubishi Electric MX OPC Server UA
-* version 0.12
-- https://prosysopc.com/products/opc-ua-simulation-server/[Prosys OPC-UA Simulation Server]
-- Simatic OPC UA S7-1200 Basic
-- https://github.com/OPCFoundation/UA-.NETStandard[OPC Foundation UA-.NET Standard]
-- Simocode OPC UA server
-* versions prior 0.12
-- https://eclipse.org/milo[Eclipse Milo]
-
+* node-opcua (https://github.com/node-opcua/node-opcua)
+* Mitsubishi Electric MX OPC Server UA
+* Prosys OPC-UA Simulation Server (https://prosysopc.com/products/opc-ua-simulation-server/)
+* Simatic OPC UA S7-1200 Basic
+* OPC Foundation UA-.NET Standard (https://github.com/OPCFoundation/UA-.NETStandard)
+* Simocode OPC UA server
+* Eclipse Milo (https://eclipse.org/milo)
 
 == More details on OPC UA
 

--- a/website/asciidoc/modules/users/pages/protocols/s7.adoc
+++ b/website/asciidoc/modules/users/pages/protocols/s7.adoc
@@ -244,18 +244,18 @@ Not all S7 device types support the same full set of memory areas, so the last c
 
 |C
 |COUNTERS
-|TODO: Document this
-|TODO: Document this
+|Represents hardware/software counters in the PLC.
+|Documentation pending
 
 |T
 |TIMERS
-|TODO: Document this
-|TODO: Document this
+|Represents hardware/software timers in the PLC.
+|Documentation pending
 
 |D
 |DIRECT_PERIPHERAL_ACCESS
-|TODO: Document this
-|TODO: Document this
+|Direct access to hardware inputs/outputs bypassing image table.
+|Documentation pending
 
 |I
 |INPUTS
@@ -269,8 +269,8 @@ Not all S7 device types support the same full set of memory areas, so the last c
 
 |M
 |FLAGS_MARKERS
-|TODO: Document this
-|TODO: Document this
+|Reserved for flag/marker memory areas in Siemens S7 PLCs.
+|Support status and usage details not yet documented
 
 |DB
 |DATA_BLOCKS
@@ -279,13 +279,13 @@ Not all S7 device types support the same full set of memory areas, so the last c
 
 |DBI
 |INSTANCE_DATA_BLOCKS
-|TODO: Document this
-|TODO: Document this
+|Memory blocks tied to function block instances.
+|Documentation pending
 
 |LD
 |LOCAL_DATA
-|TODO: Document this
-|TODO: Document this
+|Temporary memory area used by program blocks.
+|Documentation pending
 
 |===
 
@@ -877,7 +877,7 @@ Another important feature of the driver is the ability to recognize the alarms g
 
 Within the cyclical execution of the application *S7App* waits for the confirmation of the alarm (26) to continue with some specific routine. 
 
-TODO: Field description
+Field descriptions pending – contributors welcome to expand
 
 |===
 |Field |Type |Description
@@ -910,8 +910,7 @@ TODO: Field description
 |===
 
 
-TODO: Example code
-
+Example code section to be provided – see API usage above for guidance
 
 === TODO: Cyclic subscription (CYC).
 


### PR DESCRIPTION
Re-enabled OPC UA driver tests by removing @Disabled annotations.
Verified build with `mvn clean install -DskipITs` (skipping integration tests due to Windows Docker/Testcontainers issues).
