### PR TITLE
docs: fix broken links in README and website documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The project is currently split up into three repositories, the `plc4x`, `plc4x-b
 To be able to build all parts of the `plc4x-extras` repository, at least `Java 21` is required.
 
 See the PLC4J user guide on the website to start using PLC4X in your Java application:
-[https://plc4x.apache.org/plc4x/latest/users/getting-started/plc4j.html](https://plc4x.apache.org/users/getting-started/plc4j.html)
+[https://plc4x.apache.org/plc4x/latest/users/getting-started/plc4j.html](https://plc4x.apache.org/plc4x/latest/users/getting-started/plc4j.html)
 
 ## Developers
 

--- a/plc4j/transports/cotp/README.md
+++ b/plc4j/transports/cotp/README.md
@@ -223,4 +223,4 @@ Log output includes:
 
 - RFC 1006: ISO Transport Service on top of the TCP
 - ISO 8073: Connection Oriented Transport Protocol
-- [COTP Protocol Specification](/protocols/cotp/src/main/resources/protocols/cotp/cotp.mspec)
+- [COTP Protocol Specification](../../../protocols/cotp/src/main/resources/protocols/cotp/cotp.mspec)

--- a/website/asciidoc/modules/developers/pages/code-gen/index.adoc
+++ b/website/asciidoc/modules/developers/pages/code-gen/index.adoc
@@ -60,7 +60,7 @@ These modules are also maintained in a link:https://github.com/apache/plc4x-buil
 
 This is generally only due to some restrictions in the Maven build system. If you are interested in understanding the reasons - please read the chapter on `Problems with Maven` near the end of this page.
 
-Concrete link:https://github.com/apache/plc4x/tree/develop/code-generation/protocol-base-mspec[protocol spec parsers], link:https://github.com/apache/plc4x/tree/develop/code-generation/language-base-freemarker[code generators] as well as link:https://github.com/apache/plc4x/tree/develop/code-generation/language-java[templates] that actually generate code are implemented in derived modules all located under the link:https://github.com/apache/plc4x/tree/develop/code-generation[code-generation] part of the main project repository.
+Concrete link:https://github.com/apache/plc4x/tree/develop/code-generation/protocol-base-mspec[protocol spec parsers], link:https://github.com/apache/plc4x/tree/develop/code-generation/language-base-freemarker[code generators] as well as link:https://github.com/apache/plc4x/tree/develop/code-generation/language/java[templates] that actually generate code are implemented in derived modules all located under the link:https://github.com/apache/plc4x/tree/develop/code-generation[code-generation] part of the main project repository.
 
 We didn't want to tie ourselves to only one way to specify protocols and to generate code. Generally multiple types of formats for specifying drivers are thinkable and the same way, multiple ways of generating code are possible. Currently, however we only have one parser: `MSpec` and one generator: `Freemarker`.
 

--- a/website/asciidoc/modules/users/pages/commercial-support.adoc
+++ b/website/asciidoc/modules/users/pages/commercial-support.adoc
@@ -46,7 +46,7 @@ Anyone who provides `Apache PLC4X` related services can be added to this list (e
 
 == How can I get added to this list?
 
-Please create a Pull-Request on GitHub as described https://plc4x.apache.org/latest/developers/contributing.html[here]. The resource requiring editing can be found https://github.com/apache/plc4x/blob/develop/website/asciidoc/modules/users/pages/commercial-support.adoc[here]
+Please create a Pull-Request on GitHub as described https://plc4x.apache.org/plc4x/latest/developers/contributing.html[here]. The resource requiring editing can be found https://github.com/apache/plc4x/blob/develop/website/asciidoc/modules/users/pages/commercial-support.adoc[here]
 
 When updating the table, please keep the alphabetical sort by company name.
 

--- a/website/asciidoc/modules/users/pages/download.adoc
+++ b/website/asciidoc/modules/users/pages/download.adoc
@@ -156,7 +156,7 @@ improved.
 - Core: Fixed several leaks of open threads.
 
 [#release-0_11_0]
-=== 0.11.0 Official https://archive.apache.org/dist/plc4x/0.11.0/apache-plc4x-0.11.0-source-release.zip[source release] [ https://downloads.apache.org/plc4x/0.11.0/apache-plc4x-0.11.0-source-release.zip.sha512[SHA512] ] [ https://downloads.apache.org/plc4x/0.11.0/apache-plc4x-0.10.0-source-release.zip.asc[ASC] ]
+=== 0.11.0 Official https://archive.apache.org/dist/plc4x/0.11.0/apache-plc4x-0.11.0-source-release.zip[source release] [ https://downloads.apache.org/plc4x/0.11.0/apache-plc4x-0.11.0-source-release.zip.sha512[SHA512] ] [ https://downloads.apache.org/plc4x/0.11.0/apache-plc4x-0.11.0-source-release.zip.asc[ASC] ]
 
 The APIs have been streamlined in a preparation for a hopefully soon 1.0.0 release.
 Many drivers have been re-implemented with much more features.


### PR DESCRIPTION
## Description

Fixes five broken links in the README and the website documentation. Every change is a link target only — no prose, no protocol semantics, nothing about how any driver behaves.

Each one is mechanically verifiable; the status codes below were taken with `curl -L` and can be reproduced in a few seconds.

| # | File | Problem | Old target | New target |
|---|---|---|---|---|
| 1 | `README.md:96` | Link text and href are swapped — the visible text is the correct URL, the actual href is the stale one | `404` | `200` |
| 2 | `website/.../users/pages/commercial-support.adoc:49` | Missing `/plc4x/` path segment | `404` | `200` |
| 3 | `website/.../users/pages/download.adoc:159` | `0.11.0` section links the `0.10.0` `.asc` filename | `404` | `200` |
| 4 | `website/.../developers/pages/code-gen/index.adoc:63` | `code-generation/language-java` was restructured to `code-generation/language/java` | `404` | `200` |
| 5 | `plc4j/transports/cotp/README.md:226` | Root-relative link resolves to `github.com/protocols/...` | `404` | file exists in repo |

### Details

**1.** `https://plc4x.apache.org/users/getting-started/plc4j.html` → 404. The `/plc4x/latest/` form shown as the link text → 200. Only the href changed; the rendered text is unchanged.

**2.** `https://plc4x.apache.org/latest/developers/contributing.html` → 404, `https://plc4x.apache.org/plc4x/latest/developers/contributing.html` → 200. This is the link telling people how to contribute, so it seemed worth fixing.

**3.** The `0.11.0` release entry links `apache-plc4x-0.10.0-source-release.zip.asc`:
- `.../plc4x/0.11.0/apache-plc4x-0.10.0-source-release.zip.asc` → **404**
- `.../plc4x/0.11.0/apache-plc4x-0.11.0-source-release.zip.asc` → **200**
- The SHA512 link on the same line already uses `0.11.0` → 200

The `0.10.0` entry at line 192 of the same file is written correctly, which is what the `0.11.0` entry now matches. This means the signature file for 0.11.0 is currently not reachable from the download page.

**4.** `tree/develop/code-generation/language-java` → 404; `tree/develop/code-generation/language/java` → 200. `ls code-generation/` on `develop` shows `language/`, `language-base-freemarker/`, `pom.xml`, `protocol-base-mspec/`, `protocol-test/`, with `language/` containing `c cs go java python`. The other two links in the same sentence (`protocol-base-mspec`, `language-base-freemarker`) still resolve and were left untouched.

**5.** The leading `/` makes GitHub resolve the link against the site root (`github.com/protocols/...` → 404) rather than the repository. The target file does exist at `protocols/cotp/src/main/resources/protocols/cotp/cotp.mspec`, so this uses a relative path from `plc4j/transports/cotp/`. This is the only root-relative link of its kind in the repository.

### Scope

I deliberately kept this to links whose correctness can be checked with an HTTP request or an `ls`. I also checked whether each problem occurs elsewhere: the version mismatch in `download.adoc` is the only one of its kind in that file, and the root-relative link in the COTP README is the only one in the repository.

I did not touch `website/asciidoc/modules/developers/pages/maturity.adoc`, which contains a number of stale `http://plc4x.apache.org/...` links — that file reads as a historical maturity assessment, so rewriting URLs in it looked like the wrong call for an outside contributor. Happy to follow up separately if you would like those updated.

_Disclosure: prepared with AI assistance. Every status code above was verified against the live sites, and every path was checked against `develop` at `5793ca7`._
