### PR TITLE
fix: 'occured' -> 'occurred' in IPlcSubscriptionEventArgs XML doc

### DIFF
--- a/plc4net/api/api/messages/IPlcSubscriptionEventArgs.cs
+++ b/plc4net/api/api/messages/IPlcSubscriptionEventArgs.cs
@@ -28,7 +28,7 @@ namespace org.apache.plc4net.messages
     public interface IPlcSubscriptionEventArgs
     {
         /// <summary>
-        /// Timestamp of the event that occured
+        /// Timestamp of the event that occurred
         /// </summary>
         DateTime Timestamp { get; }
     }


### PR DESCRIPTION
Trivial spelling fix on the `Timestamp` property XML-doc summary of `IPlcSubscriptionEventArgs` in the .NET API:

- `plc4net/api/api/messages/IPlcSubscriptionEventArgs.cs` — `Timestamp of the event that occurred`

No functional changes.