### PR TITLE
plc4net: fix 'occured' -> 'occurred' typo in IPlcSubscriptionEventArgs doc

### DIFF
--- a/plc4net/api/api/messages/IPlcSubscriptionEventArgs.cs
+++ b/plc4net/api/api/messages/IPlcSubscriptionEventArgs.cs
@@ -28,7 +28,7 @@ namespace org.apache.plc4net.messages
     public interface IPlcSubscriptionEventArgs
     {
         /// <summary>
-        /// Timestamp of the event that occured
+        /// Timestamp of the event that occurred
         /// </summary>
         DateTime Timestamp { get; }
     }


### PR DESCRIPTION
The `Timestamp` property doxygen comment on `IPlcSubscriptionEventArgs` in `plc4net/api/api/messages/IPlcSubscriptionEventArgs.cs:31` read `Timestamp of the event that occured`. Doc-only C# change.