### PR TITLE
Add missing ASF license header to subscription-emulation logback-test.xml

### DIFF
--- a/plc4j/utils/subscription-emulation/src/test/resources/logback-test.xml
+++ b/plc4j/utils/subscription-emulation/src/test/resources/logback-test.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
Building PLC4X from a fresh checkout of `develop` currently fails after ~30 s in the root module's `apache-rat:check`: `plc4j/utils/subscription-emulation/src/test/resources/logback-test.xml` is the single file without an ASF license header (RAT: `Unapproved: 1`).

This adds the same header the sibling `logback-test.xml` files (modbus, eip, profinet-ng, …) carry. Verified locally: `mvn -N apache-rat:check` → `Unapproved: 0`, BUILD SUCCESS.

Found while testing PLC4X against a current Maven `4.0.0-SNAPSHOT` (pre-RC-6) — thanks for adopting Maven 4 so early! 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)