### PR TITLE
(plc4j/eip): Optimize EipTcpConnection::toAnsi

### DIFF
--- a/plc4j/drivers/eip/src/main/java/org/apache/plc4x/java/eip/base/EipTcpConnection.java
+++ b/plc4j/drivers/eip/src/main/java/org/apache/plc4x/java/eip/base/EipTcpConnection.java
@@ -51,8 +51,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * EtherNet/IP (CIP encapsulation) TCP connection — direct port of the legacy
@@ -553,7 +551,7 @@ public class EipTcpConnection extends PollingSubscriptionConnectionBase<EIPConfi
             EipTag eipTag = (EipTag) request.getTag(tagName);
             CompletableFuture<Void> tagFuture = chain.thenComposeAsync(v -> executeThrottled(() -> {
                 try {
-                    CipReadRequest req = new CipReadRequest(toAnsi(eipTag.getTag()), elementCount(eipTag));
+                    CipReadRequest req = new CipReadRequest(toAnsi(eipTag), eipTag.getElementNb());
                     CipUnconnectedRequest requestItem = new CipUnconnectedRequest(
                         classSegment, instanceSegment, req,
                         (byte) getConfiguration().getBackplane(),
@@ -604,7 +602,7 @@ public class EipTcpConnection extends PollingSubscriptionConnectionBase<EIPConfi
         for (String tagName : sendableTagNames(request)) {
             EipTag eipTag = (EipTag) request.getTag(tagName);
             try {
-                requests.add(new CipReadRequest(toAnsi(eipTag.getTag()), elementCount(eipTag)));
+                requests.add(new CipReadRequest(toAnsi(eipTag), eipTag.getElementNb()));
             } catch (BufferException e) {
                 return CompletableFuture.failedFuture(new PlcRuntimeException("Failed to read field", e));
             }
@@ -647,7 +645,7 @@ public class EipTcpConnection extends PollingSubscriptionConnectionBase<EIPConfi
         for (String tagName : sendableTagNames(request)) {
             EipTag eipTag = (EipTag) request.getTag(tagName);
             try {
-                requests.add(new CipReadRequest(toAnsi(eipTag.getTag()), elementCount(eipTag)));
+                requests.add(new CipReadRequest(toAnsi(eipTag), eipTag.getElementNb()));
             } catch (BufferException e) {
                 return CompletableFuture.failedFuture(new PlcRuntimeException("Failed to read field", e));
             }
@@ -756,12 +754,11 @@ public class EipTcpConnection extends PollingSubscriptionConnectionBase<EIPConfi
         for (String fieldName : sendableTagNames(request)) {
             EipTag field = (EipTag) request.getTag(fieldName);
             PlcValue value = request.getPlcValue(fieldName);
-            int elements = Math.max(field.getElementNb(), 1);
             CompletableFuture<Void> tagFuture = chain.thenComposeAsync(v -> executeThrottled(() -> {
                 try {
                     byte[] data = encodeValue(value, field.getType());
                     CipWriteRequest writeReq = new CipWriteRequest(
-                        toAnsi(field.getTag()), field.getType(), elements, data);
+                        toAnsi(field), field.getType(), field.getElementNb(), data);
                     CipUnconnectedRequest requestItem = new CipUnconnectedRequest(
                         classSegment, instanceSegment, writeReq,
                         (byte) getConfiguration().getBackplane(),
@@ -806,10 +803,9 @@ public class EipTcpConnection extends PollingSubscriptionConnectionBase<EIPConfi
         for (String fieldName : sendableTagNames(request)) {
             EipTag field = (EipTag) request.getTag(fieldName);
             PlcValue value = request.getPlcValue(fieldName);
-            int elements = Math.max(field.getElementNb(), 1);
             byte[] data = encodeValue(value, field.getType());
             try {
-                items.add(new CipWriteRequest(toAnsi(field.getTag()), field.getType(), elements, data));
+                items.add(new CipWriteRequest(toAnsi(field), field.getType(), field.getElementNb(), data));
             } catch (BufferException e) {
                 return CompletableFuture.failedFuture(new PlcRuntimeException("Failed to write field", e));
             }
@@ -855,10 +851,9 @@ public class EipTcpConnection extends PollingSubscriptionConnectionBase<EIPConfi
         for (String fieldName : sendableTagNames(request)) {
             EipTag field = (EipTag) request.getTag(fieldName);
             PlcValue value = request.getPlcValue(fieldName);
-            int elements = Math.max(field.getElementNb(), 1);
             byte[] data = encodeValue(value, field.getType());
             try {
-                items.add(new CipWriteRequest(toAnsi(field.getTag()), field.getType(), elements, data));
+                items.add(new CipWriteRequest(toAnsi(field), field.getType(), field.getElementNb(), data));
             } catch (BufferException e) {
                 return CompletableFuture.failedFuture(new PlcRuntimeException("Failed to write field", e));
             }
@@ -905,24 +900,18 @@ public class EipTcpConnection extends PollingSubscriptionConnectionBase<EIPConfi
     // Encoders / decoders
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    private byte[] toAnsi(String tag) throws BufferException {
-        Pattern resourcePattern = Pattern.compile("([.\\[\\]])*([A-Za-z_0-9]+)");
-        Matcher matcher = resourcePattern.matcher(tag);
-        List<PathSegment> segments = new LinkedList<>();
+    private byte[] toAnsi(EipTag eipTag) throws BufferException {
         int lengthBytes = 0;
-        while (matcher.find()) {
-            String identifier = matcher.group(2);
-            String qualifier = matcher.group(1);
-            PathSegment newSegment;
-            if ("[".equals(qualifier)) {
-                newSegment = new LogicalSegment(new MemberID((byte) 0x00, Short.parseShort(identifier)));
-            } else {
-                newSegment = new DataSegment(new AnsiExtendedSymbolSegment(identifier,
-                    (identifier.length() % 2 == 0) ? null : (short) 0));
+        List<PathSegment> segments = new ArrayList<>(2);
+        PathSegment symbolSegment = new DataSegment(new AnsiExtendedSymbolSegment(eipTag.getTag(),
+            (eipTag.getTag().length() % 2 == 0) ? null : (short) 0));
+        segments.add(symbolSegment);
+        lengthBytes += symbolSegment.getLengthInBytes();
+        if (eipTag.getIndex() != null) {
+            PathSegment memberSegment = new LogicalSegment(new MemberID((byte) 0x00, eipTag.getIndex()));
+            lengthBytes += memberSegment.getLengthInBytes();
+            segments.add(memberSegment);
             }
-            segments.add(newSegment);
-            lengthBytes += newSegment.getLengthInBytes();
-        }
         WriteBufferByteBased buffer = messageCodec.createWriteBuffer(lengthBytes);
         for (PathSegment segment : segments) {
             segment.serialize(buffer);
@@ -1008,15 +997,6 @@ public class EipTcpConnection extends PollingSubscriptionConnectionBase<EIPConfi
         return values;
     }
 
-    /**
-     * Number of elements to ask the device for. An array tag ({@code %tag[0]:DINT:8}) has to
-     * request all of its elements - see GH-1008 - otherwise the device returns a single element
-     * and the decoder below has nothing to read the remaining ones from.
-     */
-    private static int elementCount(EipTag tag) {
-        return Math.max(tag.getElementNb(), 1);
-    }
-
     /** Whether the type is stored as a flat sequence of equally sized elements. */
     private static boolean isFixedSize(CIPDataTypeCode type) {
         return switch (type) {
@@ -1030,7 +1010,7 @@ public class EipTcpConnection extends PollingSubscriptionConnectionBase<EIPConfi
         final int STRING_LEN_OFFSET = 2;
         final int STRING_DATA_OFFSET = 6;
         ByteBuffer data = ByteBuffer.wrap(rawData).order(ByteOrder.LITTLE_ENDIAN);
-        int nb = elementCount(tag);
+        int nb = tag.getElementNb();
         if (nb > 1) {
             // Never read past what the device actually sent - a short reply must not blow up
             // the whole response with an IndexOutOfBoundsException. Only the fixed-size types

--- a/plc4j/drivers/eip/src/main/java/org/apache/plc4x/java/eip/base/tag/EipTag.java
+++ b/plc4j/drivers/eip/src/main/java/org/apache/plc4x/java/eip/base/tag/EipTag.java
@@ -36,47 +36,54 @@ import java.util.regex.Pattern;
 public class EipTag implements PlcTag, Serializable {
 
     private static final Pattern ADDRESS_PATTERN =
-        Pattern.compile("^(?<tag>[%a-zA-Z_.0-9]+\\[?[0-9]*]?):?(?<dataType>[A-Z]*):?(?<elementNb>[0-9]*)");
+        Pattern.compile("^(?<tag>[%a-zA-Z_.0-9]+)(\\[(?<index>[0-9]+)?])?:?(?<dataType>[A-Z]*):?(?<elementNb>[0-9]*)");
 
     private static final String GROUP_NAME_TAG = "tag";
-    private static final String GROUP_NAME_GROUP_NAME_ELEMENTS = "elementNb";
+    private static final String GROUP_NAME_INDEX = "index";
     private static final String GROUP_NAME_TYPE = "dataType";
+    private static final String GROUP_NAME_ELEMENTS = "elementNb";
 
     private final String tag;
-    private CIPDataTypeCode type;
-    private int elementNb;
+    private final Short index;
+    private final CIPDataTypeCode type;
+    private final int elementNb;
 
     public EipTag(String tag) {
-        this.tag = tag;
-        this.elementNb = 1;
+        this(tag, null, null, 1);
     }
 
     public EipTag(String tag, int elementNb) {
-        this.tag = tag;
-        this.elementNb = elementNb;
+        this(tag, null, null, elementNb);
     }
 
     public EipTag(String tag, CIPDataTypeCode type, int elementNb) {
-        this.tag = tag;
-        this.type = type;
-        this.elementNb = elementNb;
+        this(tag, null, type, elementNb);
     }
 
     public EipTag(String tag, CIPDataTypeCode type) {
+        this(tag, null, type, 1);
+    }
+
+    public EipTag(String tag, Short index, CIPDataTypeCode type, int elementNb) {
         this.tag = tag;
+        this.index = index != null ? (short)Math.max(0, index) : null;
         this.type = type;
+        this.elementNb = Math.max(1, elementNb);
     }
 
     @Override
     public String getAddressString() {
         // Mirrors the format ADDRESS_PATTERN accepts, so of(getAddressString()) round-trips:
-        //   tag[:dataType[:elementNb]]
+        //   tag[index]:dataType:elementNb
         StringBuilder sb = new StringBuilder(tag);
+        if (index != null) {
+            sb.append('[').append(index).append(']');
+        }
         if (type != null) {
             sb.append(':').append(type.name());
-            if (elementNb > 1) {
-                sb.append(':').append(elementNb);
-            }
+        }
+        if (elementNb > 1) {
+            sb.append(':').append(elementNb);
         }
         return sb.toString();
     }
@@ -95,20 +102,17 @@ public class EipTag implements PlcTag, Serializable {
         return type;
     }
 
-    public void setType(CIPDataTypeCode type) {
-        this.type = type;
-    }
 
     public int getElementNb() {
         return elementNb;
     }
 
-    public void setElementNb(int elementNb) {
-        this.elementNb = elementNb;
-    }
-
     public String getTag() {
         return tag;
+    }
+
+    public Short getIndex() {
+        return index;
     }
 
     public static boolean matches(String tagQuery) {
@@ -119,21 +123,16 @@ public class EipTag implements PlcTag, Serializable {
         Matcher matcher = ADDRESS_PATTERN.matcher(tagString);
         if (matcher.matches()) {
             String tag = matcher.group(GROUP_NAME_TAG);
-            int nb = 1;
-            CIPDataTypeCode type;
-            if (!matcher.group(GROUP_NAME_GROUP_NAME_ELEMENTS).isEmpty()) {
-                nb = Integer.parseInt(matcher.group(GROUP_NAME_GROUP_NAME_ELEMENTS));
-            }
-            if (!matcher.group(GROUP_NAME_TYPE).isEmpty()) {
-                type = CIPDataTypeCode.valueOf(matcher.group(GROUP_NAME_TYPE));
-            } else {
-                type = CIPDataTypeCode.DINT;
-            }
-            if (nb != 0) {
-                return new EipTag(tag, type, nb);
-            } else {
-                return new EipTag(tag, type);
-            }
+
+            String elementsString = matcher.group(GROUP_NAME_ELEMENTS);
+            int nb = elementsString.isEmpty() ? 1 : Integer.parseInt(elementsString);
+
+            String indexString = matcher.group(GROUP_NAME_INDEX);
+            Short index = indexString != null ? Short.parseShort(indexString) : null;
+
+            String typeString = matcher.group(GROUP_NAME_TYPE);
+            CIPDataTypeCode type = typeString.isEmpty() ? CIPDataTypeCode.DINT : CIPDataTypeCode.valueOf(typeString);
+            return new EipTag(tag, index, type, nb);
         }
         return null;
     }

--- a/plc4j/drivers/eip/src/test/java/org/apache/plc4x/java/eip/base/tag/EipTagCoverageTest.java
+++ b/plc4j/drivers/eip/src/test/java/org/apache/plc4x/java/eip/base/tag/EipTagCoverageTest.java
@@ -30,11 +30,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class EipTagCoverageTest {
 
     @Test
-    void singleArgCtorDefaultsElementsTo1AndLeavesTypeNull() {
+    void singleArgCtorDefaultsElementsTo1AndLeavesTypeAndIndexNull() {
         EipTag tag = new EipTag("%A0");
         assertThat(tag.getTag()).isEqualTo("%A0");
         assertThat(tag.getElementNb()).isEqualTo(1);
         assertThat(tag.getType()).isNull();
+        assertThat(tag.getIndex()).isNull();
     }
 
     @Test
@@ -42,15 +43,16 @@ class EipTagCoverageTest {
         EipTag tag = new EipTag("%A0", 4);
         assertThat(tag.getElementNb()).isEqualTo(4);
         assertThat(tag.getType()).isNull();
+        assertThat(tag.getIndex()).isNull();
     }
 
     @Test
     void ctorWithTypeOnly() {
         EipTag tag = new EipTag("%A0", CIPDataTypeCode.INT);
         assertThat(tag.getType()).isEqualTo(CIPDataTypeCode.INT);
-        // No element-count constructor → default int zero (not the 1 the
+        // No element-count constructor → default int 1
         // single-arg ctor injects). Lock the surface in place.
-        assertThat(tag.getElementNb()).isZero();
+        assertThat(tag.getElementNb()).isOne();
     }
 
     @Test
@@ -62,21 +64,13 @@ class EipTagCoverageTest {
     }
 
     @Test
-    void setTypeAndSetElementNbRoundtrip() {
-        EipTag tag = new EipTag("%A0");
-        tag.setType(CIPDataTypeCode.REAL);
-        tag.setElementNb(7);
-        assertThat(tag.getType()).isEqualTo(CIPDataTypeCode.REAL);
-        assertThat(tag.getElementNb()).isEqualTo(7);
-    }
-
-    @Test
     void ofParsesTagWithTypeAndElements() {
         EipTag tag = EipTag.of("MyVar:INT:5");
         assertThat(tag).isNotNull();
         assertThat(tag.getTag()).isEqualTo("MyVar");
         assertThat(tag.getType()).isEqualTo(CIPDataTypeCode.INT);
         assertThat(tag.getElementNb()).isEqualTo(5);
+        assertThat(tag.getIndex()).isNull();
     }
 
     @Test
@@ -85,14 +79,26 @@ class EipTagCoverageTest {
         assertThat(tag).isNotNull();
         assertThat(tag.getType()).isEqualTo(CIPDataTypeCode.DINT);
         assertThat(tag.getElementNb()).isEqualTo(2);
+        assertThat(tag.getIndex()).isNull();
+    }
+
+    @Test
+    void ofDefaultsDataTypeToDintAndElementNbTo1WhenMissing() {
+        EipTag tag = EipTag.of("%A0[1]");
+        assertThat(tag).isNotNull();
+        assertThat(tag.getTag()).isEqualTo("%A0");
+        assertThat(tag.getIndex()).isOne();
+        assertThat(tag.getType()).isEqualTo(CIPDataTypeCode.DINT);
+        assertThat(tag.getElementNb()).isEqualTo(1);
     }
 
     @Test
     void ofWithZeroElementsUsesTypeOnlyCtorPath() {
-        // elementNb=0 selects the (tag, type) constructor branch.
+        // elementNb=0 selects the minimum element value that is 1
         EipTag tag = EipTag.of("%A0:INT:0");
         assertThat(tag).isNotNull();
-        assertThat(tag.getElementNb()).isZero();
+        assertThat(tag.getIndex()).isNull();
+        assertThat(tag.getElementNb()).isOne();
         assertThat(tag.getType()).isEqualTo(CIPDataTypeCode.INT);
     }
 
@@ -111,11 +117,15 @@ class EipTagCoverageTest {
         assertThat(new EipTag("%A0").getAddressString()).isEqualTo("%A0");
         assertThat(new EipTag("%A0", CIPDataTypeCode.DINT).getAddressString()).isEqualTo("%A0:DINT");
         assertThat(new EipTag("%A0", CIPDataTypeCode.DINT, 8).getAddressString()).isEqualTo("%A0:DINT:8");
+        assertThat(new EipTag("%A0", (short)1, CIPDataTypeCode.DINT, 8).getAddressString()).isEqualTo("%A0[1]:DINT:8");
 
         // Whatever it renders has to parse back into an equivalent tag.
-        EipTag original = EipTag.of("%A0:DINT:8");
+        EipTag original = EipTag.of("%A0[1]:DINT:8");
+        assertThat(original).isNotNull();
         EipTag reparsed = EipTag.of(original.getAddressString());
+        assertThat(reparsed).isNotNull();
         assertThat(reparsed.getTag()).isEqualTo(original.getTag());
+        assertThat(reparsed.getIndex()).isEqualTo(original.getIndex());
         assertThat(reparsed.getType()).isEqualTo(original.getType());
         assertThat(reparsed.getElementNb()).isEqualTo(original.getElementNb());
     }

--- a/plc4j/drivers/eip/src/test/java/org/apache/plc4x/java/eip/base/tag/EipTagTest.java
+++ b/plc4j/drivers/eip/src/test/java/org/apache/plc4x/java/eip/base/tag/EipTagTest.java
@@ -42,19 +42,20 @@ public class EipTagTest {
      */
     @Test
     public void testDocumentedAddressForms() {
-        assertTag("myTag", "myTag", CIPDataTypeCode.DINT, 1);
-        assertTag("myTag:REAL", "myTag", CIPDataTypeCode.REAL, 1);
-        assertTag("myTag:4", "myTag", CIPDataTypeCode.DINT, 4);
-        assertTag("myArray[3]:DINT", "myArray[3]", CIPDataTypeCode.DINT, 1);
-        assertTag("myArray[0]:DINT:4", "myArray[0]", CIPDataTypeCode.DINT, 4);
+        assertTag("myTag", "myTag", null, CIPDataTypeCode.DINT, 1);
+        assertTag("myTag:REAL", "myTag", null, CIPDataTypeCode.REAL, 1);
+        assertTag("myTag:4", "myTag", null, CIPDataTypeCode.DINT, 4);
+        assertTag("myArray[3]:DINT", "myArray", (short)3, CIPDataTypeCode.DINT, 1);
+        assertTag("myArray[0]:DINT:4", "myArray", (short)0, CIPDataTypeCode.DINT, 4);
         // The '%' prefix is optional.
-        assertTag("%myTag:REAL", "%myTag", CIPDataTypeCode.REAL, 1);
+        assertTag("%myTag:REAL", "%myTag", null, CIPDataTypeCode.REAL, 1);
     }
 
-    private void assertTag(String address, String tag, CIPDataTypeCode type, int elementNb) {
+    private void assertTag(String address, String tag, Short index, CIPDataTypeCode type, int elementNb) {
         EipTag eipTag = EipTag.of(address);
         Assertions.assertNotNull(eipTag, address);
         Assertions.assertEquals(tag, eipTag.getTag(), address);
+        Assertions.assertEquals(index, eipTag.getIndex(), address);
         Assertions.assertEquals(type, eipTag.getType(), address);
         Assertions.assertEquals(elementNb, eipTag.getElementNb(), address);
     }


### PR DESCRIPTION
This PR remove the use of Pattern.compile from EipTcpConnection::toAnsi to optimize a method that is called for every request and for each tag address.

The part responsible for identifying the array index (CIP member) has been moved to the EipTag constructor. This avoids reprocessing the tag address on every request.

A simpler optimization would be to make the resourcePattern  static:

```java
static Pattern resourcePattern = Pattern.compile("([.\\[\\]])*([A-Za-z_0-9]+)");
```

However, this would still require processing the tag address on every request.

The pattern above also supports identifying more than one member, while EipTag.ADDRESS_PATTERN only allows a single index. Therefore, this difference has no impact on the new implementation.

EipTag is now immutable, which also makes it more suitable for future Valhalla optimizations.

Additionally, EipTag::getElementNb() is now enforced to be greater than 1, removing the need for the corresponding check in EipTcpConnection.

Moving the index identification to EipTag also has the additional benefit of making this information available for other use cases, such as DWORD-type processing.

The EipTag.type continues to be possible to be null but in case of passing null on constructor. Would it not be better to do it DINT?