### PR TITLE
fix(plc4py/umas): resolve Python 3.12+ SyntaxWarnings in UmasTag

### DIFF
--- a/plc4py/plc4py/drivers/umas/UmasTag.py
+++ b/plc4py/plc4py/drivers/umas/UmasTag.py
@@ -27,7 +27,7 @@ from plc4py.spi.messages.PlcRequest import TagBuilder
 
 class UmasTag(PlcTag):
     _ADDRESS_PATTERN: str = (
-        "^(?P<tag>[%a-zA-Z_.0-9]+):?(?P<dataType>[A-Z_]*)(\[(?P<elementNb>[0-9]*)\])?"
+        r"^(?P<tag>[%a-zA-Z_.0-9]+):?(?P<dataType>[A-Z_]*)(\[(?P<elementNb>[0-9]*)\])?"
     )
 
     _ADDRESS_COMPILED: Pattern[AnyStr] = re.compile(_ADDRESS_PATTERN)
@@ -56,14 +56,14 @@ class UmasTag(PlcTag):
             int(matcher.group("elementNb"))
             if "elementNb" in matcher.groupdict()
             and matcher.group("elementNb") is not None
-            and len(matcher.group("elementNb")) is not 0
+            and len(matcher.group("elementNb")) != 0
             else 1
         )
         data_type = (
             matcher.group("dataType")
             if "dataType" in matcher.groupdict()
             and matcher.group("dataType") is not None
-            and len(matcher.group("dataType")) is not 0
+            and len(matcher.group("dataType")) != 0
             else None
         )
         return cls(tag_name, quantity, data_type)


### PR DESCRIPTION
## Summary

Fixes three `SyntaxWarning` messages emitted by Python 3.12+ in `plc4py/drivers/umas/UmasTag.py`:

1. Invalid escape sequence `\[` in the regex `_ADDRESS_PATTERN` — converted the string literal to a raw string.
2. Two occurrences of `len(...) is not 0` — replaced with `!= 0`. Comparing `int` with `is`/`is not` is unreliable (works only by CPython small-int caching) and the behavior is deprecated.

## Test plan
- [x] `pytest` passes (77 passed, 36 xfailed — same as before, now with 0 warnings)
- [x] No behavioral changes — both fixes are semantics-preserving