### PR TITLE
Add AGENTS.md and SECURITY.md for security-model discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Agent guidance
+
+This file is read by automated agents (security scanners, code analyzers,
+AI assistants) operating on this repository. It points them at the
+human-authored references they should consult before producing output.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md), which links to the project's
+threat model at [draft-THREAT-MODEL.md](./draft-THREAT-MODEL.md).
+
+Agents that scan this repository should consult `draft-THREAT-MODEL.md` for
+the project's in-scope / out-of-scope declarations, adversary model, security
+properties, and known non-findings before reporting issues. Apache PLC4X is a
+client library for industrial protocols (most of which are unauthenticated /
+unencrypted by design); the threat model is about which threats the library
+takes on versus which are left to the operator and the OT network.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities in Apache PLC4X privately to
+the Apache Security Team at <security@apache.org>, following the ASF process
+at <https://www.apache.org/security/>. Do not open public GitHub issues or
+pull requests for security reports.
+
+## Threat Model
+
+Apache PLC4X's security threat model — what is in and out of scope, the
+security properties the project provides and disclaims, the adversary model,
+the environmental assumptions, and how findings are triaged — is documented in
+[draft-THREAT-MODEL.md](./draft-THREAT-MODEL.md).
+
+PLC4X speaks industrial protocols (Modbus, S7, OPC-UA, ADS, EtherNet/IP, …),
+most of which are unauthenticated and unencrypted by design. The threat model
+covers the parser/driver trust boundary (responses from the device/wire) and
+draws the line on what is the operator's and the OT network's responsibility.


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct, reject, or discuss as needed.** Nothing here is a requirement.

This adds `AGENTS.md` + `SECURITY.md` so an automated scan agent (and any other tooling) can mechanically discover the project's security model via the conventional `AGENTS.md → SECURITY.md → model` chain. Both files only point at the existing in-repo `draft-THREAT-MODEL.md` — no model content is added or changed here.

Context: the ASF Security team is preparing PLC4X for an automated agentic security scan we're piloting. Such scans refuse to run unless the model is discoverable by that path (refusing upfront beats a noise-heavy run against a model the agent never found). The Security team has been in touch separately on the PMC's private list with the program details.

Two things the PMC may want to do as follow-ups (not needed for this PR):
- Rename `draft-THREAT-MODEL.md` → `THREAT_MODEL.md` once you're happy with it (then this PR's links update to match).
- Work through the `§14 Open questions for the maintainers` in that draft — those are the spots where we inferred a position and would like your confirmation.

Questions / pushback welcome — happy to adjust wording or move the section to fit the project's house style.
