### PR TITLE
fix(plc4j/drivers/s7): stop S7HMuxImpl from leaking direct buffers (fixes #2248)

### DIFF
--- a/plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7/readwrite/protocol/S7HMuxImpl.java
+++ b/plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7/readwrite/protocol/S7HMuxImpl.java
@@ -19,6 +19,7 @@
 package org.apache.plc4x.java.s7.readwrite.protocol;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandler.Sharable;
@@ -130,9 +131,18 @@ public class S7HMuxImpl extends MessageToMessageCodec<ByteBuf, ByteBuf> implemen
     @Override
     protected void encode(ChannelHandlerContext ctx, ByteBuf outBB, List<Object> list) {
         if ((embedCtx == null) && (ctx.channel() instanceof EmbeddedChannel)) embedCtx = ctx;
-        if ((tcpChannel != null) && (embedCtx == ctx)) {
-            tcpChannel.writeAndFlush(outBB.copy());
+
+        if (ctx == embedCtx) {
+            if (tcpChannel != null) {
+                tcpChannel.writeAndFlush(outBB.copy());
+            }
+            // Netty requires at least one element in the out list, but nothing consumes
+            // the EmbeddedChannel's outbound queue. Use the EMPTY_BUFFER singleton instead
+            // of a copied ByteBuf to avoid leaking direct memory (see issue #2248).
+            list.add(Unpooled.EMPTY_BUFFER);
+            return;
         }
+
         list.add(outBB.copy());
     }
 

--- a/plc4j/drivers/s7/src/test/java/org/apache/plc4x/java/s7/readwrite/protocol/S7HMuxLeakTest.java
+++ b/plc4j/drivers/s7/src/test/java/org/apache/plc4x/java/s7/readwrite/protocol/S7HMuxLeakTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.plc4x.java.s7.readwrite.protocol;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.ResourceLeakDetector;
+import org.apache.plc4x.java.s7.readwrite.configuration.S7Configuration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression test for issue #2248.
+ *
+ * <p>S7HMuxImpl is installed in the EmbeddedChannel pipeline of S7HPlcConnection. Its encode()
+ * forwards each outbound message to the active TCP channel and propagates a sentinel downstream.
+ * Before the fix, encode() pushed a freshly-copied direct ByteBuf into the EmbeddedChannel's
+ * outbound queue: nothing in plc4j ever drained that queue, so every sent message leaked one
+ * direct buffer until DirectMemory was exhausted (OutOfMemoryError reported on long-running
+ * applications).
+ */
+public class S7HMuxLeakTest {
+
+    private static final int ITERATIONS = 2000;
+    private static final int PAYLOAD_BYTES = 256;
+
+    @Test
+    void embeddedOutboundQueueShouldNotAccumulateRealByteBufs() throws Exception {
+        ResourceLeakDetector.Level previous = ResourceLeakDetector.getLevel();
+        ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
+        try {
+            S7HMuxImpl mux = new S7HMuxImpl();
+            EmbeddedChannel embedded = new EmbeddedChannel(mux);
+            EmbeddedChannel tcp = new EmbeddedChannel();
+
+            mux.setEmbededhannel(embedded, new S7Configuration());
+            mux.setPrimaryChannel(tcp);
+
+            int forwardedToTcp = 0;
+            for (int i = 0; i < ITERATIONS; i++) {
+                ByteBuf out = PooledByteBufAllocator.DEFAULT.directBuffer(PAYLOAD_BYTES);
+                out.writeZero(PAYLOAD_BYTES);
+                embedded.writeOutbound(out);
+
+                Object msg;
+                while ((msg = tcp.readOutbound()) != null) {
+                    if (msg instanceof ByteBuf) {
+                        ((ByteBuf) msg).release();
+                        forwardedToTcp++;
+                    }
+                }
+            }
+
+            assertEquals(ITERATIONS, forwardedToTcp,
+                "every message written to the embedded channel must be forwarded once to the TCP channel");
+
+            int leakedBuffers = 0;
+            long leakedBytes = 0;
+            Object pending;
+            while ((pending = embedded.readOutbound()) != null) {
+                if (pending instanceof ByteBuf) {
+                    ByteBuf bb = (ByteBuf) pending;
+                    if (bb.capacity() > 0) {
+                        leakedBuffers++;
+                        leakedBytes += bb.capacity();
+                    }
+                    bb.release();
+                }
+            }
+            assertEquals(0, leakedBuffers,
+                "EmbeddedChannel outbound queue must not accumulate non-empty ByteBufs (leaked "
+                    + leakedBytes + " bytes across " + leakedBuffers + " buffers)");
+
+            embedded.finishAndReleaseAll();
+            tcp.finishAndReleaseAll();
+        } finally {
+            ResourceLeakDetector.setLevel(previous);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2248 — direct memory leak in the S7 driver that exhausts `MaxDirectMemorySize` on long-running applications (`OutOfMemoryError: Cannot reserve N bytes of direct buffer memory`).

`S7HMuxImpl` is installed on three pipelines (`EmbeddedChannel` + primary/secondary TCP), and its `encode()` was both forwarding the outbound message to the active TCP channel and pushing a freshly-copied direct `ByteBuf` into the `MessageToMessageCodec` out list. That second copy ends up in the `EmbeddedChannel`'s outbound queue, which nothing in plc4j ever drains. Result: every sent S7 message leaked one direct buffer, leading to the OOM described in the issue (1-2 weeks to reproduce in production).

The fix replaces the second copy with the `Unpooled.EMPTY_BUFFER` singleton — Netty still requires at least one element in the out list (otherwise `MessageToMessageEncoder` throws `EncoderException`), but the singleton allocates zero direct memory and its `release()` is a no-op. The forward to the active TCP channel (`outBB.copy()` + `writeAndFlush`) is unchanged, so wire behaviour is identical.

## Why `copy()` and not `retainedDuplicate()` for the TCP forward

`copy()` is kept on purpose: future contributors who modify `S7HMuxImpl` (e.g. add another consumer, change the failover logic, insert handlers in the TCP pipeline) shouldn't have to reason about shared refcounts and concurrent reads of the same backing memory. The cost of one `copy()` per S7 request is negligible compared to the safety margin.

## Regression test

`S7HMuxLeakTest` wires `S7HMuxImpl` exactly like `S7HPlcConnection` does (one `EmbeddedChannel` as the logical pipeline, one as the primary TCP channel), runs 2000 outbound writes and asserts:

1. each message is forwarded exactly once to the TCP side,
2. the `EmbeddedChannel`'s outbound queue does not accumulate non-empty `ByteBuf`s.

Verified locally: the test fails on the unfixed code with `expected: <0> but was: <2000>` (~512 KB of leaked buffers, exactly matching the synthetic payload), and passes with the fix.

## Test plan

- [x] `mvn -pl :plc4j-driver-s7 -P with-java test -Dtest=S7HMuxLeakTest` passes with the fix
- [x] Same test fails deterministically on the unfixed code path (confirms the regression test is meaningful)
- [ ] Long-running soak test against a real S7 PLC by users that hit the original issue