### PR TITLE
fix(bacnet): Don't fail the build when the vendor id can't be downlaoded.

### DIFF
--- a/protocols/bacnetip/src/main/script/getVendorIds.groovy
+++ b/protocols/bacnetip/src/main/script/getVendorIds.groovy
@@ -50,6 +50,9 @@ if (update) {
         println "Successfully updated BACnet Vendor IDs.htm"
     } catch (Exception e) {
         println "Got an error updating BACnet Vendor IDs.htm. Intentionally not failing the build as we might just be offline: " + e.getMessage()
+        // If we can't update the vendor id file, it may be older and we run the risk of incorrectly updating the repo with an older version.
+        // The vendor id website also has a cloudfare check which depending on the location may fail the build.
+        return
     }
 } else {
     println "Skipped updating BACnet Vendor IDs.htm as it's fresh enough"


### PR DESCRIPTION
There seems to be an issue accessing the vendor id file. It seems to depend on the location https://bacnet.org/assigned-vendor-ids/ is accessed from.

When it can't be downlaoded automatically just don't update the vendor id. We also run the risk of updating it with an older version of the file, which would cause a nuisence for people that can't access it.

We do run the risk of silently ignoring any issues here though