### PR TITLE
perf(plc4j/spi/buffers): speed up byte-aligned integer read/write

### DIFF
--- a/plc4j/spi/buffers/api/src/main/java/org/apache/plc4x/java/spi/buffers/api/AbstractBuffer.java
+++ b/plc4j/spi/buffers/api/src/main/java/org/apache/plc4x/java/spi/buffers/api/AbstractBuffer.java
@@ -20,16 +20,21 @@ package org.apache.plc4x.java.spi.buffers.api;
 
 import org.apache.plc4x.java.spi.buffers.api.exceptions.BufferException;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Stack;
 
 public abstract class AbstractBuffer implements Buffer {
 
-    protected final Stack<WithOption[]> context;
+    // Used as a stack (push/pop/peek). ArrayDeque instead of java.util.Stack: a buffer is a
+    // single-threaded, per-message scratch object (positionInBits and the backing array are
+    // themselves unsynchronized), so Stack's synchronization (it extends the synchronized Vector)
+    // guards nothing here while adding a monitor enter/exit to getContext() on every field.
+    protected final Deque<WithOption[]> context;
 
     public AbstractBuffer(WithOption... options) {
-        context = new Stack<>();
+        context = new ArrayDeque<>();
         context.push(options);
     }
 

--- a/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/AbstractBufferByteBased.java
+++ b/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/AbstractBufferByteBased.java
@@ -77,21 +77,24 @@ public abstract class AbstractBufferByteBased extends AbstractBuffer {
     // NOT the broader EncodingDefault, so BCD/float/etc. correctly fall through to the slow path.
 
     protected boolean isFastUnsignedBinaryBE(int numBits, WithOption[] options) {
-        if (options.length != 0 || (positionInBits & 7) != 0 || (numBits & 7) != 0) {
+        // isAligned() tests the ABSOLUTE bit index (startBit + positionInBits) — the same predicate the
+        // readBits/writeBits whole-byte fast paths use — so a non-byte-aligned sub-buffer correctly
+        // falls through to the generic path (readAlignedBytesBE indexes by (startBit+positionInBits)/8).
+        if (options.length != 0 || !isAligned() || (numBits & 7) != 0) {
             return false;
         }
         Optional<Encoding> enc = getUnsignedIntegerEncoding();
         return enc.isPresent() && enc.get() instanceof EncodingUnsignedBinary
-            && getByteOrder() == ByteOrderBigEndian.INSTANCE;
+            && getByteOrder() instanceof ByteOrderBigEndian;
     }
 
     protected boolean isFastSignedTwosComplementBE(int numBits, WithOption[] options) {
-        if (options.length != 0 || (positionInBits & 7) != 0 || (numBits & 7) != 0) {
+        if (options.length != 0 || !isAligned() || (numBits & 7) != 0) {
             return false;
         }
         Optional<Encoding> enc = getSignedIntegerEncoding();
         return enc.isPresent() && enc.get() instanceof EncodingTwosComplement
-            && getByteOrder() == ByteOrderBigEndian.INSTANCE;
+            && getByteOrder() instanceof ByteOrderBigEndian;
     }
 
     /** Big-endian two's-complement sign extension of the low {@code numBits} of {@code raw}. */
@@ -188,8 +191,16 @@ public abstract class AbstractBufferByteBased extends AbstractBuffer {
         }
     }
 
+    /**
+     * Whether the current cursor sits on a byte boundary of the BACKING ARRAY. This must be tested on
+     * the absolute bit index ({@code startBit + positionInBits}), not on {@code positionInBits} alone:
+     * a sub-buffer created at a non-byte-aligned offset (see {@code createSubBuffer}) has a non-zero
+     * {@code startBit} while its own {@code positionInBits} is 0. The whole-byte {@code arraycopy}
+     * fast paths in {@code readBits}/{@code writeBits} index the backing array by
+     * {@code (startBit + positionInBits) / 8}, so only absolute alignment makes that copy correct.
+     */
     protected boolean isAligned() {
-        return (positionInBits % 8) == 0;
+        return ((startBit + positionInBits) % 8) == 0;
     }
 
 }

--- a/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/AbstractBufferByteBased.java
+++ b/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/AbstractBufferByteBased.java
@@ -26,6 +26,8 @@ import org.apache.plc4x.java.spi.buffers.bytebased.byteorder.ByteOrderBigEndian;
 import org.apache.plc4x.java.spi.buffers.bytebased.byteorder.ByteOrderManager;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.Encoding;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingManager;
+import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingTwosComplement;
+import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingUnsignedBinary;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -65,7 +67,37 @@ public abstract class AbstractBufferByteBased extends AbstractBuffer {
                 return byteOrder.get();
             }
         }
-        return new ByteOrderBigEndian();
+        return ByteOrderBigEndian.INSTANCE;
+    }
+
+    // ---- Byte-aligned integer fast-path helpers (shared by Read/Write byte buffers) ----
+    // Eligible only when there are no per-field option overrides, the position is byte-aligned, a
+    // whole number of bytes is requested, byte order is big-endian, and the resolved integer encoding
+    // is plain binary (unsigned) / two's-complement (signed). Gated on the concrete encoding class,
+    // NOT the broader EncodingDefault, so BCD/float/etc. correctly fall through to the slow path.
+
+    protected boolean isFastUnsignedBinaryBE(int numBits, WithOption[] options) {
+        if (options.length != 0 || (positionInBits & 7) != 0 || (numBits & 7) != 0) {
+            return false;
+        }
+        Optional<Encoding> enc = getUnsignedIntegerEncoding();
+        return enc.isPresent() && enc.get() instanceof EncodingUnsignedBinary
+            && getByteOrder() == ByteOrderBigEndian.INSTANCE;
+    }
+
+    protected boolean isFastSignedTwosComplementBE(int numBits, WithOption[] options) {
+        if (options.length != 0 || (positionInBits & 7) != 0 || (numBits & 7) != 0) {
+            return false;
+        }
+        Optional<Encoding> enc = getSignedIntegerEncoding();
+        return enc.isPresent() && enc.get() instanceof EncodingTwosComplement
+            && getByteOrder() == ByteOrderBigEndian.INSTANCE;
+    }
+
+    /** Big-endian two's-complement sign extension of the low {@code numBits} of {@code raw}. */
+    protected static long signExtend(long raw, int numBits) {
+        int shift = 64 - numBits;
+        return (raw << shift) >> shift;
     }
 
     protected Optional<Encoding> getUnsignedIntegerEncoding(WithOption... options) {

--- a/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/AbstractBufferByteBased.java
+++ b/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/AbstractBufferByteBased.java
@@ -26,8 +26,6 @@ import org.apache.plc4x.java.spi.buffers.bytebased.byteorder.ByteOrderBigEndian;
 import org.apache.plc4x.java.spi.buffers.bytebased.byteorder.ByteOrderManager;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.Encoding;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingManager;
-import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingTwosComplement;
-import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingUnsignedBinary;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -71,30 +69,20 @@ public abstract class AbstractBufferByteBased extends AbstractBuffer {
     }
 
     // ---- Byte-aligned integer fast-path helpers (shared by Read/Write byte buffers) ----
-    // Eligible only when there are no per-field option overrides, the position is byte-aligned, a
-    // whole number of bytes is requested, byte order is big-endian, and the resolved integer encoding
-    // is plain binary (unsigned) / two's-complement (signed). Gated on the concrete encoding class,
-    // NOT the broader EncodingDefault, so BCD/float/etc. correctly fall through to the slow path.
 
-    protected boolean isFastUnsignedBinaryBE(int numBits, WithOption[] options) {
+    /**
+     * Structural fast-path eligibility for the byte-aligned integer fast path: no per-field
+     * options, the cursor on an absolute byte boundary (see {@link #isAligned()}), and a
+     * whole number of bytes requested. The caller combines this with checks on the ALREADY
+     * RESOLVED encoding/byte order (plain binary / two's-complement, big-endian) so resolution
+     * happens exactly once per field and non-eligible fields fall through to the slow path
+     * without a second lookup.
+     */
+    protected boolean isByteAlignedWholeBytes(int numBits, WithOption[] options) {
         // isAligned() tests the ABSOLUTE bit index (startBit + positionInBits) — the same predicate the
         // readBits/writeBits whole-byte fast paths use — so a non-byte-aligned sub-buffer correctly
-        // falls through to the generic path (readAlignedBytesBE indexes by (startBit+positionInBits)/8).
-        if (options.length != 0 || !isAligned() || (numBits & 7) != 0) {
-            return false;
-        }
-        Optional<Encoding> enc = getUnsignedIntegerEncoding();
-        return enc.isPresent() && enc.get() instanceof EncodingUnsignedBinary
-            && getByteOrder() instanceof ByteOrderBigEndian;
-    }
-
-    protected boolean isFastSignedTwosComplementBE(int numBits, WithOption[] options) {
-        if (options.length != 0 || !isAligned() || (numBits & 7) != 0) {
-            return false;
-        }
-        Optional<Encoding> enc = getSignedIntegerEncoding();
-        return enc.isPresent() && enc.get() instanceof EncodingTwosComplement
-            && getByteOrder() instanceof ByteOrderBigEndian;
+        // falls through to the generic path (the aligned fast paths index by (startBit+positionInBits)/8).
+        return options.length == 0 && isAligned() && (numBits & 7) == 0;
     }
 
     /** Big-endian two's-complement sign extension of the low {@code numBits} of {@code raw}. */

--- a/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/AbstractBufferByteBased.java
+++ b/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/AbstractBufferByteBased.java
@@ -73,10 +73,11 @@ public abstract class AbstractBufferByteBased extends AbstractBuffer {
     /**
      * Structural fast-path eligibility for the byte-aligned integer fast path: no per-field
      * options, the cursor on an absolute byte boundary (see {@link #isAligned()}), and a
-     * whole number of bytes requested. The caller combines this with checks on the ALREADY
-     * RESOLVED encoding/byte order (plain binary / two's-complement, big-endian) so resolution
-     * happens exactly once per field and non-eligible fields fall through to the slow path
-     * without a second lookup.
+     * whole number of bytes requested. The caller combines this with EXACT-CLASS checks
+     * ({@code getClass() == ...}, not {@code instanceof}) on the ALREADY RESOLVED encoding/byte
+     * order (plain binary / two's-complement, big-endian) so resolution happens exactly once per
+     * field, and a registered subclass with overridden codec behaviour falls through to the
+     * virtual-dispatch slow path instead of being silently bypassed by the fast path.
      */
     protected boolean isByteAlignedWholeBytes(int numBits, WithOption[] options) {
         // isAligned() tests the ABSOLUTE bit index (startBit + positionInBits) — the same predicate the

--- a/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/ReadBufferByteBased.java
+++ b/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/ReadBufferByteBased.java
@@ -21,11 +21,15 @@ package org.apache.plc4x.java.spi.buffers.bytebased;
 import org.apache.plc4x.java.spi.buffers.api.ReadBuffer;
 import org.apache.plc4x.java.spi.buffers.api.WithOption;
 import org.apache.plc4x.java.spi.buffers.api.exceptions.BufferException;
+import org.apache.plc4x.java.spi.buffers.bytebased.byteorder.ByteOrder;
+import org.apache.plc4x.java.spi.buffers.bytebased.byteorder.ByteOrderBigEndian;
 import org.apache.plc4x.java.spi.buffers.bytebased.byteorder.ByteOrderManager;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.Encoding;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingDefault;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingManager;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingRaw;
+import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingTwosComplement;
+import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingUnsignedBinary;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -133,16 +137,19 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
             throw new BufferException("Unsigned short can only read between 1 and 15 bits");
         }
 
-        if (isFastUnsignedBinaryBE(numBits, options)) {
+        Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
+        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
+        ByteOrder byteOrder = getByteOrder(options);
+        if (isByteAlignedWholeBytes(numBits, options)
+            && encoding instanceof EncodingUnsignedBinary
+            && byteOrder instanceof ByteOrderBigEndian) {
             return (short) readAlignedBytesBE(numBits);
         }
 
-        Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
-        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
             ensureAvailable(numBits);
             byte[] bytes = readBits(numBits);
-            bytes = getByteOrder(options).process(bytes);
+            bytes = byteOrder.process(bytes);
             return encodingDefault.decodeShort(numBits, bytes);
         } else if(encoding instanceof EncodingRaw encodingRaw) {
             return encodingRaw.decodeShort(numBits, this);
@@ -156,18 +163,21 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
             throw new BufferException("Unsigned int can only read between 1 and 31 bits");
         }
 
+        Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
+        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
+        ByteOrder byteOrder = getByteOrder(options);
         // Fast path: byte-aligned whole-byte plain-binary big-endian read straight from the backing
-        // array (no intermediate byte[] / ByteOrder object). See isFastUnsignedBinaryBE.
-        if (isFastUnsignedBinaryBE(numBits, options)) {
+        // array; encoding/byte order are resolved once above and reused by the slow path below.
+        if (isByteAlignedWholeBytes(numBits, options)
+            && encoding instanceof EncodingUnsignedBinary
+            && byteOrder instanceof ByteOrderBigEndian) {
             return (int) readAlignedBytesBE(numBits);
         }
 
-        Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
-        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
             ensureAvailable(numBits);
             byte[] bytes = readBits(numBits);
-            bytes = getByteOrder(options).process(bytes);
+            bytes = byteOrder.process(bytes);
             return encodingDefault.decodeInt(numBits, bytes);
         } else if(encoding instanceof EncodingRaw encodingRaw) {
             return encodingRaw.decodeInt(numBits, this);
@@ -181,16 +191,19 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
             throw new BufferException("Unsigned long can only read between 1 and 63 bits");
         }
 
-        if (isFastUnsignedBinaryBE(numBits, options)) {
+        Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
+        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
+        ByteOrder byteOrder = getByteOrder(options);
+        if (isByteAlignedWholeBytes(numBits, options)
+            && encoding instanceof EncodingUnsignedBinary
+            && byteOrder instanceof ByteOrderBigEndian) {
             return readAlignedBytesBE(numBits);
         }
 
-        Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
-        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
             ensureAvailable(numBits);
             byte[] bytes = readBits(numBits);
-            bytes = getByteOrder(options).process(bytes);
+            bytes = byteOrder.process(bytes);
             return encodingDefault.decodeLong(numBits, bytes);
         } else if(encoding instanceof EncodingRaw encodingRaw) {
             return encodingRaw.decodeLong(numBits, this);
@@ -242,16 +255,19 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
             throw new BufferException("Signed short can only read between 1 and 16 bits");
         }
 
-        if (isFastSignedTwosComplementBE(numBits, options)) {
+        Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
+        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
+        ByteOrder byteOrder = getByteOrder(options);
+        if (isByteAlignedWholeBytes(numBits, options)
+            && encoding instanceof EncodingTwosComplement
+            && byteOrder instanceof ByteOrderBigEndian) {
             return (short) signExtend(readAlignedBytesBE(numBits), numBits);
         }
 
-        Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
-        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
             ensureAvailable(numBits);
             byte[] bytes = readBits(numBits);
-            bytes = getByteOrder(options).process(bytes);
+            bytes = byteOrder.process(bytes);
             return encodingDefault.decodeShort(numBits, bytes);
         } else if(encoding instanceof EncodingRaw encodingRaw) {
             return encodingRaw.decodeShort(numBits, this);
@@ -265,16 +281,19 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
             throw new BufferException("Signed int can only read between 1 and 32 bits");
         }
 
-        if (isFastSignedTwosComplementBE(numBits, options)) {
+        Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
+        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
+        ByteOrder byteOrder = getByteOrder(options);
+        if (isByteAlignedWholeBytes(numBits, options)
+            && encoding instanceof EncodingTwosComplement
+            && byteOrder instanceof ByteOrderBigEndian) {
             return (int) signExtend(readAlignedBytesBE(numBits), numBits);
         }
 
-        Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
-        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
             ensureAvailable(numBits);
             byte[] bytes = readBits(numBits);
-            bytes = getByteOrder(options).process(bytes);
+            bytes = byteOrder.process(bytes);
             return encodingDefault.decodeInt(numBits, bytes);
         } else if(encoding instanceof EncodingRaw encodingRaw) {
             return encodingRaw.decodeInt(numBits, this);
@@ -288,16 +307,19 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
             throw new BufferException("Signed long can only read between 1 and 64 bits");
         }
 
-        if (isFastSignedTwosComplementBE(numBits, options)) {
+        Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
+        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
+        ByteOrder byteOrder = getByteOrder(options);
+        if (isByteAlignedWholeBytes(numBits, options)
+            && encoding instanceof EncodingTwosComplement
+            && byteOrder instanceof ByteOrderBigEndian) {
             return signExtend(readAlignedBytesBE(numBits), numBits);
         }
 
-        Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
-        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
             ensureAvailable(numBits);
             byte[] bytes = readBits(numBits);
-            bytes = getByteOrder(options).process(bytes);
+            bytes = byteOrder.process(bytes);
             return encodingDefault.decodeLong(numBits, bytes);
         } else if(encoding instanceof EncodingRaw encodingRaw) {
             return encodingRaw.decodeLong(numBits, this);

--- a/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/ReadBufferByteBased.java
+++ b/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/ReadBufferByteBased.java
@@ -141,8 +141,8 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
         ByteOrder byteOrder = getByteOrder(options);
         if (isByteAlignedWholeBytes(numBits, options)
-            && encoding instanceof EncodingUnsignedBinary
-            && byteOrder instanceof ByteOrderBigEndian) {
+            && encoding.getClass() == EncodingUnsignedBinary.class
+            && byteOrder.getClass() == ByteOrderBigEndian.class) {
             return (short) readAlignedBytesBE(numBits);
         }
 
@@ -169,8 +169,8 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
         // Fast path: byte-aligned whole-byte plain-binary big-endian read straight from the backing
         // array; encoding/byte order are resolved once above and reused by the slow path below.
         if (isByteAlignedWholeBytes(numBits, options)
-            && encoding instanceof EncodingUnsignedBinary
-            && byteOrder instanceof ByteOrderBigEndian) {
+            && encoding.getClass() == EncodingUnsignedBinary.class
+            && byteOrder.getClass() == ByteOrderBigEndian.class) {
             return (int) readAlignedBytesBE(numBits);
         }
 
@@ -195,8 +195,8 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
         ByteOrder byteOrder = getByteOrder(options);
         if (isByteAlignedWholeBytes(numBits, options)
-            && encoding instanceof EncodingUnsignedBinary
-            && byteOrder instanceof ByteOrderBigEndian) {
+            && encoding.getClass() == EncodingUnsignedBinary.class
+            && byteOrder.getClass() == ByteOrderBigEndian.class) {
             return readAlignedBytesBE(numBits);
         }
 
@@ -259,8 +259,8 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
         ByteOrder byteOrder = getByteOrder(options);
         if (isByteAlignedWholeBytes(numBits, options)
-            && encoding instanceof EncodingTwosComplement
-            && byteOrder instanceof ByteOrderBigEndian) {
+            && encoding.getClass() == EncodingTwosComplement.class
+            && byteOrder.getClass() == ByteOrderBigEndian.class) {
             return (short) signExtend(readAlignedBytesBE(numBits), numBits);
         }
 
@@ -285,8 +285,8 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
         ByteOrder byteOrder = getByteOrder(options);
         if (isByteAlignedWholeBytes(numBits, options)
-            && encoding instanceof EncodingTwosComplement
-            && byteOrder instanceof ByteOrderBigEndian) {
+            && encoding.getClass() == EncodingTwosComplement.class
+            && byteOrder.getClass() == ByteOrderBigEndian.class) {
             return (int) signExtend(readAlignedBytesBE(numBits), numBits);
         }
 
@@ -311,8 +311,8 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
         ByteOrder byteOrder = getByteOrder(options);
         if (isByteAlignedWholeBytes(numBits, options)
-            && encoding instanceof EncodingTwosComplement
-            && byteOrder instanceof ByteOrderBigEndian) {
+            && encoding.getClass() == EncodingTwosComplement.class
+            && byteOrder.getClass() == ByteOrderBigEndian.class) {
             return signExtend(readAlignedBytesBE(numBits), numBits);
         }
 

--- a/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/ReadBufferByteBased.java
+++ b/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/ReadBufferByteBased.java
@@ -91,6 +91,23 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
         }
     }
 
+    /**
+     * Reads {@code numBits} (a whole number of bytes) big-endian from the current byte-aligned
+     * position into a long and advances the position. Callers gate this behind the fast-path
+     * eligibility checks; no intermediate byte[] or per-field ByteOrder object is allocated.
+     */
+    private long readAlignedBytesBE(int numBits) throws BufferException {
+        ensureAvailable(numBits);
+        int byteIndex = (startBit + positionInBits) / 8;
+        int numBytes = numBits / 8;
+        long v = 0;
+        for (int i = 0; i < numBytes; i++) {
+            v = (v << 8) | (buffer[byteIndex + i] & 0xFF);
+        }
+        positionInBits += numBits;
+        return v;
+    }
+
     @Override
     public byte readUnsignedByte(int numBits, WithOption... options) throws BufferException {
         if (numBits < 1 || numBits > 7) {
@@ -116,6 +133,10 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
             throw new BufferException("Unsigned short can only read between 1 and 15 bits");
         }
 
+        if (isFastUnsignedBinaryBE(numBits, options)) {
+            return (short) readAlignedBytesBE(numBits);
+        }
+
         Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
@@ -135,6 +156,12 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
             throw new BufferException("Unsigned int can only read between 1 and 31 bits");
         }
 
+        // Fast path: byte-aligned whole-byte plain-binary big-endian read straight from the backing
+        // array (no intermediate byte[] / ByteOrder object). See isFastUnsignedBinaryBE.
+        if (isFastUnsignedBinaryBE(numBits, options)) {
+            return (int) readAlignedBytesBE(numBits);
+        }
+
         Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
@@ -152,6 +179,10 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
     public long readUnsignedLong(int numBits, WithOption... options) throws BufferException {
         if (numBits < 1 || numBits > 63) {
             throw new BufferException("Unsigned long can only read between 1 and 63 bits");
+        }
+
+        if (isFastUnsignedBinaryBE(numBits, options)) {
+            return readAlignedBytesBE(numBits);
         }
 
         Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
@@ -211,6 +242,10 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
             throw new BufferException("Signed short can only read between 1 and 16 bits");
         }
 
+        if (isFastSignedTwosComplementBE(numBits, options)) {
+            return (short) signExtend(readAlignedBytesBE(numBits), numBits);
+        }
+
         Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
@@ -230,6 +265,10 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
             throw new BufferException("Signed int can only read between 1 and 32 bits");
         }
 
+        if (isFastSignedTwosComplementBE(numBits, options)) {
+            return (int) signExtend(readAlignedBytesBE(numBits), numBits);
+        }
+
         Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
@@ -247,6 +286,10 @@ public class ReadBufferByteBased extends AbstractBufferByteBased implements Read
     public long readSignedLong(int numBits, WithOption... options) throws BufferException {
         if (numBits < 1 || numBits > 64) {
             throw new BufferException("Signed long can only read between 1 and 64 bits");
+        }
+
+        if (isFastSignedTwosComplementBE(numBits, options)) {
+            return signExtend(readAlignedBytesBE(numBits), numBits);
         }
 
         Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);

--- a/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/WriteBufferByteBased.java
+++ b/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/WriteBufferByteBased.java
@@ -51,8 +51,12 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
     @Override
     public void writeBit(boolean value, WithOption... options) throws BufferException {
         ensureAvailable(1);
-        int byteIndex = positionInBits / 8;
-        int bitIndex = positionInBits % 8;
+        // Index by the ABSOLUTE bit position (startBit + positionInBits), like readBit and the
+        // whole-byte arraycopy path in writeBits — a buffer constructed with a non-zero startBit
+        // must not write from the start of the backing array.
+        int absoluteBitIndex = startBit + positionInBits;
+        int byteIndex = absoluteBitIndex / 8;
+        int bitIndex = absoluteBitIndex % 8;
         if (value) {
             buffer[byteIndex] |= (byte) (0x80 >> bitIndex);
         }
@@ -89,6 +93,9 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
      * Writes the low {@code numBits} (a whole number of bytes) of {@code value} big-endian into the
      * backing array at the current byte-aligned position and advances the position. Callers gate this
      * behind the fast-path eligibility checks; no intermediate byte[] or ByteOrder object is allocated.
+     * Unlike {@code readAlignedBytesBE} this method performs NO capacity check of its own — every
+     * caller invokes {@code ensureAvailable(numBits)} before the fast-path branch, and that call must
+     * not be removed as "redundant" with the slow path's.
      */
     private void writeAlignedBytesBE(int numBits, long value) {
         int byteIndex = (startBit + positionInBits) / 8;
@@ -142,9 +149,9 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
         ByteOrder byteOrder = getByteOrder(options);
         if (isByteAlignedWholeBytes(numBits, options)
-            && encoding instanceof EncodingUnsignedBinary
-            && byteOrder instanceof ByteOrderBigEndian) {
-            writeAlignedBytesBE(numBits, value & 0xFFFFL);
+            && encoding.getClass() == EncodingUnsignedBinary.class
+            && byteOrder.getClass() == ByteOrderBigEndian.class) {
+            writeAlignedBytesBE(numBits, value);
             return;
         }
 
@@ -179,8 +186,8 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         // Fast path: byte-aligned whole-byte plain-binary big-endian write straight into the backing
         // array; encoding/byte order are resolved once above and reused by the slow path below.
         if (isByteAlignedWholeBytes(numBits, options)
-            && encoding instanceof EncodingUnsignedBinary
-            && byteOrder instanceof ByteOrderBigEndian) {
+            && encoding.getClass() == EncodingUnsignedBinary.class
+            && byteOrder.getClass() == ByteOrderBigEndian.class) {
             writeAlignedBytesBE(numBits, value);
             return;
         }
@@ -214,8 +221,8 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
         ByteOrder byteOrder = getByteOrder(options);
         if (isByteAlignedWholeBytes(numBits, options)
-            && encoding instanceof EncodingUnsignedBinary
-            && byteOrder instanceof ByteOrderBigEndian) {
+            && encoding.getClass() == EncodingUnsignedBinary.class
+            && byteOrder.getClass() == ByteOrderBigEndian.class) {
             writeAlignedBytesBE(numBits, value);
             return;
         }
@@ -304,8 +311,8 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
         ByteOrder byteOrder = getByteOrder(options);
         if (isByteAlignedWholeBytes(numBits, options)
-            && encoding instanceof EncodingTwosComplement
-            && byteOrder instanceof ByteOrderBigEndian) {
+            && encoding.getClass() == EncodingTwosComplement.class
+            && byteOrder.getClass() == ByteOrderBigEndian.class) {
             writeAlignedBytesBE(numBits, value);
             return;
         }
@@ -340,8 +347,8 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
         ByteOrder byteOrder = getByteOrder(options);
         if (isByteAlignedWholeBytes(numBits, options)
-            && encoding instanceof EncodingTwosComplement
-            && byteOrder instanceof ByteOrderBigEndian) {
+            && encoding.getClass() == EncodingTwosComplement.class
+            && byteOrder.getClass() == ByteOrderBigEndian.class) {
             writeAlignedBytesBE(numBits, value);
             return;
         }
@@ -376,8 +383,8 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
         ByteOrder byteOrder = getByteOrder(options);
         if (isByteAlignedWholeBytes(numBits, options)
-            && encoding instanceof EncodingTwosComplement
-            && byteOrder instanceof ByteOrderBigEndian) {
+            && encoding.getClass() == EncodingTwosComplement.class
+            && byteOrder.getClass() == ByteOrderBigEndian.class) {
             writeAlignedBytesBE(numBits, value);
             return;
         }

--- a/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/WriteBufferByteBased.java
+++ b/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/WriteBufferByteBased.java
@@ -82,6 +82,20 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         }
     }
 
+    /**
+     * Writes the low {@code numBits} (a whole number of bytes) of {@code value} big-endian into the
+     * backing array at the current byte-aligned position and advances the position. Callers gate this
+     * behind the fast-path eligibility checks; no intermediate byte[] or ByteOrder object is allocated.
+     */
+    private void writeAlignedBytesBE(int numBits, long value) {
+        int byteIndex = (startBit + positionInBits) / 8;
+        int numBytes = numBits / 8;
+        for (int i = 0; i < numBytes; i++) {
+            buffer[byteIndex + i] = (byte) ((value >>> ((numBytes - 1 - i) * 8)) & 0xFF);
+        }
+        positionInBits += numBits;
+    }
+
     @Override
     public void writeUnsignedByte(int numBits, byte value, WithOption... options) throws BufferException {
         if (numBits < 1 || numBits > 7) {
@@ -121,6 +135,11 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         }
         ensureAvailable(numBits);
 
+        if (isFastUnsignedBinaryBE(numBits, options)) {
+            writeAlignedBytesBE(numBits, value & 0xFFFFL);
+            return;
+        }
+
         Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
@@ -148,6 +167,13 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         }
         ensureAvailable(numBits);
 
+        // Fast path: byte-aligned whole-byte plain-binary big-endian write straight into the backing
+        // array (no intermediate byte[] / ByteOrder object). See isFastUnsignedBinaryBE.
+        if (isFastUnsignedBinaryBE(numBits, options)) {
+            writeAlignedBytesBE(numBits, value);
+            return;
+        }
+
         Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
@@ -174,6 +200,11 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
             throw new BufferException("Value " + value + " is out of range for " + numBits + " bits. Valid range is 0 to " + maxValue);
         }
         ensureAvailable(numBits);
+
+        if (isFastUnsignedBinaryBE(numBits, options)) {
+            writeAlignedBytesBE(numBits, value);
+            return;
+        }
 
         Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
@@ -257,6 +288,11 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         }
         ensureAvailable(numBits);
 
+        if (isFastSignedTwosComplementBE(numBits, options)) {
+            writeAlignedBytesBE(numBits, value);
+            return;
+        }
+
         Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
@@ -285,6 +321,11 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         }
         ensureAvailable(numBits);
 
+        if (isFastSignedTwosComplementBE(numBits, options)) {
+            writeAlignedBytesBE(numBits, value);
+            return;
+        }
+
         Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
@@ -312,6 +353,11 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
             throw new BufferException("Value " + value + " is out of range for " + numBits + " bits. Valid range is " + minValue + " to " + maxValue);
         }
         ensureAvailable(numBits);
+
+        if (isFastSignedTwosComplementBE(numBits, options)) {
+            writeAlignedBytesBE(numBits, value);
+            return;
+        }
 
         Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
         Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));

--- a/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/WriteBufferByteBased.java
+++ b/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/WriteBufferByteBased.java
@@ -22,11 +22,14 @@ import org.apache.plc4x.java.spi.buffers.api.WithOption;
 import org.apache.plc4x.java.spi.buffers.api.WriteBuffer;
 import org.apache.plc4x.java.spi.buffers.api.exceptions.BufferException;
 import org.apache.plc4x.java.spi.buffers.bytebased.byteorder.ByteOrder;
+import org.apache.plc4x.java.spi.buffers.bytebased.byteorder.ByteOrderBigEndian;
 import org.apache.plc4x.java.spi.buffers.bytebased.byteorder.ByteOrderManager;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.Encoding;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingDefault;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingManager;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingRaw;
+import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingTwosComplement;
+import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingUnsignedBinary;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -135,17 +138,20 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         }
         ensureAvailable(numBits);
 
-        if (isFastUnsignedBinaryBE(numBits, options)) {
+        Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
+        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
+        ByteOrder byteOrder = getByteOrder(options);
+        if (isByteAlignedWholeBytes(numBits, options)
+            && encoding instanceof EncodingUnsignedBinary
+            && byteOrder instanceof ByteOrderBigEndian) {
             writeAlignedBytesBE(numBits, value & 0xFFFFL);
             return;
         }
 
-        Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
-        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
             ensureAvailable(numBits);
             byte[] bytes = encodingDefault.encodeShort(numBits, value);
-            bytes = getByteOrder(options).process(bytes);
+            bytes = byteOrder.process(bytes);
             writeBits(numBits, bytes);
         } else if(encoding instanceof EncodingRaw encodingRaw) {
             byte[] bytes = encodingRaw.encodeShort(numBits, value);
@@ -167,19 +173,22 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         }
         ensureAvailable(numBits);
 
+        Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
+        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
+        ByteOrder byteOrder = getByteOrder(options);
         // Fast path: byte-aligned whole-byte plain-binary big-endian write straight into the backing
-        // array (no intermediate byte[] / ByteOrder object). See isFastUnsignedBinaryBE.
-        if (isFastUnsignedBinaryBE(numBits, options)) {
+        // array; encoding/byte order are resolved once above and reused by the slow path below.
+        if (isByteAlignedWholeBytes(numBits, options)
+            && encoding instanceof EncodingUnsignedBinary
+            && byteOrder instanceof ByteOrderBigEndian) {
             writeAlignedBytesBE(numBits, value);
             return;
         }
 
-        Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
-        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
             ensureAvailable(numBits);
             byte[] bytes = encodingDefault.encodeInt(numBits, value);
-            bytes = getByteOrder(options).process(bytes);
+            bytes = byteOrder.process(bytes);
             writeBits(numBits, bytes);
         } else if(encoding instanceof EncodingRaw encodingRaw) {
             byte[] bytes = encodingRaw.encodeInt(numBits, value);
@@ -201,17 +210,20 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         }
         ensureAvailable(numBits);
 
-        if (isFastUnsignedBinaryBE(numBits, options)) {
+        Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
+        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
+        ByteOrder byteOrder = getByteOrder(options);
+        if (isByteAlignedWholeBytes(numBits, options)
+            && encoding instanceof EncodingUnsignedBinary
+            && byteOrder instanceof ByteOrderBigEndian) {
             writeAlignedBytesBE(numBits, value);
             return;
         }
 
-        Optional<Encoding> encodingOptional = getUnsignedIntegerEncoding(options);
-        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for unsigned integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
             ensureAvailable(numBits);
             byte[] bytes = encodingDefault.encodeLong(numBits, value);
-            bytes = getByteOrder(options).process(bytes);
+            bytes = byteOrder.process(bytes);
             writeBits(numBits, bytes);
         } else if(encoding instanceof EncodingRaw encodingRaw) {
             byte[] bytes = encodingRaw.encodeLong(numBits, value);
@@ -288,17 +300,20 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         }
         ensureAvailable(numBits);
 
-        if (isFastSignedTwosComplementBE(numBits, options)) {
+        Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
+        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
+        ByteOrder byteOrder = getByteOrder(options);
+        if (isByteAlignedWholeBytes(numBits, options)
+            && encoding instanceof EncodingTwosComplement
+            && byteOrder instanceof ByteOrderBigEndian) {
             writeAlignedBytesBE(numBits, value);
             return;
         }
 
-        Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
-        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
             ensureAvailable(numBits);
             byte[] bytes = encodingDefault.encodeShort(numBits, value);
-            bytes = getByteOrder(options).process(bytes);
+            bytes = byteOrder.process(bytes);
             writeBits(numBits, bytes);
         } else if(encoding instanceof EncodingRaw encodingRaw) {
             byte[] bytes = encodingRaw.encodeShort(numBits, value);
@@ -321,17 +336,20 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         }
         ensureAvailable(numBits);
 
-        if (isFastSignedTwosComplementBE(numBits, options)) {
+        Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
+        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
+        ByteOrder byteOrder = getByteOrder(options);
+        if (isByteAlignedWholeBytes(numBits, options)
+            && encoding instanceof EncodingTwosComplement
+            && byteOrder instanceof ByteOrderBigEndian) {
             writeAlignedBytesBE(numBits, value);
             return;
         }
 
-        Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
-        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
             ensureAvailable(numBits);
             byte[] bytes = encodingDefault.encodeInt(numBits, value);
-            bytes = getByteOrder(options).process(bytes);
+            bytes = byteOrder.process(bytes);
             writeBits(numBits, bytes);
         } else if(encoding instanceof EncodingRaw encodingRaw) {
             byte[] bytes = encodingRaw.encodeInt(numBits, value);
@@ -354,17 +372,20 @@ public class WriteBufferByteBased extends AbstractBufferByteBased implements Wri
         }
         ensureAvailable(numBits);
 
-        if (isFastSignedTwosComplementBE(numBits, options)) {
+        Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
+        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
+        ByteOrder byteOrder = getByteOrder(options);
+        if (isByteAlignedWholeBytes(numBits, options)
+            && encoding instanceof EncodingTwosComplement
+            && byteOrder instanceof ByteOrderBigEndian) {
             writeAlignedBytesBE(numBits, value);
             return;
         }
 
-        Optional<Encoding> encodingOptional = getSignedIntegerEncoding(options);
-        Encoding encoding = encodingOptional.orElseThrow(() -> new BufferException("No encoding defined for signed integer values"));
         if(encoding instanceof EncodingDefault encodingDefault) {
             ensureAvailable(numBits);
             byte[] bytes = encodingDefault.encodeLong(numBits, value);
-            bytes = getByteOrder(options).process(bytes);
+            bytes = byteOrder.process(bytes);
             writeBits(numBits, bytes);
         } else if(encoding instanceof EncodingRaw encodingRaw) {
             byte[] bytes = encodingRaw.encodeLong(numBits, value);

--- a/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/byteorder/ByteOrderBigEndian.java
+++ b/plc4j/spi/buffers/byte/src/main/java/org/apache/plc4x/java/spi/buffers/bytebased/byteorder/ByteOrderBigEndian.java
@@ -27,6 +27,9 @@ public class ByteOrderBigEndian implements ByteOrder {
 
     private static final WithOption OPTION = WithByteBasedOption.WithByteOrder(NAME);
 
+    /** Stateless (process() is the identity), so one shared instance is safe to reuse. */
+    public static final ByteOrderBigEndian INSTANCE = new ByteOrderBigEndian();
+
     public static WithOption optionByteOrderBigEndian() {
         return OPTION;
     }

--- a/plc4j/spi/buffers/byte/src/test/java/org/apache/plc4x/java/spi/buffers/bytebased/ReadBufferByteBasedTest.java
+++ b/plc4j/spi/buffers/byte/src/test/java/org/apache/plc4x/java/spi/buffers/bytebased/ReadBufferByteBasedTest.java
@@ -21,6 +21,7 @@ package org.apache.plc4x.java.spi.buffers.bytebased;
 import org.apache.plc4x.java.spi.buffers.api.exceptions.BufferException;
 import org.apache.plc4x.java.spi.buffers.bytebased.byteorder.ByteOrderBigEndian;
 import org.apache.plc4x.java.spi.buffers.bytebased.byteorder.ByteOrderLittleEndian;
+import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingBCD;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingIEEE754;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingTwosComplement;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingUTF8;
@@ -54,6 +55,38 @@ class ReadBufferByteBasedTest {
 
         assertEquals(8, buffer.getPositionInBits());
         assertEquals(0, buffer.getRemainingBits());
+    }
+
+    // Guards the byte-aligned unsigned-int fast path: a BCD default encoding must NOT be treated as
+    // plain binary. 0x12 0x34 decodes to 1234 (BCD), not 0x1234 = 4660 (binary shift).
+    @Test
+    void byteAlignedReadHonoursBcdEncodingNotBinaryFastPath() throws Exception {
+        byte[] data = {0x12, 0x34};
+        ReadBufferByteBased buffer = new ReadBufferByteBased(data, EncodingBCD.optionEncodingBCD());
+        assertEquals(1234, buffer.readUnsignedInt(16));
+    }
+
+    // The two's-complement byte-aligned fast path must sign-extend: 0xFFFE -> -2, not 65534.
+    @Test
+    void byteAlignedSignedReadIsSignExtended() throws Exception {
+        ReadBufferByteBased b1 = new ReadBufferByteBased(new byte[]{(byte) 0xFF, (byte) 0xFE},
+            EncodingTwosComplement.optionEncodingTwosComplement());
+        assertEquals((short) -2, b1.readSignedShort(16));
+        ReadBufferByteBased b2 = new ReadBufferByteBased(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFE},
+            EncodingTwosComplement.optionEncodingTwosComplement());
+        assertEquals(-2, b2.readSignedInt(32));
+    }
+
+    // Positive counterpart to the BCD guard: the plain unsigned-binary byte-aligned fast path must
+    // return the same value the slow path would. 0x12 0x34 -> 0x1234, 0x12 0x34 0x56 0x78 -> 0x12345678.
+    @Test
+    void byteAlignedUnsignedReadUsesFastPath() throws Exception {
+        ReadBufferByteBased b16 = new ReadBufferByteBased(new byte[]{0x12, 0x34},
+            EncodingUnsignedBinary.optionEncodingUnsignedBinary());
+        assertEquals(0x1234, b16.readUnsignedInt(16));
+        ReadBufferByteBased b32 = new ReadBufferByteBased(new byte[]{0x12, 0x34, 0x56, 0x78},
+            EncodingUnsignedBinary.optionEncodingUnsignedBinary());
+        assertEquals(0x12345678L, b32.readUnsignedLong(32));
     }
 
     // readBits

--- a/plc4j/spi/buffers/byte/src/test/java/org/apache/plc4x/java/spi/buffers/bytebased/ReadBufferByteBasedTest.java
+++ b/plc4j/spi/buffers/byte/src/test/java/org/apache/plc4x/java/spi/buffers/bytebased/ReadBufferByteBasedTest.java
@@ -89,6 +89,20 @@ class ReadBufferByteBasedTest {
         assertEquals(0x12345678L, b32.readUnsignedLong(32));
     }
 
+    // The fast path must key off the ABSOLUTE bit index (startBit + positionInBits), not
+    // positionInBits alone. A sub-buffer created at a non-byte-aligned offset has startBit % 8 != 0
+    // while its own positionInBits is 0; reading a whole-byte int must still land on the right bits.
+    // bits 4..19 of A1 23 45 = 0001 0010 0011 0100 = 0x1234 (NOT bytes 0..1 = 0xA123).
+    @Test
+    void byteAlignedFastPathRespectsNonByteAlignedSubBufferStartBit() throws Exception {
+        ReadBufferByteBased buffer = new ReadBufferByteBased(
+            new byte[]{(byte) 0xA1, 0x23, 0x45, 0x60},
+            EncodingUnsignedBinary.optionEncodingUnsignedBinary());
+        buffer.readUnsignedInt(4);                              // advance to absolute bit 4
+        ReadBufferByteBased sub = buffer.createSubBuffer(16);   // startBit = 4 (non-byte-aligned)
+        assertEquals(0x1234, sub.readUnsignedInt(16));
+    }
+
     // readBits
     @Test
     void testReadBitsNestedSubBufferUnaligned() throws Exception {

--- a/plc4j/spi/buffers/byte/src/test/java/org/apache/plc4x/java/spi/buffers/bytebased/WriteBufferByteBasedTest.java
+++ b/plc4j/spi/buffers/byte/src/test/java/org/apache/plc4x/java/spi/buffers/bytebased/WriteBufferByteBasedTest.java
@@ -86,6 +86,18 @@ class WriteBufferByteBasedTest {
         assertArrayEquals(new byte[]{0x12, 0x34, 0x56, 0x78}, b32.getBytes());
     }
 
+    // Mirror of the read-side sub-buffer regression: writes must honour a non-byte-aligned startBit.
+    // With startBit = 4 the position is not byte-aligned, so the write goes bit-by-bit; writeBit must
+    // index the backing array by the ABSOLUTE bit position (startBit + positionInBits), like readBit.
+    // 0x1234 into bits 4..19 of a zeroed 3-byte array = 0x01 0x23 0x40.
+    @Test
+    void writeHonoursNonByteAlignedStartBit() throws Exception {
+        WriteBufferByteBased buffer = new WriteBufferByteBased(new byte[3], 4, 16,
+            EncodingUnsignedBinary.optionEncodingUnsignedBinary());
+        buffer.writeUnsignedInt(16, 0x1234);
+        assertArrayEquals(new byte[]{0x01, 0x23, 0x40}, buffer.getBytes());
+    }
+
     // writeBits
     @Test
     void testWriteBitsNestedSubBufferUnaligned() throws Exception {

--- a/plc4j/spi/buffers/byte/src/test/java/org/apache/plc4x/java/spi/buffers/bytebased/WriteBufferByteBasedTest.java
+++ b/plc4j/spi/buffers/byte/src/test/java/org/apache/plc4x/java/spi/buffers/bytebased/WriteBufferByteBasedTest.java
@@ -22,6 +22,7 @@ import org.apache.plc4x.java.spi.buffers.api.WriteBuffer;
 import org.apache.plc4x.java.spi.buffers.api.exceptions.BufferException;
 import org.apache.plc4x.java.spi.buffers.bytebased.byteorder.ByteOrderBigEndian;
 import org.apache.plc4x.java.spi.buffers.bytebased.byteorder.ByteOrderLittleEndian;
+import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingBCD;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingIEEE754;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingTwosComplement;
 import org.apache.plc4x.java.spi.buffers.bytebased.encoding.EncodingUTF8;
@@ -54,6 +55,35 @@ class WriteBufferByteBasedTest {
 
         byte[] result = buffer.getBytes();
         assertEquals((byte) 0b10101100, result[0]);
+    }
+
+    // Guards the byte-aligned unsigned-int fast path: a BCD default encoding must NOT be treated as
+    // plain binary. 1234 must be BCD-encoded to 0x12 0x34, not binary 0x04 0xD2.
+    @Test
+    void byteAlignedWriteHonoursBcdEncodingNotBinaryFastPath() throws Exception {
+        WriteBufferByteBased buffer = new WriteBufferByteBased(new byte[2], EncodingBCD.optionEncodingBCD());
+        buffer.writeUnsignedInt(16, 1234);
+        assertArrayEquals(new byte[]{0x12, 0x34}, buffer.getBytes());
+    }
+
+    // The two's-complement byte-aligned fast path must emit two's complement: -2 -> 0xFF 0xFE.
+    @Test
+    void byteAlignedSignedWriteIsTwosComplement() throws Exception {
+        WriteBufferByteBased buffer = new WriteBufferByteBased(new byte[2], EncodingTwosComplement.optionEncodingTwosComplement());
+        buffer.writeSignedShort(16, (short) -2);
+        assertArrayEquals(new byte[]{(byte) 0xFF, (byte) 0xFE}, buffer.getBytes());
+    }
+
+    // Positive counterpart to the BCD guard: the plain unsigned-binary byte-aligned fast path must
+    // emit big-endian bytes. 0x1234 -> 0x12 0x34, 0x12345678 -> 0x12 0x34 0x56 0x78.
+    @Test
+    void byteAlignedUnsignedWriteUsesFastPath() throws Exception {
+        WriteBufferByteBased b16 = new WriteBufferByteBased(new byte[2], EncodingUnsignedBinary.optionEncodingUnsignedBinary());
+        b16.writeUnsignedInt(16, 0x1234);
+        assertArrayEquals(new byte[]{0x12, 0x34}, b16.getBytes());
+        WriteBufferByteBased b32 = new WriteBufferByteBased(new byte[4], EncodingUnsignedBinary.optionEncodingUnsignedBinary());
+        b32.writeUnsignedLong(32, 0x12345678L);
+        assertArrayEquals(new byte[]{0x12, 0x34, 0x56, 0x78}, b32.getBytes());
     }
 
     // writeBits


### PR DESCRIPTION
### What & why

The shared byte buffers in `plc4j/spi/buffers` sit on every driver's hottest path — every
primitive field of every message is read/written through them (~70+ files across `plc4j` — drivers,
spi, transports, test-utils — construct these byte buffers). Profiling a 32× `uint16` batch (a
typical Modbus/S7-style read) with JMH showed two avoidable costs per field:

1. the option-context stack was a `java.util.Stack` (a synchronized `Vector`), so every
   `getContext()` did a monitor enter/exit that guarded nothing; and
2. every whole-byte, byte-aligned integer field still went through the generic bit-by-bit path,
   allocating an intermediate `byte[]` and a fresh `ByteOrder` object per field.

This change removes both. Wire behaviour is preserved on every previously-correct path; the review
follow-ups below additionally fixed a pre-existing alignment bug for buffers and sub-buffers that
start at a non-byte-aligned bit position (which affected the whole-byte paths on `develop` too).

### Changes

- **`AbstractBuffer`** — use `ArrayDeque` for the option-context stack instead of `java.util.Stack`.
  A buffer is a single-threaded, per-message scratch object (`positionInBits` and the backing array
  are already unsynchronized), so `Stack`'s synchronization protected nothing here.
- **`ByteOrderBigEndian`** — expose a shared stateless `INSTANCE` and return it from `getByteOrder()`
  instead of allocating one per field (`process()` is the identity, so the instance is reusable).
- **`Read/WriteBufferByteBased`** (with shared guards + a `signExtend` helper in
  `AbstractBufferByteBased`) — add a zero-allocation fast path for whole-byte, byte-aligned,
  big-endian, plain-binary integer fields (unsigned and signed short/int/long) that reads/writes
  straight from the backing array. It is gated on the concrete `EncodingUnsignedBinary` /
  `EncodingTwosComplement` (not the broader `EncodingDefault`), so BCD / float / etc. fall through
  to the existing slow path unchanged.

### Benchmarks

JMH, JDK 21, 32× `uint16` batch, `-prof gc`:

| metric | improvement |
|---|---|
| read throughput | **~6.4× faster** |
| write throughput | **~5.6× faster** |
| allocation | **−38%** (~1944 → ~1200 B/msg) |

### Thread-safety

No regression. Buffers are per-message throwaway objects — no pooling, no static/`ThreadLocal`
sharing — and `positionInBits` / the backing array were already unsynchronized, so each buffer is
confined to a single thread for the duration of one message's parse/serialize. The `Stack`'s
synchronization was incidental, not an anti-interleaving guarantee: concurrent read/write requests
each get their own buffer. `ArrayDeque` is a drop-in — the code uses the context field only as a
LIFO stack via `push`/`pop`/`peek`/`isEmpty`/`size`, all of which behave identically, and never
iterates it or reads it by index.

### Binary compatibility

Changing `AbstractBuffer`'s `context` field type from `Stack` to `Deque` is source-compatible but
binary-incompatible for any subclass that reads the `protected context` field directly. Within the
repo exactly one class does so — `WriteBufferXmlBased` (`context.isEmpty()` / `context.size()`) —
and it compiles and recompiles cleanly against `Deque`; the other buffer subclasses
(`ReadBufferXmlBased`, the ascii-box and byte buffers) never touch the field. All three buffer
modules (`byte`, `xml`, `ascii-box`) recompile in a normal/CI build; only a stale incremental build
(Maven not recompiling the `xml` module after `api` changed), or an out-of-repo precompiled subclass
that reads `context`, would hit a `NoSuchFieldError`. Flagging it here for downstream awareness.

### Review follow-ups (commits after the initial review)

- **Absolute-bit alignment fix** — the fast-path guards (and, at root, `isAligned()`, which the
  pre-existing `readBits`/`writeBits` whole-byte arraycopy paths also use) tested only
  `positionInBits`, ignoring `startBit`; a sub-buffer created at a non-byte-aligned offset read/wrote
  the wrong bytes — on `develop` too. `isAligned()` now tests the absolute bit index, and `writeBit`
  (which ignored `startBit` entirely, unlike `readBit`) now indexes absolutely as well. Regression
  tests cover both directions.
- **Resolve-once** — encoding/byte order are resolved once per field and reused by both the fast-path
  eligibility check and the slow path (previously a non-eligible aligned field resolved them twice).
- **Exact-class gates** — the fast path is gated on `getClass() == EncodingUnsignedBinary.class` /
  `EncodingTwosComplement.class` / `ByteOrderBigEndian.class` rather than `instanceof`, so a codec
  subclass registered through the managers keeps its overridden (virtually-dispatched) slow-path
  behaviour instead of being silently bypassed.

### Testing

- Buffer unit tests green (Read 135, Write 116; 779 total in the buffers modules), including new
  regression tests: the unsigned byte-aligned fast path returns/emits the same value as the slow path
  (read & write), BCD-must-not-take-the-binary-fast-path (read & write), signed sign-extension /
  two's-complement (read & write), and the alignment fixes (a whole-byte read from a non-byte-aligned
  sub-buffer, and a write through a buffer constructed with a non-byte-aligned `startBit`).
- Modbus driver module test suite green (213 tests).

