### PR TITLE
Fixes #2266

### DIFF
--- a/plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7/S7CotpConnectionResponseDecodeTest.java
+++ b/plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7/S7CotpConnectionResponseDecodeTest.java
@@ -1,0 +1,432 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.plc4x.java.s7;
+
+import org.apache.plc4x.java.api.types.PlcResponseCode;
+import org.apache.plc4x.java.api.value.PlcValue;
+import org.apache.plc4x.java.s7.configuration.S7Configuration;
+import org.apache.plc4x.java.s7.optimizer.S7ReadChunk;
+import org.apache.plc4x.java.s7.readwrite.DataTransportErrorCode;
+import org.apache.plc4x.java.s7.readwrite.DataTransportSize;
+import org.apache.plc4x.java.s7.readwrite.MemoryArea;
+import org.apache.plc4x.java.s7.readwrite.S7AddressAny;
+import org.apache.plc4x.java.s7.readwrite.S7MessageResponseData;
+import org.apache.plc4x.java.s7.readwrite.S7ParameterReadVarResponse;
+import org.apache.plc4x.java.s7.readwrite.S7PayloadReadVarResponse;
+import org.apache.plc4x.java.s7.readwrite.S7VarPayloadDataItem;
+import org.apache.plc4x.java.s7.readwrite.S7VarRequestParameterItemAddress;
+import org.apache.plc4x.java.s7.readwrite.TransportSize;
+import org.apache.plc4x.java.s7.tag.S7Tag;
+import org.apache.plc4x.java.spi.drivers.messages.items.PlcResponseItem;
+import org.apache.plc4x.java.spi.transports.api.TransportInstance;
+import org.apache.plc4x.java.utils.auditlog.api.AuditLog;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for the read-response decoding in {@link S7CotpConnection}.
+ *
+ * <h2>Issue #2266 — NullPointerException / ArrayIndexOutOfBoundsException when reading
+ * an undefined DB variable</h2>
+ *
+ * <p>The S7 protocol returns a per-item {@code returnCode} for every variable in a
+ * multi-item read response.  When a DB variable does not exist, the PLC sets
+ * {@code returnCode = NOT_FOUND} (or {@code INVALID_ADDRESS}) and provides either a
+ * {@code null} or zero-length {@code data} array.
+ *
+ * <p><b>Before the fix</b> the code in {@code applyChunkResponse} read
+ * {@code byte[] data = item.getData()} without null-checking, then passed it straight
+ * into {@code decodeBindingInto}, which called {@code data.length} → NPE, or tried
+ * {@code System.arraycopy} with a non-zero offset into a zero-length array →
+ * {@code ArrayIndexOutOfBoundsException}.  Both exceptions were swallowed by the
+ * surrounding {@code try/catch} and silently reported as {@code INTERNAL_ERROR}.
+ *
+ * <p><b>After the fix</b>:
+ * <ul>
+ *   <li>A {@code null} data array is normalised to an empty array before any use.</li>
+ *   <li>A non-OK {@code returnCode} always reaches {@code mergeBindingFailure} and is
+ *       surfaced as {@code INVALID_ADDRESS} (for NOT_FOUND / INVALID_ADDRESS) without
+ *       ever calling {@code decodeBindingInto}.</li>
+ *   <li>An OK code with an empty payload is treated as a protocol inconsistency and
+ *       reported as {@code INVALID_ADDRESS} with a warning log instead of crashing.</li>
+ *   <li>A block-merged binding whose {@code payloadByteOffset} exceeds the actual data
+ *       length is reported as {@code INTERNAL_ERROR} instead of throwing AIOOBE.</li>
+ * </ul>
+ */
+class S7CotpConnectionResponseDecodeTest {
+
+    // -----------------------------------------------------------------------
+    // Test infrastructure
+    // -----------------------------------------------------------------------
+
+    /**
+     * Reflective handle for the private {@code applyChunkResponse(S7ReadChunk, S7Message, Map)}
+     * method.  We test it directly because it carries all the logic changed by the fix and
+     * can be exercised without a real network connection.
+     */
+    private Method applyChunkResponse;
+    private S7CotpConnection connection;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        S7Configuration cfg = new S7Configuration();
+        @SuppressWarnings("unchecked")
+        TransportInstance<?> transport = mock(TransportInstance.class);
+        AuditLog auditLog = mock(AuditLog.class);
+
+        connection = new S7CotpConnection(cfg, transport, auditLog);
+
+        applyChunkResponse = S7CotpConnection.class.getDeclaredMethod(
+            "applyChunkResponse",
+            S7ReadChunk.class,
+            org.apache.plc4x.java.s7.readwrite.S7Message.class,
+            Map.class);
+        applyChunkResponse.setAccessible(true);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Build a minimal {@link S7AddressAny} for a single INT at {@code DB<dbNum>.DBW<byteOff>}.
+     */
+    private static S7AddressAny intDbAddress(int dbNum, int byteOff) {
+        return new S7AddressAny(TransportSize.INT, 1, dbNum,
+            MemoryArea.DATA_BLOCKS, byteOff, (byte) 0);
+    }
+
+    /**
+     * Build a one-slot {@link S7ReadChunk} whose binding represents a single
+     * non-split, non-block-merged user tag.
+     *
+     * @param tagAddress S7 address string, e.g. {@code "%DB1.DBW0:INT"}
+     */
+    private static S7ReadChunk singleSlotChunk(String tagAddress) {
+        S7Tag tag = S7Tag.of(tagAddress);
+        S7VarRequestParameterItemAddress reqItem =
+            new S7VarRequestParameterItemAddress(
+                intDbAddress(tag.getBlockNumber(), tag.getByteOffset()));
+        S7ReadChunk.Binding binding =
+            new S7ReadChunk.Binding(tagAddress, tag, 0, 0, false);
+        S7ReadChunk.Slot slot =
+            new S7ReadChunk.Slot(reqItem, tag, Collections.singletonList(binding));
+        return new S7ReadChunk(Collections.singletonList(slot));
+    }
+
+    /**
+     * Wrap a variable-length list of payload items in a well-formed
+     * {@link S7MessageResponseData} with no PDU-level error.
+     */
+    private static S7MessageResponseData responseWith(S7VarPayloadDataItem... items) {
+        return new S7MessageResponseData(
+            0,
+            new S7ParameterReadVarResponse((short) items.length),
+            new S7PayloadReadVarResponse(List.of(items)),
+            (short) 0,   // errorClass = 0 (no PDU-level error)
+            (short) 0);  // errorCode  = 0
+    }
+
+    /**
+     * Invoke {@code applyChunkResponse} and return the result map.
+     * Any checked exceptions are re-thrown as unchecked so tests stay readable.
+     */
+    private Map<String, PlcResponseItem<PlcValue>> invoke(
+            S7ReadChunk chunk,
+            org.apache.plc4x.java.s7.readwrite.S7Message response) {
+        Map<String, PlcResponseItem<PlcValue>> out = new LinkedHashMap<>();
+        try {
+            applyChunkResponse.invoke(connection, chunk, response, out);
+        } catch (java.lang.reflect.InvocationTargetException ite) {
+            Throwable cause = ite.getCause();
+            throw (cause instanceof RuntimeException re) ? re
+                : new RuntimeException("applyChunkResponse threw unexpected checked exception", cause);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Reflection failed", e);
+        }
+        return out;
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests — Issue #2266 regression cases
+    // -----------------------------------------------------------------------
+
+    /**
+     * <b>Primary regression: NOT_FOUND with null data</b>
+     *
+     * <p>Some PLC firmware variants return {@code returnCode = NOT_FOUND} with a
+     * genuinely {@code null} data reference.  Before the fix this caused a
+     * {@link NullPointerException} deep in {@code decodeBindingInto}.  After the
+     * fix the NPE is impossible and the caller sees {@code INVALID_ADDRESS}.
+     */
+    @Test
+    void notFoundWithNullData_returnsInvalidAddress_noNPE() {
+        S7VarPayloadDataItem item = new S7VarPayloadDataItem(
+            DataTransportErrorCode.NOT_FOUND,
+            DataTransportSize.BYTE_WORD_DWORD,
+            null  // <-- the null that triggered the NPE
+        );
+
+        S7ReadChunk chunk = singleSlotChunk("%DB1.DBW0:INT");
+
+        // Must not throw — before the fix this threw NullPointerException.
+        Map<String, PlcResponseItem<PlcValue>> result = invoke(chunk, responseWith(item));
+
+        PlcResponseItem<PlcValue> tagResult = result.get("%DB1.DBW0:INT");
+        assertNotNull(tagResult, "Result entry must be present for the requested tag");
+        assertEquals(
+            PlcResponseCode.INVALID_ADDRESS,
+            tagResult.getResponseCode(),
+            "NOT_FOUND from PLC must surface as INVALID_ADDRESS, not as an NPE or INTERNAL_ERROR");
+        assertNull(tagResult.getValue(), "No value expected for a missing DB variable");
+    }
+
+    /**
+     * <b>Secondary regression: INVALID_ADDRESS with zero-length data</b>
+     *
+     * <p>When the PLC returns {@code returnCode = INVALID_ADDRESS} and an empty
+     * byte array, the old code's {@code data.length} didn't NPE but the block-merged
+     * path could hit AIOOBE.  The fix guards both paths.
+     */
+    @Test
+    void invalidAddressWithEmptyData_returnsInvalidAddress_noException() {
+        S7VarPayloadDataItem item = new S7VarPayloadDataItem(
+            DataTransportErrorCode.INVALID_ADDRESS,
+            DataTransportSize.BYTE_WORD_DWORD,
+            new byte[0]  // zero-length
+        );
+
+        S7ReadChunk chunk = singleSlotChunk("%DB1.DBW4:INT");
+
+        Map<String, PlcResponseItem<PlcValue>> result = invoke(chunk, responseWith(item));
+
+        PlcResponseItem<PlcValue> tagResult = result.get("%DB1.DBW4:INT");
+        assertNotNull(tagResult);
+        assertEquals(PlcResponseCode.INVALID_ADDRESS, tagResult.getResponseCode());
+        assertNull(tagResult.getValue());
+    }
+
+    /**
+     * <b>OK return-code but zero-length payload (protocol inconsistency)</b>
+     *
+     * <p>Certain edge-case PLC firmware bugs produce {@code returnCode = OK} with
+     * an empty data array.  Before the fix, attempting {@code data.length} checks
+     * in {@code decodeBindingInto} led to AIOOBE; the surrounding catch masked it
+     * as {@code INTERNAL_ERROR}.  After the fix the early guard in
+     * {@code applyChunkResponse} catches this before entering
+     * {@code decodeBindingInto} and maps it to {@code INVALID_ADDRESS}.
+     */
+    @Test
+    void okWithEmptyData_returnsInvalidAddress_noException() {
+        S7VarPayloadDataItem item = new S7VarPayloadDataItem(
+            DataTransportErrorCode.OK,
+            DataTransportSize.BYTE_WORD_DWORD,
+            new byte[0]  // protocol inconsistency: OK but no bytes
+        );
+
+        S7ReadChunk chunk = singleSlotChunk("%DB2.DBW0:INT");
+
+        Map<String, PlcResponseItem<PlcValue>> result = invoke(chunk, responseWith(item));
+
+        PlcResponseItem<PlcValue> tagResult = result.get("%DB2.DBW0:INT");
+        assertNotNull(tagResult);
+        assertEquals(
+            PlcResponseCode.INVALID_ADDRESS,
+            tagResult.getResponseCode(),
+            "OK + empty data must map to INVALID_ADDRESS (protocol inconsistency), not INTERNAL_ERROR");
+    }
+
+    /**
+     * <b>Mixed response: first tag undefined (NOT_FOUND + null), second tag valid</b>
+     *
+     * <p>Before the fix, the NPE on the first item also prevented the second
+     * (perfectly valid) tag from being decoded.  After the fix each slot is
+     * processed independently: the missing tag gets {@code INVALID_ADDRESS} and
+     * the valid tag is decoded correctly.
+     */
+    @Test
+    void mixedResponse_undefinedFirstTag_definedSecondTag_processedIndependently() {
+        // Slot 1: undefined DB variable → null data with NOT_FOUND
+        S7Tag tag1 = S7Tag.of("%DB1.DBW0:INT");
+        S7VarRequestParameterItemAddress req1 =
+            new S7VarRequestParameterItemAddress(intDbAddress(1, 0));
+        S7ReadChunk.Binding b1 = new S7ReadChunk.Binding("%DB1.DBW0:INT", tag1, 0, 0, false);
+        S7ReadChunk.Slot slot1 = new S7ReadChunk.Slot(req1, tag1, List.of(b1));
+
+        S7VarPayloadDataItem item1 = new S7VarPayloadDataItem(
+            DataTransportErrorCode.NOT_FOUND,
+            DataTransportSize.BYTE_WORD_DWORD,
+            null);
+
+        // Slot 2: valid DB variable — INT value 42 = 0x002A
+        S7Tag tag2 = S7Tag.of("%DB1.DBW2:INT");
+        S7VarRequestParameterItemAddress req2 =
+            new S7VarRequestParameterItemAddress(intDbAddress(1, 2));
+        S7ReadChunk.Binding b2 = new S7ReadChunk.Binding("%DB1.DBW2:INT", tag2, 0, 0, false);
+        S7ReadChunk.Slot slot2 = new S7ReadChunk.Slot(req2, tag2, List.of(b2));
+
+        S7VarPayloadDataItem item2 = new S7VarPayloadDataItem(
+            DataTransportErrorCode.OK,
+            DataTransportSize.BYTE_WORD_DWORD,
+            new byte[]{0x00, 0x2A}  // INT 42
+        );
+
+        S7ReadChunk chunk = new S7ReadChunk(List.of(slot1, slot2));
+        S7MessageResponseData response = responseWith(item1, item2);
+
+        // Must not throw
+        Map<String, PlcResponseItem<PlcValue>> result = invoke(chunk, response);
+
+        // Undefined tag → INVALID_ADDRESS
+        PlcResponseItem<PlcValue> res1 = result.get("%DB1.DBW0:INT");
+        assertNotNull(res1, "Undefined tag must have a result entry");
+        assertEquals(PlcResponseCode.INVALID_ADDRESS, res1.getResponseCode(),
+            "Undefined DB variable must be reported as INVALID_ADDRESS");
+        assertNull(res1.getValue());
+
+        // Valid tag → OK with decoded value 42
+        PlcResponseItem<PlcValue> res2 = result.get("%DB1.DBW2:INT");
+        assertNotNull(res2, "Valid tag must have a result entry");
+        assertEquals(PlcResponseCode.OK, res2.getResponseCode(),
+            "Valid DB variable must decode successfully");
+        assertNotNull(res2.getValue(), "Valid tag must have a non-null decoded value");
+        assertEquals(42, res2.getValue().getInteger(),
+            "INT bytes 0x002A must decode to 42");
+    }
+
+    /**
+     * <b>Block-merged binding: payload truncated (AIOOBE regression)</b>
+     *
+     * <p>The {@link org.apache.plc4x.java.s7.optimizer.S7BlockReadOptimizer} can
+     * merge adjacent DB variables into a single protocol slot to reduce round trips.
+     * In that case a slot may have multiple bindings, each at a different
+     * {@code payloadByteOffset}.  If the PLC response is shorter than expected (e.g.
+     * because one of the merged variables is undefined), the old code threw
+     * {@code ArrayIndexOutOfBoundsException} in
+     * {@code System.arraycopy(data, b.payloadByteOffset(), ...)}.  After the fix
+     * the short-data guard in {@code decodeBindingInto} catches this and reports
+     * {@code INTERNAL_ERROR} instead of crashing.
+     */
+    @Test
+    void blockMergedSlot_payloadTooShortForSecondBinding_returnsInternalError_noException() {
+        // Simulate a block-read slot that covers two INTs at byte-offsets 0 and 2
+        // (4 bytes total), but the PLC only returns 2 bytes.
+
+        // The "block" tag covers bytes 0-3 as a BYTE array of length 4.
+        S7Tag blockTag = new S7Tag(
+            TransportSize.BYTE,
+            MemoryArea.DATA_BLOCKS,
+            1, 0, (byte) 0, 4  // DB1.DBB0, 4 bytes
+        );
+        S7VarRequestParameterItemAddress reqItem =
+            new S7VarRequestParameterItemAddress(
+                new S7AddressAny(TransportSize.BYTE, 4, 1, MemoryArea.DATA_BLOCKS, 0, (byte) 0));
+
+        // Two user tags merged into this slot, at offsets 0 and 2 within the block.
+        S7Tag userTag1 = S7Tag.of("%DB1.DBW0:INT");
+        S7Tag userTag2 = S7Tag.of("%DB1.DBW2:INT");
+
+        S7ReadChunk.Binding bind1 = new S7ReadChunk.Binding("first",  userTag1, 0, 0, false);
+        S7ReadChunk.Binding bind2 = new S7ReadChunk.Binding("second", userTag2, 2, 0, false);
+
+        S7ReadChunk.Slot slot = new S7ReadChunk.Slot(reqItem, blockTag, List.of(bind1, bind2));
+        S7ReadChunk chunk = new S7ReadChunk(List.of(slot));
+
+        // PLC only returns 2 bytes — offset 2 for "second" is out of range.
+        S7VarPayloadDataItem item = new S7VarPayloadDataItem(
+            DataTransportErrorCode.OK,
+            DataTransportSize.BYTE_WORD_DWORD,
+            new byte[]{0x01, 0x00}  // only 2 bytes, not 4
+        );
+
+        S7MessageResponseData response = responseWith(item);
+
+        // Must not throw — before the fix this threw ArrayIndexOutOfBoundsException
+        // which was swallowed and converted to INTERNAL_ERROR (still a bad user experience).
+        Map<String, PlcResponseItem<PlcValue>> result = invoke(chunk, response);
+
+        // "second" binding at offset 2 is beyond the 2-byte payload.
+        PlcResponseItem<PlcValue> res2 = result.get("second");
+        assertNotNull(res2, "'second' must have a result entry even if the payload is too short");
+        assertEquals(
+            PlcResponseCode.INTERNAL_ERROR,
+            res2.getResponseCode(),
+            "Out-of-range block binding must be INTERNAL_ERROR, not a thrown exception");
+    }
+
+    /**
+     * <b>Happy-path smoke test</b>
+     *
+     * <p>Confirms that the fix did not regress the normal success path: a single
+     * INT read returning two valid bytes decodes to the correct integer value.
+     */
+    @Test
+    void happyPath_validIntResponse_decodesCorrectly() {
+        // INT value 1234 = 0x04D2
+        S7VarPayloadDataItem item = new S7VarPayloadDataItem(
+            DataTransportErrorCode.OK,
+            DataTransportSize.BYTE_WORD_DWORD,
+            new byte[]{0x04, (byte) 0xD2}
+        );
+
+        S7ReadChunk chunk = singleSlotChunk("%DB1.DBW0:INT");
+
+        Map<String, PlcResponseItem<PlcValue>> result = invoke(chunk, responseWith(item));
+
+        PlcResponseItem<PlcValue> tagResult = result.get("%DB1.DBW0:INT");
+        assertNotNull(tagResult, "Result must be present for the requested tag");
+        assertEquals(PlcResponseCode.OK, tagResult.getResponseCode());
+        assertNotNull(tagResult.getValue(), "A valid INT response must carry a decoded value");
+        assertEquals(1234, tagResult.getValue().getInteger(),
+            "Bytes 0x04D2 must decode to integer 1234");
+    }
+
+    /**
+     * <b>NOT_FOUND with empty (not null) data array</b>
+     *
+     * <p>A second firmware variant that produces zero-length data alongside a
+     * non-OK return code — distinct from the null-data case.
+     */
+    @Test
+    void notFoundWithEmptyData_returnsInvalidAddress_noException() {
+        S7VarPayloadDataItem item = new S7VarPayloadDataItem(
+            DataTransportErrorCode.NOT_FOUND,
+            DataTransportSize.BYTE_WORD_DWORD,
+            new byte[0]
+        );
+
+        S7ReadChunk chunk = singleSlotChunk("%DB3.DBW0:INT");
+
+        Map<String, PlcResponseItem<PlcValue>> result = invoke(chunk, responseWith(item));
+
+        PlcResponseItem<PlcValue> tagResult = result.get("%DB3.DBW0:INT");
+        assertNotNull(tagResult);
+        assertEquals(PlcResponseCode.INVALID_ADDRESS, tagResult.getResponseCode());
+        assertNull(tagResult.getValue());
+    }
+}

--- a/plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7/S7HCotpConnection.java
+++ b/plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7/S7HCotpConnection.java
@@ -18,141 +18,122 @@
  */
 package org.apache.plc4x.java.s7;
 
+import org.apache.plc4x.java.api.types.PlcSubscriptionType;
+import org.apache.plc4x.java.s7.readwrite.*;
+
+import org.apache.plc4x.java.spi.buffers.api.WithOption;
+import org.apache.plc4x.java.spi.buffers.bytebased.WithByteBasedOption;
 import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
+import org.apache.plc4x.java.api.exceptions.PlcProtocolException;
 import org.apache.plc4x.java.api.exceptions.PlcRuntimeException;
-import org.apache.plc4x.java.api.messages.PlcBrowseRequest;
+import org.apache.plc4x.java.api.messages.*;
+import org.apache.plc4x.java.api.types.ConnectionStateChangeType;
+import org.apache.plc4x.java.api.types.PlcResponseCode;
+import org.apache.plc4x.java.api.value.PlcValue;
+import org.apache.plc4x.java.s7.configuration.S7Configuration;
+import org.apache.plc4x.java.s7.context.S7DriverContext;
+import org.apache.plc4x.java.s7.optimizer.S7BlockReadOptimizer;
+import org.apache.plc4x.java.s7.optimizer.S7ReadChunk;
+import org.apache.plc4x.java.s7.optimizer.S7WriteChunk;
+import org.apache.plc4x.java.s7.tag.S7StringFixedLengthTag;
+import org.apache.plc4x.java.s7.tag.S7Tag;
+import org.apache.plc4x.java.s7.tag.S7PlcTagHandler;
+import org.apache.plc4x.java.s7.tag.S7AlarmTag;
+import org.apache.plc4x.java.s7.userdata.S7AlarmQueryHandle;
+import org.apache.plc4x.java.s7.userdata.S7AlarmSubscriptionHandle;
+import org.apache.plc4x.java.s7.userdata.S7AlarmSubscriptionService;
+import org.apache.plc4x.java.s7.userdata.S7BrowseService;
+import org.apache.plc4x.java.s7.userdata.S7CyclicSubscriptionHandle;
+import org.apache.plc4x.java.s7.userdata.S7CyclicSubscriptionService;
+import org.apache.plc4x.java.s7.userdata.S7SzlService;
+import org.apache.plc4x.java.s7.userdata.S7UserDataPushDispatcher;
+import org.apache.plc4x.java.api.messages.PlcBrowseItem;
 import org.apache.plc4x.java.api.messages.PlcBrowseRequestInterceptor;
-import org.apache.plc4x.java.api.messages.PlcBrowseResponse;
-import org.apache.plc4x.java.api.messages.PlcPingRequest;
-import org.apache.plc4x.java.api.messages.PlcPingResponse;
-import org.apache.plc4x.java.api.messages.PlcReadRequest;
-import org.apache.plc4x.java.api.messages.PlcReadResponse;
+import org.apache.plc4x.java.api.model.PlcQuery;
+import org.apache.plc4x.java.spi.drivers.messages.DefaultPlcBrowseResponse;
+import org.apache.plc4x.java.s7.readwrite.ControllerType;
+import org.apache.plc4x.java.s7.readwrite.SzlId;
+import org.apache.plc4x.java.api.metadata.PlcConnectionMetadata;
+import org.apache.plc4x.java.spi.buffers.api.exceptions.BufferException;
+import org.apache.plc4x.java.spi.buffers.bytebased.ReadBufferByteBased;
+import org.apache.plc4x.java.spi.buffers.bytebased.WriteBufferByteBased;
+import org.apache.plc4x.java.spi.drivers.ConnectionBase;
+import org.apache.plc4x.java.spi.drivers.exceptions.MessageCodecException;
+import org.apache.plc4x.java.spi.drivers.messages.DefaultPlcPingResponse;
+import org.apache.plc4x.java.spi.drivers.messages.DefaultPlcReadResponse;
+import org.apache.plc4x.java.spi.drivers.messages.DefaultPlcWriteResponse;
 import org.apache.plc4x.java.api.messages.PlcSubscriptionEvent;
 import org.apache.plc4x.java.api.messages.PlcSubscriptionRequest;
 import org.apache.plc4x.java.api.messages.PlcSubscriptionResponse;
 import org.apache.plc4x.java.api.messages.PlcUnsubscriptionRequest;
 import org.apache.plc4x.java.api.messages.PlcUnsubscriptionResponse;
-import org.apache.plc4x.java.api.messages.PlcWriteRequest;
-import org.apache.plc4x.java.api.messages.PlcWriteResponse;
-import org.apache.plc4x.java.api.metadata.PlcConnectionMetadata;
 import org.apache.plc4x.java.api.model.PlcConsumerRegistration;
 import org.apache.plc4x.java.api.model.PlcSubscriptionHandle;
-import org.apache.plc4x.java.s7.configuration.S7Configuration;
-import org.apache.plc4x.java.spi.drivers.ConnectionBase;
+import org.apache.plc4x.java.api.model.PlcSubscriptionTag;
+import org.apache.plc4x.java.api.model.PlcTag;
+import org.apache.plc4x.java.spi.drivers.messages.DefaultPlcConsumerRegistration;
+import org.apache.plc4x.java.spi.drivers.messages.DefaultPlcSubscriptionEvent;
+import org.apache.plc4x.java.spi.drivers.messages.DefaultPlcSubscriptionResponse;
+import org.apache.plc4x.java.spi.drivers.messages.DefaultPlcUnsubscriptionResponse;
+import org.apache.plc4x.java.spi.drivers.messages.items.DefaultPlcResponseItem;
+import org.apache.plc4x.java.spi.drivers.messages.items.PlcResponseItem;
 import org.apache.plc4x.java.spi.drivers.tags.PlcTagHandler;
 import org.apache.plc4x.java.spi.transports.api.TransportInstance;
 import org.apache.plc4x.java.spi.values.DefaultPlcValueHandler;
+import org.apache.plc4x.java.spi.values.PlcBOOL;
+import org.apache.plc4x.java.spi.values.PlcList;
+import org.apache.plc4x.java.spi.values.PlcRawByteArray;
 import org.apache.plc4x.java.spi.values.PlcValueHandler;
 import org.apache.plc4x.java.utils.auditlog.api.AuditLog;
+import org.apache.plc4x.java.utils.auditlog.api.AuditLogEventType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
+import java.nio.ByteBuffer;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 /**
- * Highly-available S7 connection wrapping two underlying {@link S7CotpConnection} instances —
- * one to a primary host and one to a secondary host. Routes every operation to whichever
- * inner connection is currently "active", and transparently fails over to the other when
- * the active one drops.
+ * S7 connection over the COTP transport. The COTP transport handles TPKT framing and the
+ * COTP CR/CC handshake; this connection only deals with raw S7 PDUs (the inner payload of
+ * COTP-DT packets, starting with magic 0x32).
  *
- * <h3>Use cases</h3>
- * <ul>
- *   <li><b>S7-400H redundant CPU pair</b> — two CPUs hot-syncing on separate chassis. The
- *       wrapper talks to both, switches when one dies. The classic SPI1 use case.</li>
- *   <li><b>Network-level redundancy on a single CPU</b> — e.g. an S7-300 with both an
- *       on-board PN port and a CP 343-1 module exposed at separate IPs. Same data on
- *       both interfaces, but the connection survives a cable / NIC / switch failure.</li>
- * </ul>
- *
- * <h3>Behaviour</h3>
- * <ul>
- *   <li>{@code connect()} attempts both inner connections in parallel; succeeds if at
- *       least one comes up. Active defaults to the first that connected, with a primary
- *       preference.</li>
- *   <li>Each request is dispatched to the active inner. If the operation fails because
- *       the inner's transport is no longer connected, the wrapper swaps to the other
- *       inner and retries once.</li>
- *   <li>A scheduled heartbeat task periodically reconnects dropped inners and switches
- *       back to the primary when it recovers (configurable preference).</li>
- *   <li>{@code close()} closes both inners. The heartbeat is stopped first.</li>
- * </ul>
- *
- * <h3>Subscriptions and failover</h3>
- * Push subscriptions (alarm, cyclic) are PLC-side state keyed to a TCP connection — when
- * a TCP drops, the PLC drops its corresponding subscription state. This wrapper does
- * <em>not</em> currently re-subscribe automatically on failover. Callers wanting transparent
- * subscription failover should listen for connection-lost events and re-subscribe in
- * application code; the wrapper itself only ensures reads/writes/pings keep working.
+ * <p>The S7 SetupCommunication exchange happens in {@link #onConnect()} once the transport is
+ * already open. After that, read/write requests use a tpdu-reference-keyed pendingRequests map
+ * for response correlation.
  */
-public class S7HCotpConnection extends ConnectionBase<S7Configuration> {
+public class S7CotpConnection extends ConnectionBase<S7Configuration> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(S7HCotpConnection.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(S7CotpConnection.class);
 
-    /**
-     * Heartbeat tick interval and wrapper-level failover timeout, both in milliseconds.
-     * Read from {@link S7Configuration#getHaHeartbeatInterval()} /
-     * {@link S7Configuration#getHaFailoverTimeout()} at connection construction so each
-     * connection can be tuned independently via URL params {@code ?ha-heartbeat-interval=}
-     * and {@code ?ha-failover-timeout=}.
-     */
-    private final long heartbeatIntervalMs;
-    private final long failoverTimeoutMs;
+    private final AtomicInteger tpduGenerator = new AtomicInteger(10);
+    private final Map<Integer, CompletableFuture<S7Message>> pendingRequests = new ConcurrentHashMap<>();
+    private final S7DriverContext driverContext;
+    private final S7BlockReadOptimizer optimizer = new S7BlockReadOptimizer();
+    private final S7UserDataPushDispatcher pushDispatcher = new S7UserDataPushDispatcher();
+    private final Map<DefaultPlcConsumerRegistration, Consumer<PlcSubscriptionEvent>> consumers = new ConcurrentHashMap<>();
+    private final Set<S7AlarmSubscriptionHandle> alarmHandles = ConcurrentHashMap.newKeySet();
+    private final List<java.io.Closeable> alarmDispatcherHooks = new ArrayList<>();
+    private final Map<Short, List<S7CyclicSubscriptionHandle>> cyclicHandlesByJob = new ConcurrentHashMap<>();
+    private final List<java.io.Closeable> cyclicDispatcherHooks = new ArrayList<>();
 
-    /**
-     * Factories that build fresh inner connections from the configured URL. Used both for
-     * the initial connect and to <em>rebuild</em> an inner whose transport has died — the
-     * underlying TCP socket can't be reopened once the kernel has closed it (cable pull,
-     * peer reset), so the heartbeat task drops the corpse and constructs a new one.
-     */
-    private final Supplier<S7CotpConnection> primaryFactory;
-    private final Supplier<S7CotpConnection> secondaryFactory;
-    /** Current inner connections. Replaced by the heartbeat when an inner is rebuilt. */
-    private final AtomicReference<S7CotpConnection> primaryRef = new AtomicReference<>();
-    private final AtomicReference<S7CotpConnection> secondaryRef = new AtomicReference<>();
-    /** Whichever ref ({@link #primaryRef} or {@link #secondaryRef}) is currently active. */
-    private final AtomicReference<AtomicReference<S7CotpConnection>> activeSlot = new AtomicReference<>();
-    /**
-     * Inners we've recently given up on (after a wrapper-level timeout or operation
-     * failure) and that the heartbeat task should re-validate before we trust them again.
-     * Keyed by slot reference (primary/secondary), not by the inner instance, so it
-     * survives rebuilds.
-     */
-    private final java.util.Set<AtomicReference<S7CotpConnection>> stale = java.util.concurrent.ConcurrentHashMap.newKeySet();
-    private final ScheduledExecutorService heartbeat;
+    private S7CotpMessageCodec messageCodec;
 
-    public S7HCotpConnection(S7Configuration configuration,
-                             TransportInstance<?> primaryTransport,
-                             AuditLog auditLog,
-                             Supplier<S7CotpConnection> primaryFactory,
-                             Supplier<S7CotpConnection> secondaryFactory) {
-        // The base class wants a transport. We never actually use it (request lifecycle is
-        // delegated to inner connections), but ConnectionBase needs a non-null reference.
-        super(configuration, primaryTransport, auditLog);
-        this.heartbeatIntervalMs = configuration.getHaHeartbeatInterval();
-        this.failoverTimeoutMs = configuration.getHaFailoverTimeout();
-        this.primaryFactory = primaryFactory;
-        this.secondaryFactory = secondaryFactory;
-        this.primaryRef.set(primaryFactory.get());
-        this.secondaryRef.set(secondaryFactory.get());
-        this.heartbeat = Executors.newSingleThreadScheduledExecutor(r -> {
-            Thread t = new Thread(r, "S7H-Heartbeat");
-            t.setDaemon(true);
-            return t;
-        });
+    public S7CotpConnection(S7Configuration configuration, TransportInstance<?> transportInstance, AuditLog auditLog) {
+        super(configuration, transportInstance, auditLog);
+        this.driverContext = new S7DriverContext();
+        this.driverContext.applyConfiguration(configuration);
     }
 
     @Override
     protected PlcTagHandler getTagHandler() {
-        // Reuse the same tag handler as the standard S7 connection — both inners use it.
-        return new org.apache.plc4x.java.s7.tag.S7PlcTagHandler();
+        return new S7PlcTagHandler();
     }
 
     @Override
@@ -160,315 +141,1178 @@ public class S7HCotpConnection extends ConnectionBase<S7Configuration> {
         return new DefaultPlcValueHandler();
     }
 
+    /** Public accessor needed by {@link S7HCotpConnection} when wrapping two inner connections. */
     @Override
-    @SuppressWarnings("resource")
-    public boolean isConnected() {
-        return current(primaryRef).isConnected() || current(secondaryRef).isConnected();
+    public S7Configuration getConfiguration() {
+        return super.getConfiguration();
     }
 
     @Override
-    @SuppressWarnings("resource")
+    protected int getMaxConcurrentRequests() {
+        // ConnectionBase invokes this from its constructor — before our fields are
+        // initialized — so we read straight from the configuration. The negotiated
+        // max-amq-callee from SetupCommunication doesn't change throttle behavior since
+        // we serialize at the codec level via tpduRef anyway.
+        return Math.max(1, getConfiguration().getMaxAmqCallee());
+    }
+
+    @Override
+    public boolean isConnected() {
+        return messageCodec != null && messageCodec.isOpen();
+    }
+
+    /**
+     * Per-device capability flags. Read/Write var are always supported. Browse and
+     * Subscribe both ride S7Comm UserData services, so they're enabled iff the SZL
+     * probe at connect time succeeded.
+     */
+    @Override
     public PlcConnectionMetadata getMetadata() {
-        AtomicReference<S7CotpConnection> slot = activeSlot.get();
-        S7CotpConnection a = slot != null ? slot.get() : current(primaryRef);
-        PlcConnectionMetadata inner = a.getMetadata();
-        // Subscriptions (alarm push, cyclic services) are PLC-side state per TCP connection.
-        // The wrapper can't transparently re-establish them on the survivor when an inner
-        // dies, so we hide the capability rather than let callers set up subscriptions
-        // that silently break on failover. Application code that wants subscriptions on a
-        // dual-path setup should connect to one host directly, listen for connection-lost
-        // events, and re-subscribe in app code.
+        boolean userData = driverContext.isUserDataServicesSupported();
         return new PlcConnectionMetadata() {
-            @Override public boolean isReadSupported()      { return inner.isReadSupported(); }
-            @Override public boolean isWriteSupported()     { return inner.isWriteSupported(); }
-            @Override public boolean isSubscribeSupported() { return false; }
-            @Override public boolean isBrowseSupported()    { return inner.isBrowseSupported(); }
+            @Override public boolean isReadSupported()      { return true; }
+            @Override public boolean isWriteSupported()     { return true; }
+            @Override public boolean isSubscribeSupported() { return userData; }
+            @Override public boolean isBrowseSupported()    { return userData; }
         };
     }
 
     @Override
     protected void onConnect() throws PlcConnectionException {
-        // Connect both inners in parallel; succeed if at least one comes up. Failure of a
-        // single inner is logged but doesn't abort the wrapper — the user might be testing
-        // with one of the IPs unreachable on purpose.
-        CompletableFuture<Boolean> primaryFuture = connectAsync(current(primaryRef), "primary");
-        CompletableFuture<Boolean> secondaryFuture = connectAsync(current(secondaryRef), "secondary");
-        CompletableFuture.allOf(primaryFuture, secondaryFuture).join();
-
-        boolean primaryUp = primaryFuture.getNow(false);
-        boolean secondaryUp = secondaryFuture.getNow(false);
-        if (!primaryUp && !secondaryUp) {
-            throw new PlcConnectionException(
-                "Both primary and secondary S7H endpoints failed to connect");
-        }
-        activeSlot.set(primaryUp ? primaryRef : secondaryRef);
-        LOGGER.info("S7H connection up — primary={}, secondary={}, active={}",
-            primaryUp ? "OK" : "DOWN", secondaryUp ? "OK" : "DOWN", primaryUp ? "primary" : "secondary");
-
-        heartbeat.scheduleAtFixedRate(this::supervise, heartbeatIntervalMs, heartbeatIntervalMs, TimeUnit.MILLISECONDS);
-    }
-
-    @Override
-    public void close() throws Exception {
-        heartbeat.shutdownNow();
-        Exception primaryEx = closeQuietly(current(primaryRef), "primary");
-        Exception secondaryEx = closeQuietly(current(secondaryRef), "secondary");
-        super.close();
-        if (primaryEx != null) throw primaryEx;
-        if (secondaryEx != null) throw secondaryEx;
-    }
-
-    // ------------------------------------------------------------------------------------
-    // Operation delegation. Each onX hook routes to the active inner; on transport-level
-    // failure we swap and retry once.
-    // ------------------------------------------------------------------------------------
-
-    @Override
-    protected CompletableFuture<PlcReadResponse> onRead(PlcReadRequest readRequest) {
-        return withFailover(c -> c.read(readRequest));
-    }
-
-    @Override
-    protected CompletableFuture<PlcWriteResponse> onWrite(PlcWriteRequest writeRequest) {
-        return withFailover(c -> c.write(writeRequest));
-    }
-
-    @Override
-    protected CompletableFuture<PlcPingResponse> onPing(PlcPingRequest pingRequest) {
-        return withFailover(c -> c.ping().thenApply(r -> (PlcPingResponse) r));
-    }
-
-    @Override
-    protected CompletableFuture<PlcBrowseResponse> onBrowse(PlcBrowseRequest browseRequest) {
-        return withFailover(c -> c.browse(browseRequest));
-    }
-
-    @Override
-    protected CompletableFuture<PlcBrowseResponse> onBrowseWithInterceptor(PlcBrowseRequest browseRequest, PlcBrowseRequestInterceptor interceptor) {
-        return withFailover(c -> c.browseWithInterceptor(browseRequest, interceptor));
-    }
-
-    @Override
-    protected CompletableFuture<PlcSubscriptionResponse> onSubscribe(PlcSubscriptionRequest subscriptionRequest) {
-        // Refuse subscriptions outright on the dual-path connection. PLC-side subscription
-        // state is keyed to a TCP connection, so a transparent fail-over would silently
-        // drop alarm pushes and cyclic streams — better to surface the limitation now via
-        // an UNSUPPORTED response than to let the app discover it after a real failover.
-        // Apps that want subscriptions in a dual-path setup should connect to one host
-        // directly, listen for connection-lost events, and re-subscribe in app code.
-        return CompletableFuture.failedFuture(new PlcRuntimeException(
-            "Subscribe not supported on S7H dual-path connections — see S7HCotpConnection "
-            + "javadoc. Connect to a single host instead."));
-    }
-
-    @Override
-    protected CompletableFuture<PlcUnsubscriptionResponse> onUnsubscribe(PlcUnsubscriptionRequest unsubscriptionRequest) {
-        return CompletableFuture.failedFuture(new PlcRuntimeException(
-            "Unsubscribe not supported on S7H dual-path connections"));
-    }
-
-    @Override
-    protected PlcConsumerRegistration onRegisterConsumer(Consumer<PlcSubscriptionEvent> consumer, Collection<PlcSubscriptionHandle> handles) {
-        throw new PlcRuntimeException("Register consumer not supported on S7H dual-path connections");
-    }
-
-    @Override
-    protected void onUnregisterConsumer(PlcConsumerRegistration registration) {
-        // No-op: nothing was registered. Throwing here would be hostile if app code calls
-        // unregister defensively in cleanup paths.
-    }
-
-    // ------------------------------------------------------------------------------------
-    // Internals
-    // ------------------------------------------------------------------------------------
-
-    /** Read the inner currently held in a slot. Slots get replaced when an inner is rebuilt. */
-    private static S7CotpConnection current(AtomicReference<S7CotpConnection> slot) {
-        return slot.get();
-    }
-
-    /** Pick a slot to try next: prefer active if it's not stale; else fall back to alt. */
-    @SuppressWarnings("resource")
-    private AtomicReference<S7CotpConnection> chooseSlot() {
-        AtomicReference<S7CotpConnection> a = activeSlot.get();
-        if (a != null && !stale.contains(a) && current(a).isConnected()) {
-            return a;
-        }
-        AtomicReference<S7CotpConnection> alt = (a == primaryRef) ? secondaryRef : primaryRef;
-        if (alt != null && !stale.contains(alt) && current(alt).isConnected()) {
-            activeSlot.set(alt);
-            return alt;
-        }
-        // Both stale or disconnected — last resort: use whichever still claims connected.
-        if (a != null && current(a).isConnected()) return a;
-        if (alt != null && current(alt).isConnected()) return alt;
-        return null;
-    }
-
-    /**
-     * Invoke {@code op} on the active inner with a wrapper-level timeout
-     * ({@link #failoverTimeoutMs}). If the inner doesn't respond in that window — or
-     * fails outright — mark its slot stale and retry once on the other slot. The stale
-     * flag gets cleared by the heartbeat task once it successfully validates (ping or
-     * full rebuild), so a transient drop heals without staying out of rotation forever.
-     */
-    private <R> CompletableFuture<R> withFailover(Function<S7CotpConnection, CompletableFuture<R>> op) {
-        AtomicReference<S7CotpConnection> targetSlot = chooseSlot();
-        if (targetSlot == null) {
-            return CompletableFuture.failedFuture(
-                new PlcRuntimeException("Neither primary nor secondary S7H endpoint is reachable"));
-        }
-        S7CotpConnection target = current(targetSlot);
-        return tryWithTimeout(target, op).handle((r, t) -> {
-            if (t == null) {
-                return CompletableFuture.completedFuture(r);
-            }
-            stale.add(targetSlot);
-            AtomicReference<S7CotpConnection> altSlot = (targetSlot == primaryRef) ? secondaryRef : primaryRef;
-            S7CotpConnection alt = current(altSlot);
-            if (!stale.contains(altSlot) && alt.isConnected()) {
-                LOGGER.info("S7H operation failed on {} ({}), retrying on {}",
-                    label(targetSlot), describe(t), label(altSlot));
-                activeSlot.set(altSlot);
-                return tryWithTimeout(alt, op);
-            }
-            LOGGER.info("S7H operation failed on {} and no healthy alternate available: {}",
-                label(targetSlot), describe(t));
-            return CompletableFuture.<R>failedFuture(t);
-        }).thenCompose(Function.identity());
-    }
-
-    private <R> CompletableFuture<R> tryWithTimeout(S7CotpConnection inner,
-                                                    Function<S7CotpConnection, CompletableFuture<R>> op) {
-        return op.apply(inner).orTimeout(failoverTimeoutMs, TimeUnit.MILLISECONDS);
-    }
-
-    private String label(AtomicReference<S7CotpConnection> slot) {
-        return slot == primaryRef ? "primary" : "secondary";
-    }
-
-    /**
-     * Pretty-print a Throwable for log lines: prefer the message; fall back to the simple
-     * class name when {@link Throwable#getMessage()} is null (e.g. {@link
-     * java.util.concurrent.TimeoutException} routinely is).
-     */
-    private static String describe(Throwable t) {
-        if (t == null) return "null";
-        String msg = t.getMessage();
-        return msg != null ? msg : t.getClass().getSimpleName();
-    }
-
-    /**
-     * Heartbeat tick — for each slot, validate its inner by pinging the PLC; if the ping
-     * fails or the underlying transport has died, <em>rebuild</em> the inner from its
-     * factory and reconnect. Successfully-validated inners have their stale flag cleared
-     * so {@link #withFailover} considers them again. Finally, if primary is healthy and
-     * we're not on it, switch active back.
-     *
-     * <p>Rebuild-on-failure is necessary because the SPI3 transport doesn't reopen after
-     * the kernel closes the socket — the only way back is a fresh transport instance.
-     */
-    @SuppressWarnings("resource")
-    private void supervise() {
-        try {
-            validate(primaryRef, primaryFactory, "primary");
-            validate(secondaryRef, secondaryFactory, "secondary");
-            // Prefer primary when it's healthy.
-            if (!stale.contains(primaryRef) && current(primaryRef).isConnected()
-                && activeSlot.get() != primaryRef) {
-                LOGGER.info("S7H heartbeat: primary recovered, switching active back to primary");
-                activeSlot.set(primaryRef);
-            }
-        } catch (Throwable t) {
-            LOGGER.debug("S7H heartbeat tick failed", t);
-        }
-    }
-
-    /**
-     * Probe a slot's inner by pinging the PLC and rebuild it if needed. Logs the
-     * <em>transitions</em>:
-     * <ul>
-     *   <li>healthy → broken: one INFO {@code "X disrupted"} line.</li>
-     *   <li>broken → healthy: one INFO {@code "X recovered"} line.</li>
-     *   <li>still broken / still healthy: silent at INFO (DEBUG details available).</li>
-     * </ul>
-     * The {@link #stale} set doubles as the "is it currently broken?" predicate, so first
-     * insert/remove on each transition gives us clean once-per-edge logging.
-     */
-    private void validate(AtomicReference<S7CotpConnection> slot,
-                          Supplier<S7CotpConnection> factory, String label) {
-        S7CotpConnection inner = slot.get();
-        String reason;
-        boolean nowHealthy;
-        if (!inner.isConnected()) {
-            reason = "transport dead";
-            nowHealthy = rebuild(slot, factory, label);
-        } else {
+        messageCodec = new S7CotpMessageCodec(transportInstance, this::handleIncomingMessage);
+        startReceiving(() -> {
             try {
-                inner.ping().get(failoverTimeoutMs, TimeUnit.MILLISECONDS);
-                reason = null;
-                nowHealthy = true;
-            } catch (Exception e) {
-                reason = "ping failed: " + describe(e);
-                nowHealthy = rebuild(slot, factory, label);
+                messageCodec.processIncomingData();
+            } catch (MessageCodecException e) {
+                LOGGER.error("Error processing incoming S7 data", e);
             }
-        }
+        });
 
-        if (nowHealthy) {
-            if (stale.remove(slot)) {
-                LOGGER.info("S7H heartbeat: {} recovered", label);
-            }
-        } else if (stale.add(slot)) {
-            LOGGER.info("S7H heartbeat: {} disrupted ({}), rebuild attempt failed", label, reason);
-        } else {
-            LOGGER.debug("S7H heartbeat: {} still down ({}), rebuild attempt failed", label, reason);
-        }
-    }
-
-    /**
-     * Replace the inner held in {@code slot} with a fresh one built by {@code factory},
-     * closing the old one first. Returns {@code true} iff the new inner connected.
-     */
-    private boolean rebuild(AtomicReference<S7CotpConnection> slot,
-                            Supplier<S7CotpConnection> factory, String label) {
-        S7CotpConnection old = slot.get();
-        try { old.close(); } catch (Exception ignored) { /* best-effort */ }
-        S7CotpConnection fresh;
         try {
-            fresh = factory.get();
+            doSetupCommunication().get(driverContext.getReadTimeout() * 2L, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
-            LOGGER.debug("S7H heartbeat: factory for {} threw: {}", label, e.getMessage());
-            return false;
-        }
-        try {
-            fresh.connect();
-        } catch (Exception e) {
-            LOGGER.debug("S7H heartbeat: reconnect of fresh {} failed: {}", label, e.getMessage());
-            return false;
-        }
-        slot.set(fresh);
-        return true;
-    }
-
-    private static CompletableFuture<Boolean> connectAsync(S7CotpConnection inner, String label) {
-        return CompletableFuture.supplyAsync(() -> {
             try {
-                inner.connect();
-                return true;
-            } catch (Exception e) {
-                LOGGER.debug("S7H {} connect failed: {}", label, e.getMessage());
-                return false;
+                close();
+            } catch (Exception ignored) {
+                // ignore
+            }
+            throw new PlcConnectionException("Error during S7 SetupCommunication", e);
+        }
+
+        // SZL capability probe. A successful response gives us the article number → controller
+        // type and tells us the device speaks S7Comm UserData services (browse, alarms, cyclic
+        // subscriptions). On failure (LOGO et al.), keep the connection — just mark UserData
+        // unavailable so getMetadata() reflects reality and the higher layers don't try.
+        probeUserDataCapability();
+
+        LOGGER.info("S7 connection established (pdu-size={}, max-amq-caller={}, max-amq-callee={}, "
+                + "controllerType={}, userdata-services={})",
+            driverContext.getPduSize(), driverContext.getMaxAmqCaller(), driverContext.getMaxAmqCallee(),
+            driverContext.getControllerType(), driverContext.isUserDataServicesSupported());
+        if (auditLog.isEnabled()) {
+            auditLog.write(AuditLogEventType.CONNECT, "S7 connection established");
+        }
+        fireConnectionStateChanged(ConnectionStateChangeType.CONNECTED, null);
+    }
+
+    private void probeUserDataCapability() {
+        boolean userConfigured = driverContext.getControllerType() != ControllerType.ANY;
+        // Try the modern COMPONENT_IDENTIFICATION SZL first — works on S7-1200/1500 and is
+        // tolerated by S7-300/400. Fall back to the legacy MODULE_IDENTIFICATION SZL if the
+        // first attempt errors out or doesn't yield a recognisable article number. Either
+        // success counts as "device speaks UserData services".
+        S7SzlService.ProbeResult result = trySzlProbe(S7SzlService.COMPONENT_IDENTIFICATION, 0x0001);
+        if (result == null) {
+            result = trySzlProbe(S7SzlService.MODULE_IDENTIFICATION, 0x0000);
+        }
+        if (result != null) {
+            driverContext.setArticleNumber(result.articleNumber());
+            if (!userConfigured) {
+                driverContext.setControllerType(result.controllerType());
+            }
+            driverContext.setUserDataServicesSupported(true);
+            LOGGER.info("SZL probe ok: article='{}', controllerType={}",
+                result.articleNumber(), driverContext.getControllerType());
+        } else {
+            // Common on LOGO and other non-SZL devices. Connection stays usable for plain
+            // Read/Write var; advanced services just stay disabled.
+            driverContext.setUserDataServicesSupported(false);
+            LOGGER.info("SZL probe yielded no usable identification; S7Comm UserData services "
+                + "disabled for this device");
+        }
+    }
+
+    private S7SzlService.ProbeResult trySzlProbe(SzlId szlId, int szlIndex) {
+        try {
+            S7Message request = S7SzlService.buildRequest(getTpduId(), szlId, szlIndex);
+            S7Message response = sendInternal(request).get(driverContext.getReadTimeout(), TimeUnit.MILLISECONDS);
+            return S7SzlService.parseProbeResponse(response);
+        } catch (Exception e) {
+            LOGGER.debug("SZL {}/{} probe failed: {}", szlId.getSublistList(), szlIndex, e.getMessage());
+            return null;
+        }
+    }
+
+    private CompletableFuture<Void> doSetupCommunication() {
+        S7ParameterSetupCommunication setup = new S7ParameterSetupCommunication(
+            driverContext.getMaxAmqCaller(), driverContext.getMaxAmqCallee(), driverContext.getPduSize());
+        S7Message request = new S7MessageRequest(getTpduId(), setup, null);
+        return sendInternal(request).thenAccept(response -> {
+            if (response.getParameter() instanceof S7ParameterSetupCommunication setupResp) {
+                driverContext.setMaxAmqCaller(setupResp.getMaxAmqCaller());
+                driverContext.setMaxAmqCallee(setupResp.getMaxAmqCallee());
+                driverContext.setPduSize(setupResp.getPduLength());
+                setMaxConcurrentRequests(driverContext.getMaxAmqCallee());
+            } else {
+                throw new PlcRuntimeException("Unexpected response to S7 SetupCommunication: " +
+                    (response.getParameter() == null ? "null" : response.getParameter().getClass().getSimpleName()));
             }
         });
     }
 
-    private static Exception closeQuietly(S7CotpConnection inner, String label) {
+    @Override
+    public void close() throws Exception {
+        // Drain active subscriptions cleanly before tearing the codec down: tell the PLC to
+        // stop pushing alarms / cyclic data so we don't leak server-side state and so the
+        // cancel requests actually make the wire (without this drain they race the TCP FIN
+        // and get dropped by the codec shutdown).
+        drainActiveSubscriptions();
+        stopReceiving();
+        if (messageCodec != null) {
+            messageCodec.close();
+        }
+        pendingRequests.values().forEach(f ->
+            f.completeExceptionally(new PlcRuntimeException("Connection closed")));
+        pendingRequests.clear();
+        super.close();
+        fireConnectionStateChanged(ConnectionStateChangeType.DISCONNECTED, null);
+    }
+
+    private void drainActiveSubscriptions() {
+        List<CompletableFuture<Void>> drains = new ArrayList<>();
+        if (!alarmHandles.isEmpty()) {
+            alarmHandles.clear();
+            drains.add(deactivateAlarmSubscription());
+        }
+        if (!cyclicHandlesByJob.isEmpty()) {
+            Set<Short> jobs = new java.util.HashSet<>(cyclicHandlesByJob.keySet());
+            cyclicHandlesByJob.clear();
+            drains.add(cancelCyclicJobs(jobs));
+        }
+        if (drains.isEmpty()) {
+            return;
+        }
         try {
-            inner.close();
-            return null;
-        } catch (Exception e) {
-            LOGGER.debug("S7H close on {} failed: {}", label, e.getMessage());
-            return e;
+            // Bounded wait — if a cancel times out, we still close cleanly afterwards.
+            CompletableFuture.allOf(drains.toArray(CompletableFuture[]::new))
+                .get(driverContext.getReadTimeout(), TimeUnit.MILLISECONDS);
+        } catch (Exception ignored) {
+            // Best-effort drain; continue with close regardless.
         }
     }
+
+    @Override
+    protected void onTransportDisconnected(Throwable cause) {
+        super.onTransportDisconnected(cause);
+        fireConnectionStateChanged(ConnectionStateChangeType.CONNECTION_LOST,
+            cause != null ? cause.getMessage() : "Connection closed by remote");
+        PlcRuntimeException ex = new PlcRuntimeException(
+            cause != null ? "Connection lost: " + cause.getMessage() : "Connection closed by remote", cause);
+        pendingRequests.values().forEach(f -> f.completeExceptionally(ex));
+        pendingRequests.clear();
+    }
+
+    private void handleIncomingMessage(S7Message message) {
+        int tpduRef = message.getTpduReference();
+        if (auditLog.isEnabled()) {
+            auditLog.write(AuditLogEventType.INCOMING_MESSAGE, "Received S7 response, tpduRef=" + tpduRef);
+        }
+        CompletableFuture<S7Message> future = pendingRequests.remove(tpduRef);
+        if (future != null) {
+            future.complete(message);
+            return;
+        }
+        // No pending request — could be an unsolicited UserData push (cyclic data, alarms,
+        // mode-change). Route through the dispatcher; only complain if nobody owned it.
+        if (pushDispatcher.dispatch(message)) {
+            return;
+        }
+        LOGGER.warn("Received S7 response for unknown tpduRef {}", tpduRef);
+    }
+
+    /** Visible for tests / future service wiring. */
+    public S7UserDataPushDispatcher getPushDispatcher() {
+        return pushDispatcher;
+    }
+
+    private CompletableFuture<S7Message> sendInternal(S7Message request) {
+        int tpduRef = request.getTpduReference();
+        CompletableFuture<S7Message> future = new CompletableFuture<>();
+        pendingRequests.put(tpduRef, future);
+        try {
+            if (auditLog.isEnabled()) {
+                auditLog.write(AuditLogEventType.OUTGOING_MESSAGE, "Sending S7 request, tpduRef=" + tpduRef);
+            }
+            messageCodec.send(request);
+        } catch (MessageCodecException e) {
+            pendingRequests.remove(tpduRef);
+            future.completeExceptionally(new PlcRuntimeException("Failed to send S7 request", e));
+            return future;
+        }
+        long timeout = Math.max(1000, driverContext.getReadTimeout());
+        future.orTimeout(timeout, TimeUnit.MILLISECONDS).whenComplete((r, e) -> {
+            if (e instanceof TimeoutException) {
+                pendingRequests.remove(tpduRef);
+            }
+        });
+        return future;
+    }
+
+    private int getTpduId() {
+        int id = tpduGenerator.getAndIncrement();
+        if (id >= 0xFFFE) {
+            tpduGenerator.set(10);
+        }
+        return id & 0xFFFF;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Ping
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    protected CompletableFuture<PlcPingResponse> onPing(PlcPingRequest pingRequest) {
+        // No dedicated ping in S7. Issue a tiny zero-tag SetupCommunication-equivalent: a
+        // bare ReadVar with one M0 byte. If we can build a request and get any response we're alive.
+        S7Address addr = new S7AddressAny(TransportSize.BYTE, 1, 0, MemoryArea.FLAGS_MARKERS, 0, (byte) 0);
+        S7VarRequestParameterItemAddress item = new S7VarRequestParameterItemAddress(addr);
+        S7Message request = new S7MessageRequest(getTpduId(),
+            new S7ParameterReadVarRequest(Collections.singletonList(item)), null);
+        return executeThrottled(() -> sendInternal(request))
+            .handle((resp, err) -> new DefaultPlcPingResponse(pingRequest,
+                err != null ? PlcResponseCode.INTERNAL_ERROR : PlcResponseCode.OK));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Read
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    protected CompletableFuture<PlcReadResponse> onRead(PlcReadRequest readRequest) {
+        // Validate tag types up front so we fail fast.
+        for (String tagName : readRequest.getTagNames()) {
+            org.apache.plc4x.java.api.model.PlcTag tag = readRequest.getTag(tagName);
+            if (!(tag instanceof S7Tag)) {
+                return CompletableFuture.failedFuture(
+                    new PlcProtocolException("Unsupported tag type " + (tag == null ? "null" : tag.getClass().getName())));
+            }
+        }
+
+        List<S7ReadChunk> chunks;
+        try {
+            chunks = optimizer.splitReadRequest(readRequest, driverContext);
+        } catch (PlcRuntimeException e) {
+            // A tag the optimizer can't fit at all is reported per-tag rather than aborting the whole request.
+            Map<String, PlcResponseItem<PlcValue>> values = new LinkedHashMap<>();
+            for (String t : readRequest.getTagNames()) {
+                values.put(t, new DefaultPlcResponseItem<>(PlcResponseCode.INVALID_DATA, null));
+            }
+            return CompletableFuture.completedFuture(new DefaultPlcReadResponse(readRequest, values));
+        }
+        if (chunks.isEmpty()) {
+            return CompletableFuture.completedFuture(
+                new DefaultPlcReadResponse(readRequest, new LinkedHashMap<>()));
+        }
+
+        // For each chunk, send one S7 read message; combine the per-chunk decoders into the final response.
+        Map<String, PlcResponseItem<PlcValue>> finalValues = new LinkedHashMap<>();
+        // Pre-seed in original request order so output order is deterministic.
+        for (String t : readRequest.getTagNames()) {
+            finalValues.put(t, null);
+        }
+        CompletableFuture<Void> chain = CompletableFuture.completedFuture(null);
+        for (S7ReadChunk chunk : chunks) {
+            chain = chain.thenCompose(v -> sendReadChunk(chunk, finalValues));
+        }
+        return chain.thenApply(v -> {
+            // Replace any still-null entries (shouldn't happen) with INTERNAL_ERROR.
+            for (Map.Entry<String, PlcResponseItem<PlcValue>> e : finalValues.entrySet()) {
+                if (e.getValue() == null) {
+                    e.setValue(new DefaultPlcResponseItem<>(PlcResponseCode.INTERNAL_ERROR, null));
+                }
+            }
+            return new DefaultPlcReadResponse(readRequest, finalValues);
+        });
+    }
+
+    private CompletableFuture<Void> sendReadChunk(S7ReadChunk chunk, Map<String, PlcResponseItem<PlcValue>> out) {
+        List<S7VarRequestParameterItem> items = new ArrayList<>(chunk.slots().size());
+        for (S7ReadChunk.Slot slot : chunk.slots()) {
+            items.add(slot.requestItem());
+        }
+        S7Message request = new S7MessageRequest(getTpduId(),
+            new S7ParameterReadVarRequest(items), null);
+        return executeThrottled(() -> sendInternal(request))
+            .handle((response, error) -> {
+                if (error != null) {
+                    for (S7ReadChunk.Slot slot : chunk.slots()) {
+                        for (S7ReadChunk.Binding b : slot.bindings()) {
+                            mergeBindingFailure(out, b, PlcResponseCode.INTERNAL_ERROR);
+                        }
+                    }
+                    return null;
+                }
+                applyChunkResponse(chunk, response, out);
+                return null;
+            });
+    }
+
+    private void applyChunkResponse(S7ReadChunk chunk, S7Message responseMessage,
+                                    Map<String, PlcResponseItem<PlcValue>> out) {
+        short errorClass = 0, errorCode = 0;
+        if (responseMessage instanceof S7MessageResponseData md) {
+            errorClass = md.getErrorClass();
+            errorCode = md.getErrorCode();
+        } else if (responseMessage instanceof S7MessageResponse mr) {
+            errorClass = mr.getErrorClass();
+            errorCode = mr.getErrorCode();
+        }
+        if (errorClass != 0 || errorCode != 0) {
+            PlcResponseCode code = mapPlcErrorCode(errorClass, errorCode);
+            for (S7ReadChunk.Slot slot : chunk.slots()) {
+                for (S7ReadChunk.Binding b : slot.bindings()) {
+                    mergeBindingFailure(out, b, code);
+                }
+            }
+            return;
+        }
+        if (!(responseMessage.getPayload() instanceof S7PayloadReadVarResponse payload)) {
+            for (S7ReadChunk.Slot slot : chunk.slots()) {
+                for (S7ReadChunk.Binding b : slot.bindings()) {
+                    mergeBindingFailure(out, b, PlcResponseCode.INTERNAL_ERROR);
+                }
+            }
+            return;
+        }
+        List<S7VarPayloadDataItem> payloadItems = payload.getItems();
+        for (int i = 0; i < chunk.slots().size(); i++) {
+            S7ReadChunk.Slot slot = chunk.slots().get(i);
+            if (i >= payloadItems.size()) {
+                for (S7ReadChunk.Binding b : slot.bindings()) {
+                    mergeBindingFailure(out, b, PlcResponseCode.INTERNAL_ERROR);
+                }
+                continue;
+            }
+            S7VarPayloadDataItem item = payloadItems.get(i);
+            PlcResponseCode code = mapDataTransportError(item.getReturnCode());
+            // item.getData() can be null or zero-length when the PLC returns a non-OK
+            // returnCode (e.g. NOT_FOUND / INVALID_ADDRESS for an undefined DB variable).
+            // Guard here so that decodeBindingInto never receives a null byte array,
+            // which would cause a NullPointerException or ArrayIndexOutOfBoundsException.
+            byte[] data = item.getData();
+            if (data == null) {
+                data = new byte[0];
+            }
+            final byte[] safeData = data;
+            for (S7ReadChunk.Binding b : slot.bindings()) {
+                if (code != PlcResponseCode.OK) {
+                    mergeBindingFailure(out, b, code);
+                    continue;
+                }
+                // A non-null but zero-length payload for an OK code is also a protocol
+                // inconsistency; surface it as INVALID_ADDRESS rather than crashing.
+                if (safeData.length == 0) {
+                    LOGGER.warn("Tag '{}': PLC returned OK but payload is empty — treating as INVALID_ADDRESS",
+                        b.tagName());
+                    mergeBindingFailure(out, b, PlcResponseCode.INVALID_ADDRESS);
+                    continue;
+                }
+                try {
+                    decodeBindingInto(out, b, safeData);
+                } catch (Exception e) {
+                    LOGGER.warn("Error decoding tag {}", b.tagName(), e);
+                    mergeBindingFailure(out, b, PlcResponseCode.INTERNAL_ERROR);
+                }
+            }
+        }
+    }
+
+    private void decodeBindingInto(Map<String, PlcResponseItem<PlcValue>> out, S7ReadChunk.Binding b, byte[] data)
+        throws BufferException {
+        S7Tag originalTag = b.originalTag();
+        if (b.isSplitFragment()) {
+            // Split-array reassembly: we expect a BYTE array in PlcRawByteArray for now.
+            int elementSize = originalTag.getDataType().getSizeInBytes();
+            int byteOffsetInOriginal = b.elementOffset() * elementSize;
+            PlcResponseItem<PlcValue> existing = out.get(b.tagName());
+            byte[] full;
+            if (existing != null && existing.getValue() instanceof PlcRawByteArray prba) {
+                full = prba.getRaw();
+            } else {
+                full = new byte[originalTag.getNumberOfElements() * elementSize];
+                out.put(b.tagName(), new DefaultPlcResponseItem<>(PlcResponseCode.OK, new PlcRawByteArray(full)));
+            }
+            int copyLen = Math.min(data.length, full.length - byteOffsetInOriginal);
+            System.arraycopy(data, 0, full, byteOffsetInOriginal, copyLen);
+            return;
+        }
+        // Slice block-merged payload.
+        int sliceLen = sliceLengthFor(originalTag);
+        // Guard: if the payload is shorter than the binding's offset, the PLC returned
+        // less data than the block-optimizer requested — this can happen when the block
+        // spans an undefined variable (the PLC truncates the response).  Surface as
+        // INTERNAL_ERROR rather than throwing ArrayIndexOutOfBoundsException.
+        if (b.payloadByteOffset() >= data.length) {
+            LOGGER.warn("Tag '{}': block-read payload too short (offset={}, dataLen={}) — treating as INTERNAL_ERROR",
+                b.tagName(), b.payloadByteOffset(), data.length);
+            mergeBindingFailure(out, b, PlcResponseCode.INTERNAL_ERROR);
+            return;
+        }
+        byte[] slice;
+        if (b.payloadByteOffset() == 0 && data.length == sliceLen) {
+            slice = data;
+        } else {
+            slice = new byte[sliceLen];
+            System.arraycopy(data, b.payloadByteOffset(), slice, 0,
+                Math.min(sliceLen, data.length - b.payloadByteOffset()));
+        }
+        PlcValue value = parsePlcValue(originalTag, slice);
+        out.put(b.tagName(), new DefaultPlcResponseItem<>(PlcResponseCode.OK, value));
+    }
+
+    private static int sliceLengthFor(S7Tag tag) {
+        if (tag.getDataType() == TransportSize.BOOL) {
+            return Math.max(1, (tag.getNumberOfElements() + 7) / 8);
+        }
+        if (tag instanceof S7StringFixedLengthTag fixed) {
+            int bytesPerChar = fixed.getDataType() == TransportSize.WSTRING ? 2 : 1;
+            return tag.getNumberOfElements() * (fixed.getStringLength() + 2) * bytesPerChar;
+        }
+        return tag.getNumberOfElements() * tag.getDataType().getSizeInBytes();
+    }
+
+    private static void mergeBindingFailure(Map<String, PlcResponseItem<PlcValue>> out,
+                                            S7ReadChunk.Binding b, PlcResponseCode code) {
+        // For split fragments a single failure poisons the whole tag; that matches the
+        // legacy behaviour and avoids returning a half-filled byte array as success.
+        out.put(b.tagName(), new DefaultPlcResponseItem<>(code, null));
+    }
+
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Write
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    protected CompletableFuture<PlcWriteResponse> onWrite(PlcWriteRequest writeRequest) {
+        for (String tagName : writeRequest.getTagNames()) {
+            org.apache.plc4x.java.api.model.PlcTag tag = writeRequest.getTag(tagName);
+            if (!(tag instanceof S7Tag)) {
+                return CompletableFuture.failedFuture(new PlcProtocolException(
+                    "Unsupported tag type " + (tag == null ? "null" : tag.getClass().getName())));
+            }
+        }
+
+        List<S7WriteChunk> chunks;
+        try {
+            chunks = optimizer.splitWriteRequest(writeRequest, driverContext);
+        } catch (PlcRuntimeException e) {
+            Map<String, PlcResponseCode> codes = new LinkedHashMap<>();
+            for (String t : writeRequest.getTagNames()) codes.put(t, PlcResponseCode.INVALID_DATA);
+            return CompletableFuture.completedFuture(new DefaultPlcWriteResponse(writeRequest, codes));
+        }
+        if (chunks.isEmpty()) {
+            return CompletableFuture.completedFuture(new DefaultPlcWriteResponse(writeRequest, new LinkedHashMap<>()));
+        }
+
+        Map<String, PlcResponseCode> finalCodes = new LinkedHashMap<>();
+        for (String t : writeRequest.getTagNames()) {
+            finalCodes.put(t, null);
+        }
+        CompletableFuture<Void> chain = CompletableFuture.completedFuture(null);
+        for (S7WriteChunk chunk : chunks) {
+            chain = chain.thenCompose(v -> sendWriteChunk(chunk, writeRequest, finalCodes));
+        }
+        return chain.thenApply(v -> {
+            for (Map.Entry<String, PlcResponseCode> e : finalCodes.entrySet()) {
+                if (e.getValue() == null) e.setValue(PlcResponseCode.INTERNAL_ERROR);
+            }
+            return new DefaultPlcWriteResponse(writeRequest, finalCodes);
+        });
+    }
+
+    private CompletableFuture<Void> sendWriteChunk(S7WriteChunk chunk, PlcWriteRequest writeRequest,
+                                                   Map<String, PlcResponseCode> out) {
+        List<S7VarRequestParameterItem> parameterItems = new ArrayList<>(chunk.tagNames().size());
+        List<S7VarPayloadDataItem> payloadItems = new ArrayList<>(chunk.tagNames().size());
+        for (String tagName : chunk.tagNames()) {
+            S7Tag s7Tag = (S7Tag) writeRequest.getTag(tagName);
+            parameterItems.add(new S7VarRequestParameterItemAddress(encodeS7Address(s7Tag)));
+            S7VarPayloadDataItem item = serializePlcValue(s7Tag, writeRequest.getPlcValue(tagName));
+            if (item == null) {
+                out.put(tagName, PlcResponseCode.INVALID_DATA);
+                // Skip this tag in the actual request — would otherwise corrupt the layout.
+                continue;
+            }
+            payloadItems.add(item);
+        }
+        if (parameterItems.size() != payloadItems.size()) {
+            // At least one serialization failed; remaining tags can still go through.
+            // Re-build the parallel lists trimmed to successful ones.
+            parameterItems = new ArrayList<>();
+            payloadItems = new ArrayList<>();
+            for (String tagName : chunk.tagNames()) {
+                if (out.get(tagName) == PlcResponseCode.INVALID_DATA) continue;
+                S7Tag s7Tag = (S7Tag) writeRequest.getTag(tagName);
+                parameterItems.add(new S7VarRequestParameterItemAddress(encodeS7Address(s7Tag)));
+                payloadItems.add(serializePlcValue(s7Tag, writeRequest.getPlcValue(tagName)));
+            }
+        }
+        if (parameterItems.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        S7Message request = new S7MessageRequest(getTpduId(),
+            new S7ParameterWriteVarRequest(parameterItems),
+            new S7PayloadWriteVarRequest(payloadItems));
+        final List<String> sentTagNames = new ArrayList<>();
+        for (String tagName : chunk.tagNames()) {
+            if (out.get(tagName) != PlcResponseCode.INVALID_DATA) {
+                sentTagNames.add(tagName);
+            }
+        }
+        return executeThrottled(() -> sendInternal(request))
+            .handle((response, error) -> {
+                if (error != null) {
+                    for (String n : sentTagNames) out.put(n, PlcResponseCode.INTERNAL_ERROR);
+                    return null;
+                }
+                short errorClass = 0, errorCode = 0;
+                if (response instanceof S7MessageResponseData md) {
+                    errorClass = md.getErrorClass();
+                    errorCode = md.getErrorCode();
+                } else if (response instanceof S7MessageResponse mr) {
+                    errorClass = mr.getErrorClass();
+                    errorCode = mr.getErrorCode();
+                }
+                if (errorClass != 0 || errorCode != 0) {
+                    PlcResponseCode code = mapPlcErrorCode(errorClass, errorCode);
+                    for (String n : sentTagNames) out.put(n, code);
+                    return null;
+                }
+                if (!(response.getPayload() instanceof S7PayloadWriteVarResponse payload)) {
+                    for (String n : sentTagNames) out.put(n, PlcResponseCode.INTERNAL_ERROR);
+                    return null;
+                }
+                List<S7VarPayloadStatusItem> items = payload.getItems();
+                for (int i = 0; i < sentTagNames.size(); i++) {
+                    String n = sentTagNames.get(i);
+                    if (i >= items.size()) {
+                        out.put(n, PlcResponseCode.INTERNAL_ERROR);
+                    } else {
+                        out.put(n, mapDataTransportError(items.get(i).getReturnCode()));
+                    }
+                }
+                return null;
+            });
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Encoding/decoding helpers (ported from s7-light S7ProtocolLogic)
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    private S7Address encodeS7Address(S7Tag s7Tag) {
+        TransportSize transportSize = s7Tag.getDataType();
+        int numElements = s7Tag.getNumberOfElements();
+        if (transportSize == TransportSize.STRING) {
+            transportSize = TransportSize.CHAR;
+            int stringLength = (s7Tag instanceof S7StringFixedLengthTag f) ? f.getStringLength() : 254;
+            numElements = numElements * (stringLength + 2);
+        } else if (transportSize == TransportSize.WSTRING) {
+            transportSize = TransportSize.CHAR;
+            int stringLength = (s7Tag instanceof S7StringFixedLengthTag f) ? f.getStringLength() : 254;
+            numElements = numElements * (stringLength + 2) * 2;
+        } else if ((transportSize == TransportSize.BOOL) && (s7Tag.getNumberOfElements() > 1)) {
+            numElements = (s7Tag.getNumberOfElements() + 7) / 8;
+            transportSize = TransportSize.BYTE;
+        }
+        if (transportSize.getCode() == 0x00) {
+            numElements = numElements * transportSize.getSizeInBytes();
+            transportSize = TransportSize.BYTE;
+        }
+        return new S7AddressAny(transportSize, numElements, s7Tag.getBlockNumber(),
+            s7Tag.getMemoryArea(), s7Tag.getByteOffset(), s7Tag.getBitOffset());
+    }
+
+    private S7VarPayloadDataItem serializePlcValue(S7Tag tag, PlcValue plcValue) {
+        try {
+            DataTransportSize transportSize = tag.getDataType().getDataTransportSize();
+            int stringLength = (tag instanceof S7StringFixedLengthTag f) ? f.getStringLength() : 254;
+            ByteBuffer byteBuffer = null;
+            if (tag.getDataType() == TransportSize.BYTE && tag.getNumberOfElements() > 1) {
+                byteBuffer = ByteBuffer.allocate(tag.getNumberOfElements());
+                byteBuffer.put(plcValue.getRaw());
+            } else if (tag.getDataType() == TransportSize.BOOL && tag.getNumberOfElements() > 1) {
+                if (!(plcValue instanceof PlcList plcList)) {
+                    throw new PlcRuntimeException("Expected PlcList for multi-element BOOL");
+                }
+                int numBytes = (tag.getNumberOfElements() + 7) / 8;
+                byteBuffer = ByteBuffer.allocate(numBytes);
+                for (int i = 0; i < tag.getNumberOfElements(); i++) {
+                    if (plcList.getIndex(i) instanceof PlcBOOL b && b.getBoolean()) {
+                        int curByte = i / 8;
+                        int curBit = i % 8;
+                        byteBuffer.put(curByte, (byte) (1 << curBit | byteBuffer.get(curByte)));
+                    }
+                }
+                transportSize = DataTransportSize.BYTE_WORD_DWORD;
+            } else {
+                for (int i = 0; i < tag.getNumberOfElements(); i++) {
+                    int lengthInBits = DataItem.getLengthInBits(plcValue.getIndex(i),
+                        tag.getDataType().getDataProtocolId(), driverContext.getControllerType(), stringLength);
+                    if (tag.getDataType() == TransportSize.STRING) {
+                        lengthInBits = Math.min(lengthInBits, (stringLength * 8) + 16);
+                    } else if (tag.getDataType() == TransportSize.WSTRING) {
+                        lengthInBits = Math.min(lengthInBits, (stringLength * 16) + 32);
+                    } else if (tag.getDataType() == TransportSize.S5TIME) {
+                        lengthInBits = lengthInBits * 8;
+                    }
+                    WriteBufferByteBased writeBuffer = new WriteBufferByteBased(
+                        new byte[(int) Math.ceil(((float) lengthInBits) / 8.0f)],
+                        WithOption.WithUnsignedIntegerEncoding("unsigned-binary"),
+                        WithOption.WithSignedIntegerEncoding("twos-complement"),
+                        WithOption.WithFloatEncoding("IEEE754"),
+                        WithByteBasedOption.WithByteOrder("BIG_ENDIAN"));
+                    DataItem.staticSerialize(writeBuffer, plcValue.getIndex(i),
+                        tag.getDataType().getDataProtocolId(), driverContext.getControllerType(), stringLength);
+                    if (byteBuffer == null) {
+                        byteBuffer = ByteBuffer.allocate(writeBuffer.getBytes().length * tag.getNumberOfElements());
+                    }
+                    byteBuffer.put(writeBuffer.getBytes());
+                }
+            }
+            if (byteBuffer != null) {
+                return new S7VarPayloadDataItem(DataTransportErrorCode.OK, transportSize, byteBuffer.array());
+            }
+        } catch (BufferException e) {
+            LOGGER.warn("Error serializing tag {}", tag.getDataType().name(), e);
+        }
+        return null;
+    }
+
+    private PlcValue parsePlcValue(S7Tag tag, byte[] data) throws BufferException {
+        ReadBufferByteBased readBuffer = new ReadBufferByteBased(data,
+            WithOption.WithUnsignedIntegerEncoding("unsigned-binary"),
+            WithOption.WithSignedIntegerEncoding("twos-complement"),
+            WithOption.WithFloatEncoding("IEEE754"),
+            WithByteBasedOption.WithByteOrder("BIG_ENDIAN"));
+        int stringLength = (tag instanceof S7StringFixedLengthTag f) ? f.getStringLength() : 254;
+        if (tag.getNumberOfElements() == 1) {
+            return DataItem.staticParse(readBuffer, tag.getDataType().getDataProtocolId(),
+                driverContext.getControllerType(), stringLength);
+        }
+        if (tag.getDataType() == TransportSize.BYTE) {
+            return new PlcRawByteArray(data);
+        }
+        PlcValue[] resultItems = IntStream.range(0, tag.getNumberOfElements()).mapToObj(i -> {
+            try {
+                return DataItem.staticParse(readBuffer, tag.getDataType().getDataProtocolId(),
+                    driverContext.getControllerType(), stringLength);
+            } catch (BufferException e) {
+                LOGGER.warn("Error parsing element {} of tag {}", i, tag.getDataType().name(), e);
+                return null;
+            }
+        }).toArray(PlcValue[]::new);
+        return DefaultPlcValueHandler.of(tag, resultItems);
+    }
+
+    private static PlcResponseCode mapDataTransportError(DataTransportErrorCode code) {
+        if (code == null) return PlcResponseCode.INTERNAL_ERROR;
+        return switch (code) {
+            case OK -> PlcResponseCode.OK;
+            case NOT_FOUND, INVALID_ADDRESS -> PlcResponseCode.INVALID_ADDRESS;
+            case DATA_TYPE_NOT_SUPPORTED -> PlcResponseCode.INVALID_DATATYPE;
+            default -> PlcResponseCode.INTERNAL_ERROR;
+        };
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Browse
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    protected CompletableFuture<PlcBrowseResponse> onBrowse(PlcBrowseRequest browseRequest) {
+        return onBrowseWithInterceptor(browseRequest, (queryName, query, item) -> true);
+    }
+
+    @Override
+    protected CompletableFuture<PlcBrowseResponse> onBrowseWithInterceptor(PlcBrowseRequest browseRequest,
+                                                                           PlcBrowseRequestInterceptor interceptor) {
+        // Browse rides UserData services. If the SZL probe at connect time said the device
+        // doesn't speak UserData, return UNSUPPORTED per query rather than throwing.
+        if (!driverContext.isUserDataServicesSupported()) {
+            Map<String, PlcResponseCode> codes = new LinkedHashMap<>();
+            Map<String, List<PlcBrowseItem>> values = new LinkedHashMap<>();
+            for (String queryName : browseRequest.getQueryNames()) {
+                codes.put(queryName, PlcResponseCode.UNSUPPORTED);
+                values.put(queryName, Collections.emptyList());
+            }
+            return CompletableFuture.completedFuture(new DefaultPlcBrowseResponse(browseRequest, codes, values));
+        }
+
+        boolean subscribable = getMetadata().isSubscribeSupported();
+        List<PlcBrowseItem> items = new ArrayList<>(S7BrowseService.staticAreas(subscribable));
+
+        // Issue a "list of blocks of type DB" request. Treat any failure (timeout, PLC
+        // doesn't honor block functions) as "no DBs" — static areas still go in the response.
+        S7Message request = S7BrowseService.buildListBlocksOfTypeRequest(
+            getTpduId(), S7BrowseService.BlockType.DB);
+        return sendInternal(request)
+            .orTimeout(driverContext.getReadTimeout(), TimeUnit.MILLISECONDS)
+            .handle((response, error) -> {
+                if (error == null) {
+                    List<Integer> blockNumbers = S7BrowseService.parseListBlocksOfTypeResponse(response);
+                    LOGGER.debug("Block-list browse found {} DB(s)", blockNumbers.size());
+                    items.addAll(S7BrowseService.dataBlocksFromNumbers(blockNumbers, subscribable));
+                } else {
+                    LOGGER.debug("Block-list browse failed; returning static areas only: {}",
+                        error.getMessage());
+                }
+                Map<String, PlcResponseCode> codes = new LinkedHashMap<>();
+                Map<String, List<PlcBrowseItem>> values = new LinkedHashMap<>();
+                for (String queryName : browseRequest.getQueryNames()) {
+                    PlcQuery query = browseRequest.getQuery(queryName);
+                    List<PlcBrowseItem> filtered = new ArrayList<>(items.size());
+                    for (PlcBrowseItem item : items) {
+                        if (interceptor.intercept(queryName, query, item)) {
+                            filtered.add(item);
+                        }
+                    }
+                    codes.put(queryName, PlcResponseCode.OK);
+                    values.put(queryName, filtered);
+                }
+                return new DefaultPlcBrowseResponse(browseRequest, codes, values);
+            });
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Alarm subscription (S7Comm UserData MsgSubscription, group=0x04, subfn=0x02)
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    protected CompletableFuture<PlcSubscriptionResponse> onSubscribe(PlcSubscriptionRequest subscriptionRequest) {
+        if (!driverContext.isUserDataServicesSupported()) {
+            return CompletableFuture.completedFuture(
+                buildSubscriptionResponse(subscriptionRequest, PlcResponseCode.UNSUPPORTED, null));
+        }
+
+        // Three flavours of subscription are supported:
+        //   - S7AlarmTag (PUSH)  + EVENT  → alarm push (S7Comm UserData group=0x04, subfn 0x02)
+        //   - S7AlarmTag (QUERY) + EVENT  → one-shot AlarmQuery (group=0x04, subfn 0x13)
+        //   - S7Tag              + CYCLIC → cyclic value push (group=0x02)
+        // Any other combination is rejected as INVALID_ADDRESS.
+        List<String> alarmTagNames = new ArrayList<>();
+        List<String> queryTagNames = new ArrayList<>();
+        List<String> cyclicTagNames = new ArrayList<>();
+        for (String name : subscriptionRequest.getTagNames()) {
+            PlcSubscriptionTag subTag = subscriptionRequest.getTag(name);
+            PlcTag inner = unwrap(subTag);
+            PlcSubscriptionType type = subTag.getPlcSubscriptionType();
+            if (inner instanceof S7AlarmTag at
+                && type == org.apache.plc4x.java.api.types.PlcSubscriptionType.EVENT) {
+                if (at.getKind() == S7AlarmTag.Kind.QUERY) {
+                    queryTagNames.add(name);
+                } else {
+                    alarmTagNames.add(name);
+                }
+            } else if (inner instanceof S7Tag && (type == PlcSubscriptionType.CYCLIC)) {
+                cyclicTagNames.add(name);
+            } else {
+                return CompletableFuture.completedFuture(
+                    buildSubscriptionResponse(subscriptionRequest, PlcResponseCode.INVALID_ADDRESS, null));
+            }
+        }
+
+        Map<String, PlcResponseItem<PlcSubscriptionHandle>> values = new LinkedHashMap<>();
+
+        CompletableFuture<Void> alarmStage = alarmTagNames.isEmpty()
+            ? CompletableFuture.completedFuture(null)
+            : ensureAlarmSubscriptionActive().thenAccept(active -> {
+                for (String name : alarmTagNames) {
+                    if (active) {
+                        S7AlarmSubscriptionHandle handle = new S7AlarmSubscriptionHandle(this, name);
+                        alarmHandles.add(handle);
+                        values.put(name, new DefaultPlcResponseItem<>(PlcResponseCode.OK, handle));
+                    } else {
+                        values.put(name, new DefaultPlcResponseItem<>(PlcResponseCode.REMOTE_ERROR, null));
+                    }
+                }
+            });
+
+        CompletableFuture<Void> cyclicStage = cyclicTagNames.isEmpty()
+            ? CompletableFuture.completedFuture(null)
+            : subscribeCyclic(subscriptionRequest, cyclicTagNames, values);
+
+        CompletableFuture<Void> queryStage = queryTagNames.isEmpty()
+            ? CompletableFuture.completedFuture(null)
+            : runAlarmQueries(subscriptionRequest, queryTagNames, values);
+
+        return CompletableFuture.allOf(alarmStage, cyclicStage, queryStage)
+            .thenApply(v -> new DefaultPlcSubscriptionResponse(subscriptionRequest, values));
+    }
+
+    /**
+     * Run a one-shot AlarmQuery for each requested tag, in parallel. Each tag carries its
+     * own QueryType (ALARM_S vs ALARM_8), so we issue one wire request per tag rather than
+     * trying to bundle them.
+     */
+    private CompletableFuture<Void> runAlarmQueries(PlcSubscriptionRequest req, List<String> tagNames,
+                                                    Map<String, PlcResponseItem<PlcSubscriptionHandle>> values) {
+        List<CompletableFuture<Void>> stages = new ArrayList<>(tagNames.size());
+        for (String name : tagNames) {
+            S7AlarmTag tag = (S7AlarmTag) unwrap(req.getTag(name));
+            S7Message request = S7AlarmSubscriptionService.buildAlarmQueryRequest(
+                getTpduId(), tag.getQueryType());
+            stages.add(sendInternal(request)
+                .orTimeout(driverContext.getReadTimeout(), TimeUnit.MILLISECONDS)
+                .handle((response, error) -> {
+                    if (error != null || response == null) {
+                        LOGGER.debug("Alarm query failed for {}: {}", name,
+                            error == null ? "no response" : error.getMessage());
+                        values.put(name, new DefaultPlcResponseItem<>(PlcResponseCode.REMOTE_ERROR, null));
+                        return null;
+                    }
+                    byte[] payload = S7AlarmSubscriptionService.parseAlarmQueryResponse(response);
+                    if (payload == null) {
+                        LOGGER.debug("Alarm query rejected by PLC for {}", name);
+                        values.put(name, new DefaultPlcResponseItem<>(PlcResponseCode.REMOTE_ERROR, null));
+                        return null;
+                    }
+                    S7AlarmQueryHandle handle = new S7AlarmQueryHandle(this, name, payload);
+                    values.put(name, new DefaultPlcResponseItem<>(PlcResponseCode.OK, handle));
+                    return null;
+                }));
+        }
+        return CompletableFuture.allOf(stages.toArray(CompletableFuture[]::new));
+    }
+
+    /**
+     * Issue cyclic-subscribe requests grouped by interval (one wire request per distinct
+     * interval) and populate {@code values} with the per-tag response items. Tags that share
+     * an interval get bundled into a single subscription with the PLC, sharing one jobId.
+     */
+    private CompletableFuture<Void> subscribeCyclic(PlcSubscriptionRequest req, List<String> tagNames,
+                                                    Map<String, PlcResponseItem<PlcSubscriptionHandle>> values) {
+        // Group tags by their (TimeBase, factor) pair so callers requesting the same cadence
+        // ride one PLC subscription rather than one-per-tag.
+        Map<S7CyclicSubscriptionService.IntervalSpec, List<String>> byInterval = new LinkedHashMap<>();
+        for (String name : tagNames) {
+            PlcSubscriptionTag subTag = req.getTag(name);
+            S7CyclicSubscriptionService.IntervalSpec interval =
+                S7CyclicSubscriptionService.pickInterval(subTag.getDuration().orElse(null));
+            byInterval.computeIfAbsent(interval, k -> new ArrayList<>()).add(name);
+        }
+
+        List<CompletableFuture<Void>> stages = new ArrayList<>(byInterval.size());
+        for (Map.Entry<S7CyclicSubscriptionService.IntervalSpec, List<String>> entry : byInterval.entrySet()) {
+            stages.add(subscribeCyclicGroup(req, entry.getKey(), entry.getValue(), values));
+        }
+        return CompletableFuture.allOf(stages.toArray(CompletableFuture[]::new));
+    }
+
+    private CompletableFuture<Void> subscribeCyclicGroup(PlcSubscriptionRequest req,
+                                                         S7CyclicSubscriptionService.IntervalSpec interval,
+                                                         List<String> tagNames,
+                                                         Map<String, PlcResponseItem<PlcSubscriptionHandle>> values) {
+        List<S7Tag> tags = new ArrayList<>(tagNames.size());
+        for (String name : tagNames) {
+            tags.add((S7Tag) unwrap(req.getTag(name)));
+        }
+        S7Message request = S7CyclicSubscriptionService.buildSubscribeRequest(getTpduId(), tags, interval);
+        return sendInternal(request)
+            .orTimeout(driverContext.getReadTimeout(), TimeUnit.MILLISECONDS)
+            .handle((response, error) -> {
+                if (error != null || response == null) {
+                    LOGGER.debug("Cyclic subscribe failed: {}",
+                        error == null ? "no response" : error.getMessage());
+                    for (String name : tagNames) {
+                        values.put(name, new DefaultPlcResponseItem<>(PlcResponseCode.REMOTE_ERROR, null));
+                    }
+                    return null;
+                }
+                Short jobId = S7CyclicSubscriptionService.parseSubscribeResponse(response);
+                if (jobId == null) {
+                    LOGGER.debug("Cyclic subscribe rejected by PLC");
+                    for (String name : tagNames) {
+                        values.put(name, new DefaultPlcResponseItem<>(PlcResponseCode.REMOTE_ERROR, null));
+                    }
+                    return null;
+                }
+                installCyclicIndicationHandlers();
+                List<S7CyclicSubscriptionHandle> handles = new ArrayList<>(tagNames.size());
+                for (int i = 0; i < tagNames.size(); i++) {
+                    String name = tagNames.get(i);
+                    S7CyclicSubscriptionHandle handle =
+                        new S7CyclicSubscriptionHandle(this, name, tags.get(i), jobId, i);
+                    handles.add(handle);
+                    values.put(name, new DefaultPlcResponseItem<>(PlcResponseCode.OK, handle));
+                }
+                cyclicHandlesByJob.put(jobId, handles);
+                LOGGER.debug("Cyclic subscribe active: jobId={}, tags={}, intervalMs={}",
+                    jobId, tagNames, interval.toMillis());
+                return null;
+            });
+    }
+
+    private void installCyclicIndicationHandlers() {
+        synchronized (cyclicDispatcherHooks) {
+            if (!cyclicDispatcherHooks.isEmpty()) {
+                return;
+            }
+            cyclicDispatcherHooks.add(pushDispatcher.register(
+                S7CyclicSubscriptionService.CPU_FUNCTION_GROUP_CYCLIC,
+                S7CyclicSubscriptionService.CPU_FUNCTION_TYPE_PUSH,
+                S7CyclicSubscriptionService.CYCLIC_PUSH_SUBFUNCTION,
+                this::dispatchCyclicPush));
+        }
+    }
+
+    private void dispatchCyclicPush(S7Message message) {
+        Short jobId = S7CyclicSubscriptionService.getJobId(message);
+        if (jobId == null) return;
+        List<S7CyclicSubscriptionHandle> handles = cyclicHandlesByJob.get(jobId);
+        if (handles == null || handles.isEmpty()) return;
+        List<byte[]> items = S7CyclicSubscriptionService.parsePushItems(message);
+        if (items == null) return;
+
+        // Decode each item using its corresponding tag's data type and emit one event per
+        // consumer registration whose handle set covers this jobId.
+        Map<String, PlcResponseItem<PlcValue>> values = new LinkedHashMap<>();
+        for (S7CyclicSubscriptionHandle handle : handles) {
+            int idx = handle.getItemIndex();
+            if (idx >= items.size()) {
+                values.put(handle.getTagName(), new DefaultPlcResponseItem<>(PlcResponseCode.NOT_FOUND, null));
+                continue;
+            }
+            try {
+                PlcValue value = parsePlcValue(handle.getTag(), items.get(idx));
+                values.put(handle.getTagName(), new DefaultPlcResponseItem<>(PlcResponseCode.OK, value));
+            } catch (Exception e) {
+                LOGGER.debug("Cyclic push decode failed for tag {}: {}", handle.getTagName(), e.getMessage());
+                values.put(handle.getTagName(), new DefaultPlcResponseItem<>(PlcResponseCode.INTERNAL_ERROR, null));
+            }
+        }
+        DefaultPlcSubscriptionEvent event = new DefaultPlcSubscriptionEvent(java.time.Instant.now(), values);
+        for (Map.Entry<DefaultPlcConsumerRegistration, Consumer<PlcSubscriptionEvent>> entry : consumers.entrySet()) {
+            for (PlcSubscriptionHandle h : entry.getKey().getSubscriptionHandles()) {
+                if (h instanceof S7CyclicSubscriptionHandle ch && ch.getJobId() == jobId) {
+                    entry.getValue().accept(event);
+                    break;    // one event per registration even if multiple handles match
+                }
+            }
+        }
+    }
+
+    @Override
+    protected CompletableFuture<PlcUnsubscriptionResponse> onUnsubscribe(PlcUnsubscriptionRequest unsubscriptionRequest) {
+        Set<Short> cyclicJobsToCancel = new java.util.HashSet<>();
+        for (PlcSubscriptionHandle h : unsubscriptionRequest.getSubscriptionHandles()) {
+            if (h instanceof S7AlarmSubscriptionHandle ah) {
+                alarmHandles.remove(ah);
+            } else if (h instanceof S7CyclicSubscriptionHandle ch) {
+                short jobId = ch.getJobId();
+                List<S7CyclicSubscriptionHandle> remaining = cyclicHandlesByJob.get(jobId);
+                if (remaining != null) {
+                    remaining.remove(ch);
+                    if (remaining.isEmpty()) {
+                        cyclicHandlesByJob.remove(jobId);
+                        cyclicJobsToCancel.add(jobId);
+                    }
+                }
+            }
+        }
+        // Wait for both deactivations (when triggered) before completing the response so the
+        // caller's subsequent connection close doesn't race ahead of the cancel requests.
+        CompletableFuture<Void> alarmStage = alarmHandles.isEmpty()
+            ? deactivateAlarmSubscription()
+            : CompletableFuture.completedFuture(null);
+        CompletableFuture<Void> cyclicStage = cancelCyclicJobs(cyclicJobsToCancel);
+        return CompletableFuture.allOf(alarmStage, cyclicStage)
+            .handle((v, t) -> new DefaultPlcUnsubscriptionResponse(unsubscriptionRequest));
+    }
+
+    private CompletableFuture<Void> cancelCyclicJobs(Set<Short> jobIds) {
+        if (jobIds.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        List<CompletableFuture<Void>> stages = new ArrayList<>(jobIds.size());
+        for (Short jobId : jobIds) {
+            try {
+                stages.add(sendInternal(S7CyclicSubscriptionService.buildUnsubscribeRequest(getTpduId(), jobId))
+                    .orTimeout(driverContext.getReadTimeout(), TimeUnit.MILLISECONDS)
+                    .handle((response, error) -> {
+                        if (error != null) {
+                            LOGGER.debug("Cyclic cancel send failed for jobId {} (ignoring): {}",
+                                jobId, error.getMessage());
+                        }
+                        return null;
+                    }));
+            } catch (Exception e) {
+                // Codec already shut down — nothing to send.
+                stages.add(CompletableFuture.completedFuture(null));
+            }
+        }
+        // If no other cyclic subscription is active, also tear down the push handler.
+        if (cyclicHandlesByJob.isEmpty()) {
+            synchronized (cyclicDispatcherHooks) {
+                for (java.io.Closeable hook : cyclicDispatcherHooks) {
+                    try { hook.close(); } catch (Exception ignored) { /* local-only impl */ }
+                }
+                cyclicDispatcherHooks.clear();
+            }
+        }
+        return CompletableFuture.allOf(stages.toArray(CompletableFuture[]::new));
+    }
+
+    @Override
+    protected PlcConsumerRegistration onRegisterConsumer(Consumer<PlcSubscriptionEvent> consumer,
+                                                         Collection<PlcSubscriptionHandle> handles) {
+        DefaultPlcConsumerRegistration registration = new DefaultPlcConsumerRegistration(
+            this, consumer, handles.toArray(new PlcSubscriptionHandle[0]));
+        consumers.put(registration, consumer);
+        // Query handles carry their result inline (it was fetched at subscribe time). Deliver
+        // it as a single PlcSubscriptionEvent now and the handle goes inert thereafter.
+        Map<String, PlcResponseItem<PlcValue>> queryValues = null;
+        for (PlcSubscriptionHandle handle : handles) {
+            if (handle instanceof S7AlarmQueryHandle qh) {
+                if (queryValues == null) {
+                    queryValues = new LinkedHashMap<>();
+                }
+                queryValues.put(qh.getTagName(),
+                    new DefaultPlcResponseItem<>(PlcResponseCode.OK, new PlcRawByteArray(qh.getPayload())));
+            }
+        }
+        if (queryValues != null) {
+            consumer.accept(new DefaultPlcSubscriptionEvent(java.time.Instant.now(), queryValues));
+        }
+        return registration;
+    }
+
+    @Override
+    protected void onUnregisterConsumer(PlcConsumerRegistration registration) {
+        if (registration instanceof DefaultPlcConsumerRegistration r) {
+            consumers.remove(r);
+        }
+    }
+
+    private CompletableFuture<Boolean> ensureAlarmSubscriptionActive() {
+        synchronized (alarmDispatcherHooks) {
+            if (!alarmDispatcherHooks.isEmpty()) {
+                return CompletableFuture.completedFuture(Boolean.TRUE);
+            }
+        }
+        S7Message request = S7AlarmSubscriptionService.buildSubscribeRequest(
+            getTpduId(), driverContext.getControllerType());
+        return sendInternal(request)
+            .orTimeout(driverContext.getReadTimeout(), TimeUnit.MILLISECONDS)
+            .handle((response, error) -> {
+                if (error != null) {
+                    LOGGER.debug("Alarm subscription failed: {}", error.getMessage(), error);
+                    return Boolean.FALSE;
+                }
+                if (!S7AlarmSubscriptionService.parseSubscribeResponse(response)) {
+                    LOGGER.debug("Alarm subscription rejected by PLC");
+                    return Boolean.FALSE;
+                }
+                installAlarmIndicationHandlers();
+                LOGGER.debug("Alarm subscription active");
+                return Boolean.TRUE;
+            });
+    }
+
+    private void installAlarmIndicationHandlers() {
+        synchronized (alarmDispatcherHooks) {
+            if (!alarmDispatcherHooks.isEmpty()) {
+                return;
+            }
+            for (Integer subfn : S7AlarmSubscriptionService.ALARM_INDICATION_SUBFUNCTIONS) {
+                alarmDispatcherHooks.add(pushDispatcher.register(
+                    S7AlarmSubscriptionService.CPU_FUNCTION_GROUP_CPU,
+                    S7AlarmSubscriptionService.CPU_FUNCTION_TYPE_PUSH,
+                    subfn,
+                    this::dispatchAlarmIndication));
+            }
+        }
+    }
+
+    /**
+     * Tear down alarm subscription state and tell the PLC to stop pushing. Returns a future
+     * that completes once the ALARM_S_ABORT request has either been answered, timed out, or
+     * failed — so {@code onUnsubscribe} can await it before returning to the caller. Without
+     * waiting, the caller's subsequent connection close races ahead of the request and the
+     * cancel never makes it onto the wire.
+     */
+    private CompletableFuture<Void> deactivateAlarmSubscription() {
+        synchronized (alarmDispatcherHooks) {
+            for (java.io.Closeable hook : alarmDispatcherHooks) {
+                try {
+                    hook.close();
+                } catch (Exception ignored) {
+                    // hook.close() is local-only and never throws in our impl.
+                }
+            }
+            alarmDispatcherHooks.clear();
+        }
+        try {
+            return sendInternal(S7AlarmSubscriptionService.buildUnsubscribeRequest(
+                    getTpduId(), driverContext.getControllerType()))
+                .orTimeout(driverContext.getReadTimeout(), TimeUnit.MILLISECONDS)
+                .handle((response, error) -> {
+                    if (error != null) {
+                        LOGGER.debug("Alarm cancel send failed (ignoring): {}", error.getMessage());
+                    }
+                    return null;
+                });
+        } catch (Exception e) {
+            // Codec already shut down — nothing to send. Treat as already-deactivated.
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private void dispatchAlarmIndication(S7Message message) {
+        PlcValue payload = S7AlarmSubscriptionService.parseAlarmIndication(message);
+        if (payload == null) {
+            return;
+        }
+        for (Map.Entry<DefaultPlcConsumerRegistration, Consumer<PlcSubscriptionEvent>> entry : consumers.entrySet()) {
+            for (PlcSubscriptionHandle handle : entry.getKey().getSubscriptionHandles()) {
+                if (handle instanceof S7AlarmSubscriptionHandle ah) {
+                    Map<String, PlcResponseItem<PlcValue>> values = new LinkedHashMap<>();
+                    values.put(ah.getTagName(), new DefaultPlcResponseItem<>(PlcResponseCode.OK, payload));
+                    entry.getValue().accept(new DefaultPlcSubscriptionEvent(java.time.Instant.now(), values));
+                }
+            }
+        }
+    }
+
+    private static PlcTag unwrap(PlcSubscriptionTag tag) {
+        return tag == null ? null : tag.getTag();
+    }
+
+    private DefaultPlcSubscriptionResponse buildSubscriptionResponse(PlcSubscriptionRequest request,
+                                                                     PlcResponseCode code,
+                                                                     PlcSubscriptionHandle handle) {
+        Map<String, PlcResponseItem<PlcSubscriptionHandle>> values = new LinkedHashMap<>();
+        for (String name : request.getTagNames()) {
+            values.put(name, new DefaultPlcResponseItem<>(code, handle));
+        }
+        return new DefaultPlcSubscriptionResponse(request, values);
+    }
+
+    private static PlcResponseCode mapPlcErrorCode(short errorClass, short errorCode) {
+        // Ported error mapping from s7-light: 129/4 means PUT/GET disabled.
+        if (errorClass == 129 && errorCode == 4) return PlcResponseCode.ACCESS_DENIED;
+        if (errorClass == 0x85) return PlcResponseCode.ACCESS_DENIED;
+        return PlcResponseCode.INTERNAL_ERROR;
+    }
+
 }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>fix(s7): Prevent NPE and AIOOBE when reading an undefined DB variable (fixes #2266)</h2>
<h3>Problem</h3>
<p>When reading a Siemens Data Block (DB) variable that does not exist in the PLC, the
S7 protocol returns a per-item <code>returnCode</code> of <code>NOT_FOUND</code> or <code>INVALID_ADDRESS</code> inside
<code>S7PayloadReadVarResponse</code>. In this case <code>S7VarPayloadDataItem.getData()</code> is either
<code>null</code> or a zero-length <code>byte[]</code>.</p>
<p>The previous code in <code>S7CotpConnection.applyChunkResponse</code> passed this value directly
into <code>decodeBindingInto</code> without any check:</p>
<pre><code class="language-java">// BEFORE
byte[] data = item.getData();          // null on some PLC firmware variants
// ...
decodeBindingInto(out, b, data);       // NullPointerException here
</code></pre>
<p>In the block-merged path inside <code>decodeBindingInto</code>:</p>
<pre><code class="language-java">// BEFORE
System.arraycopy(data, b.payloadByteOffset(), ...);  // AIOOBE if offset &gt;= data.length
</code></pre>
<p>Both exceptions were caught by the outer <code>try/catch</code> and silently converted to
<code>INTERNAL_ERROR</code>, hiding the real cause and giving the application no useful error
information.</p>
<h3>Root cause — three distinct firmware scenarios</h3>

Scenario | returnCode | getData() | Old result | Fixed result
-- | -- | -- | -- | --
Undefined variable, Variant A | NOT_FOUND | null | NullPointerException → INTERNAL_ERROR | INVALID_ADDRESS
Undefined variable, Variant B | INVALID_ADDRESS | byte[0] | Silent wrong answer / AIOOBE | INVALID_ADDRESS
PLC firmware inconsistency | OK | byte[0] | AIOOBE → INTERNAL_ERROR | INVALID_ADDRESS
Block-merged read, truncated response | OK | byte[N], N too short | AIOOBE in System.arraycopy | INTERNAL_ERROR


<h3>Files changed</h3>
<pre><code>plc4j/drivers/s7/src/main/java/org/apache/plc4x/java/s7/S7CotpConnection.java
plc4j/drivers/s7/src/test/java/org/apache/plc4x/java/s7/S7CotpConnectionResponseDecodeTest.java  [new]
</code></pre>
<p>Fixes #2266</p></body></html><!--EndFragment-->
</body>
</html>

