### PR TITLE
fix(go-codegen): chain getLengthInBits for middle-tier discriminated types

### DIFF
--- a/code-generation/language/go/src/main/resources/templates/go/complex-type-template.go.ftlh
+++ b/code-generation/language/go/src/main/resources/templates/go/complex-type-template.go.ftlh
@@ -831,7 +831,11 @@ func (m *_${type.name}) GetLengthInBits(ctx context.Context) uint16 {
 
 <#if type.isDiscriminatedParentTypeDefinition()>
 func (m *_${type.name}) getLengthInBits(ctx context.Context) uint16 {
+	<#if type.parentType.isPresent()>
+	lengthInBits := uint16(m.${type.getParentType().orElseThrow().name}Contract.(*_${type.getParentType().orElseThrow().name}).getLengthInBits(ctx))
+	<#else>
 	lengthInBits := uint16(0)
+	</#if>
 	<#list type.fields as field>
 		<#switch field.typeName>
 			<#case "array">


### PR DESCRIPTION
## Summary

- Fix Go FreeMarker template `getLengthInBits` for discriminated parent types that also have a parent (middle-tier in 3+ level hierarchies)
- Previously always initialized with `uint16(0)`, now chains to parent's `getLengthInBits` when `type.parentType.isPresent()`
- Fixes incorrect serialization sizes for protocols with multi-level discriminated type hierarchies

## Problem

In 3-level discriminated type hierarchies like IEC 60870-5-104's:
```
InformationObject (address: 24 bits)
  └── InformationObjectWithoutTime (no own fields)
        └── InformationObjectWithoutTime_SINGLE_POINT_INFORMATION (siq: 8 bits)
```

The middle-tier type `InformationObjectWithoutTime` generated:
```go
func (m *_InformationObjectWithoutTime) getLengthInBits(ctx context.Context) uint16 {
    lengthInBits := uint16(0)  // ❌ Missing parent's 24-bit address field
    return lengthInBits
}
```

This caused leaf types to compute incorrect lengths (3 bytes too short), resulting in wrong `apciLength` values during serialization.

## Fix

When a discriminated parent type also has a parent (`type.parentType.isPresent()`), chain to the parent's `getLengthInBits` instead of starting from zero:

```go
func (m *_InformationObjectWithoutTime) getLengthInBits(ctx context.Context) uint16 {
    lengthInBits := uint16(m.InformationObjectContract.(*_InformationObject).getLengthInBits(ctx))  // ✅
    return lengthInBits
}
```

Root parent types (no parent) continue to start from `uint16(0)`.

## Affected protocols

- **IEC 60870-5-104**: `InformationObjectWithoutTime`, `InformationObjectWithTreeByteTime`, `InformationObjectWithSevenByteTime`
- **OPC UA**: `ExtensionObjectWithMask`

## Test plan

- [x] Regenerated all Go protocols — builds clean
- [x] All existing S7 parser/serializer tests pass (no regressions)
- [x] IEC 60870-5-104 parser/serializer tests pass (62/65 with 3 float-precision-only diffs)