### PR TITLE
fix(plc4j/eip): NullPointerException on decodeSingleReadResponse.

### DIFF
--- a/plc4j/drivers/eip/src/main/java/org/apache/plc4x/java/eip/base/protocol/EipProtocolLogic.java
+++ b/plc4j/drivers/eip/src/main/java/org/apache/plc4x/java/eip/base/protocol/EipProtocolLogic.java
@@ -811,9 +811,9 @@ public class EipProtocolLogic extends Plc4xProtocolBase<EipPacket> implements Ha
         CipReadResponse resp = (CipReadResponse) p;
         PlcResponseCode code = decodeResponseCode(resp.getStatus());
         PlcValue plcValue = null;
-        CIPDataTypeCode type = resp.getData().getDataType();
-        ByteBuf data = Unpooled.wrappedBuffer(resp.getData().getData());
         if (code == PlcResponseCode.OK) {
+            CIPDataTypeCode type = resp.getData().getDataType();
+            ByteBuf data = Unpooled.wrappedBuffer(resp.getData().getData());
             plcValue = parsePlcValue((EipTag) tag, data, type);
         }
         PlcResponseItem<PlcValue> result = new DefaultPlcResponseItem<>(code, plcValue);


### PR DESCRIPTION
Hi everybody!

I am facing NPE at [EipProtocolLogic:::decodeSingleReadResponse](https://github.com/apache/plc4x/blob/cabd026ac1f00c39d09865a0e66fddf25da639f2/plc4j/drivers/eip/src/main/java/org/apache/plc4x/java/eip/base/protocol/EipProtocolLogic.java#L814) because the PlcResponseCode == "INTERNAL_ERROR
```
╔═CipService════════════════════════════════════════════╗
║╔═response╗╔═service╗╔═CipReadResponse════════════════╗║
║║ b1 true ║║0x4c 76 ║║╔═reserved╗╔═status╗╔═extStatus╗║║
║╚═════════╝╚════════╝║║ 0x00 0  ║║0x05 5 ║║  0x00 0  ║║║
║                     ║╚═════════╝╚═══════╝╚══════════╝║║
║                     ╚════════════════════════════════╝║
╚═══════════════════════════════════════════════════════╝
```
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.plc4x.java.eip.readwrite.CIPData.getDataType()" because the return value of "org.apache.plc4x.java.eip.readwrite.CipReadResponse.getData()" is null
	at org.apache.plc4x.java.eip.base.protocol.EipProtocolLogic.decodeSingleReadResponse(EipProtocolLogic.java:814)
	at org.apache.plc4x.java.eip.base.protocol.EipProtocolLogic.lambda$readWithoutMessageRouter$5(EipProtocolLogic.java:509)
	at java.base/java.util.function.Consumer.lambda$andThen$0(Consumer.java:65)
	at org.apache.plc4x.java.spi.Plc4xNettyWrapper.decode(Plc4xNettyWrapper.java:194)
	at io.netty.handler.codec.MessageToMessageCodec$1.decode(MessageToMessageCodec.java:67)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:91)
	at io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:120)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)


This pull request just move the type and data to inside the "if" where PlcResponseCode is OK. The data moved is just necessary inside the if to create the plcValue. So it is ok to move the code.

Instead of throwing an exception, the system will report the response code INTERNAL_ERROR and plcValue will be null.

PlcValue null value already can happen on parsePlcValue. So not prejuize to the current logic.

Best regards,
Anderson.