### PR TITLE
restore skip-code-generation property usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -971,6 +971,9 @@
           <groupId>org.apache.plc4x.plugins</groupId>
           <artifactId>plc4x-maven-plugin</artifactId>
           <version>${plc4x-code-generation.version}</version>
+          <configuration>
+            <skip>${skip-code-generation}</skip>
+          </configuration>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
restore property usage introduced in 1ff58957f83cfa00bd033c27112f50ae04d41bec
but removed in #1172

necessary to rebuild the reference release published to Maven Central, that is build with the generation profile activated, which adds dependencies (even if provided)

see https://github.com/jvm-repo-rebuild/reproducible-central/pull/4800