### PR TITLE
plc4j(ab-eth): Fix read tag after refactoring/spi3

### DIFF
--- a/plc4j/drivers/ab-eth/src/main/java/org/apache/plc4x/java/abeth/AbEthMessageCodec.java
+++ b/plc4j/drivers/ab-eth/src/main/java/org/apache/plc4x/java/abeth/AbEthMessageCodec.java
@@ -68,8 +68,8 @@ public class AbEthMessageCodec extends MessageCodecBase<CIPEncapsulationPacket> 
 
     @Override
     protected int calculateTotalMessageSize(byte[] header, int availableBytes) throws MessageCodecException {
-        // Little-endian unsigned 16-bit at offset 2
-        int payloadLength = (header[LENGTH_OFFSET] & 0xFF) | ((header[LENGTH_OFFSET + 1] & 0xFF) << 8);
+        // Big-endian unsigned 16-bit at offset 2
+        int payloadLength = ((header[LENGTH_OFFSET] & 0xFF) << 8) | (header[LENGTH_OFFSET + 1] & 0xFF);
         return payloadLength + HEADER_OVERHEAD;
     }
 


### PR DESCRIPTION
Hi @chrisdutz!

When trying to read tag values, the system is getting a timeout error. The problem occurs because the calculateTotalMessageSize is getting a big value. As a result, the driver keeps waiting for incoming data that will never arrive, since the actual data transfer has already finished. 

Note: I considered whether this behavior should be configured. However, since the rest of the reading mechanism works fine without extra configuration, a direct fix in the size calculation seems to be the correct approach.

Before refactoring/spi3 it is working properly. I tried to find similar logic in the old version but It looks like it does not exist. So I believe the old mecanism approach considers that the received data will arrive in just one shot, right?

Thanks,
Anderson.