### PR TITLE
fix(plc4go/spi): preserve WithByteOrder in UpcastReaderArgs/UpcastWriterArgs

### DIFF
--- a/plc4go/spi/utils/Buffer.go
+++ b/plc4go/spi/utils/Buffer.go
@@ -83,7 +83,13 @@ type withEncoding struct {
 func UpcastReaderArgs(args ...WithReaderArgs) []WithReaderWriterArgs {
 	result := make([]WithReaderWriterArgs, len(args))
 	for i, arg := range args {
-		result[i] = readerWriterArg{arg, writerArg{}}
+		// If the arg already implements WithReaderWriterArgs (e.g. codegen.WithByteOrder),
+		// use it directly to preserve the concrete type for type switches.
+		if rw, ok := arg.(WithReaderWriterArgs); ok {
+			result[i] = rw
+		} else {
+			result[i] = readerWriterArg{arg, writerArg{}}
+		}
 	}
 	return result
 }
@@ -91,7 +97,13 @@ func UpcastReaderArgs(args ...WithReaderArgs) []WithReaderWriterArgs {
 func UpcastWriterArgs(args ...WithWriterArgs) []WithReaderWriterArgs {
 	result := make([]WithReaderWriterArgs, len(args))
 	for i, arg := range args {
-		result[i] = readerWriterArg{readerArg{}, arg}
+		// If the arg already implements WithReaderWriterArgs (e.g. codegen.WithByteOrder),
+		// use it directly to preserve the concrete type for type switches.
+		if rw, ok := arg.(WithReaderWriterArgs); ok {
+			result[i] = rw
+		} else {
+			result[i] = readerWriterArg{readerArg{}, arg}
+		}
 	}
 	return result
 }


### PR DESCRIPTION
## Summary

- `UpcastReaderArgs`/`UpcastWriterArgs` now preserve `WithReaderWriterArgs` concrete types instead of wrapping them in `readerWriterArg`

## Problem

`UpcastReaderArgs` wraps every arg in `readerWriterArg{arg, writerArg{}}`. When the arg is already a `WithReaderWriterArgs` (e.g. `codegen.WithByteOrder`), this wrapping changes the concrete type from `withOptionByteOrder` to `readerWriterArg`.

`FieldCommons.ExtractByteOrder` does a type switch on `withOptionByteOrder` — which no longer matches the wrapped type. Result: `ExtractByteOrder` returns `nil`, and `SwitchParseByteOrderIfNecessary` skips the byte order switch entirely.

This means `codegen.WithByteOrder(binary.LittleEndian)` passed to `ReadSimpleField`/`WriteSimpleField` is **silently ignored** — fields are read/written with the buffer's default byte order.

## Fix

Check if the arg already implements `WithReaderWriterArgs` before wrapping:

```go
if rw, ok := arg.(WithReaderWriterArgs); ok {
    result[i] = rw
} else {
    result[i] = readerWriterArg{arg, writerArg{}}
}
```

## Affected protocols

All protocols using `byteOrder='LITTLE_ENDIAN'` at the type level in mspec: ADS, AB-ETH, OPC UA, IEC 60870-5-104.

## Test plan

- [x] All existing S7 parser/serializer tests pass (no regressions)
- [x] IEC 60870-5-104 parser/serializer tests pass (65/65 with both this fix and the getLengthInBits template fix from #2493)