### PR TITLE
Fix empty queue with broken connections

### DIFF
--- a/plc4j/tools/connection-cache/src/main/java/org/apache/plc4x/java/utils/cache/ConnectionContainer.java
+++ b/plc4j/tools/connection-cache/src/main/java/org/apache/plc4x/java/utils/cache/ConnectionContainer.java
@@ -179,9 +179,6 @@ class ConnectionContainer {
             return;
         }
 
-
-
-
         // Create a new lease and complete the next future in the queue with this.
         leasedConnection = new LeasedPlcConnection(this, connection, maxLeaseTime);
         CompletableFuture<PlcConnection> leaseFuture = queue.poll();

--- a/plc4j/tools/connection-cache/src/main/java/org/apache/plc4x/java/utils/cache/ConnectionContainer.java
+++ b/plc4j/tools/connection-cache/src/main/java/org/apache/plc4x/java/utils/cache/ConnectionContainer.java
@@ -152,6 +152,7 @@ class ConnectionContainer {
                 // If something goes wrong, close all waiting futures exceptionally.
                 LOGGER.warn("Can't get connection for {} complete queue items exceptionally", connectionUrl, e);
                 queue.forEach(future -> future.completeExceptionally(e));
+                queue.clear();
                 connection = null;
             }
         }
@@ -177,6 +178,9 @@ class ConnectionContainer {
             }, maxIdleTime.toMillis());
             return;
         }
+
+
+
 
         // Create a new lease and complete the next future in the queue with this.
         leasedConnection = new LeasedPlcConnection(this, connection, maxLeaseTime);


### PR DESCRIPTION
Hi all,

in Apache StreamPipes we encountered an issue where, if a connection drops during a lease and reconnection subsequently fails, the container leaves behind a “zombie” `leasedConnection` as well as a non-empty queue containing futures that have already completed. To address this, we added a `queue.clear()` call in the `ConnectionContainer`.

For StreamPipes we had temporarily copied the corresponding PLC4X classes [1] to apply this fix on our side. If this change is acceptable from your perspective, we can remove the duplicated PLC4X classes from the StreamPipes codebase.

I hope this update makes sense. If there’s anything else I should adjust, please let me know.

[1] https://github.com/apache/streampipes/tree/dev/streampipes-extensions/streampipes-connectors-plc/src/main/java/org/apache/streampipes/extensions/connectors/plc/cache