### PR TITLE
Enable consumer POM flattening for Maven 4 RC-6 readiness

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,2 @@
 -P ?reactor-with-extras,?reactor-with-build-tools
+-Dmaven.consumer.pom.flatten=true


### PR DESCRIPTION
## Heads-up: PLC4X will stop building with Maven 4.0.0-RC-6

Since [apache/maven#11780](https://github.com/apache/maven/pull/11780) (backported to 4.0.x via [#12236](https://github.com/apache/maven/pull/12236), so first shipping with **RC-6**), `install`/`deploy` of a POM-packaged project fails fast when its consumer POM cannot be downgraded to model 4.0.0. The PLC4X parent uses 4.1.0-only features (`<subprojects>`, build `<sources>`), so with a current `4.0.0-SNAPSHOT` (pre-RC-6) every build dies in the very first reactor module:

```
maven-install-plugin:3.1.4:install on project plc4x-parent: The consumer POM …
cannot be downgraded to model version 4.0.0 … Since consumer POM flattening
is disabled, the parent reference is preserved …
```

## Fix

One line in `.mvn/maven.config`: `-Dmaven.consumer.pom.flatten=true`.

Side benefit beyond staying buildable: with flattening enabled, the **jar module consumer POMs become self-contained model-4.0.0** (no `<parent>` reference), which fixes Maven 3/Gradle consumption of published PLC4X artifacts — the very issue behind [apache/maven#11772](https://github.com/apache/maven/issues/11772) (rc-5 silently publishes model-4.1.0 parent POMs that Maven 3/Gradle cannot parse).

## Verified locally

- `4.0.0-rc-5` (current wrapper pin): full reactor `BUILD SUCCESS` — property exists and is safe on rc-5
- current `4.0.0-SNAPSHOT` (pre-RC-6): full reactor (113 modules) `BUILD SUCCESS`; without this change: fail-fast as above
- installed jar consumer POMs are model 4.0.0 without parent reference; note the POM-packaged parents themselves currently remain model 4.1.0 even with flattening — raised upstream with the Maven folks

Found while testing PLC4X against pre-RC-6 Maven for the Maven 4 adoption effort — happy to keep sending such findings your way if useful. 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)