### PR TITLE
fix(plc4j/spi): RequestThrottle silently drops a limit reduction while requests are in flight

### DIFF
--- a/plc4j/spi/drivers/src/main/java/org/apache/plc4x/java/spi/drivers/throttle/RequestThrottle.java
+++ b/plc4j/spi/drivers/src/main/java/org/apache/plc4x/java/spi/drivers/throttle/RequestThrottle.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 /**
@@ -41,6 +42,10 @@ public class RequestThrottle {
     /** Requests waiting for a permit, started in the order they were submitted. */
     private final Queue<Runnable> pending = new ConcurrentLinkedQueue<>();
     private final AtomicBoolean draining = new AtomicBoolean();
+    /** Part of a reduction that could not be applied at once, settled as in-flight permits return. */
+    private final AtomicInteger permitDebt = new AtomicInteger();
+    /** Permits handed out to requests that have not returned them yet. */
+    private final AtomicInteger inFlight = new AtomicInteger();
 
     public RequestThrottle(int maxConcurrentRequests) {
         if (maxConcurrentRequests < 1) {
@@ -57,13 +62,29 @@ public class RequestThrottle {
      */
     public void acquire() throws InterruptedException {
         semaphore.acquire();
+        inFlight.incrementAndGet();
     }
 
     /**
      * Releases a permit previously acquired via {@link #acquire()}.
      */
     public void release() {
-        semaphore.release();
+        releasePermit();
+    }
+
+    /** Returns a permit to the pool, or retires it if a reduction is still outstanding. */
+    private void releasePermit() {
+        inFlight.decrementAndGet();
+        while (true) {
+            int debt = permitDebt.get();
+            if (debt == 0) {
+                semaphore.release();
+                return;
+            }
+            if (permitDebt.compareAndSet(debt, debt - 1)) {
+                return;
+            }
+        }
     }
 
     public <T> CompletableFuture<T> execute(Supplier<CompletableFuture<T>> requestSupplier) {
@@ -85,10 +106,11 @@ public class RequestThrottle {
             }
             try {
                 while (!pending.isEmpty() && semaphore.tryAcquire()) {
+                    inFlight.incrementAndGet();
                     Runnable request = pending.poll();
                     if (request == null) {
                         // Another thread took the entry between the check and the poll.
-                        semaphore.release();
+                        releasePermit();
                         break;
                     }
                     request.run();
@@ -124,7 +146,7 @@ public class RequestThrottle {
     }
 
     private void releaseAndDrain() {
-        semaphore.release();
+        releasePermit();
         drain();
     }
 
@@ -138,16 +160,34 @@ public class RequestThrottle {
 
         int difference = newMax - this.maxConcurrentRequests;
         if (difference > 0) {
-            semaphore.release(difference);
+            this.maxConcurrentRequests = newMax;
+            // Cancel any unsettled reduction first, otherwise it would be undone twice.
+            int cancelled = Math.min(difference, permitDebt.getAndUpdate(debt -> Math.max(0, debt - difference)));
+            int toRelease = difference - cancelled;
+            if (toRelease > 0) {
+                semaphore.release(toRelease);
+            }
             drain();
         } else {
-            int toDrain = Math.min(-difference, semaphore.availablePermits());
-            if (toDrain > 0) {
-                semaphore.acquireUninterruptibly(toDrain);
+            int toRemove = -difference;
+            // Only take what is free: waiting here would block under the monitor for permits that
+            // only the in-flight requests can return.
+            int removed = 0;
+            while ((removed < toRemove) && semaphore.tryAcquire()) {
+                removed++;
             }
+            if (removed < toRemove) {
+                permitDebt.addAndGet(toRemove - removed);
+            }
+            this.maxConcurrentRequests = newMax;
         }
-        this.maxConcurrentRequests = newMax;
-        LOGGER.info("Adjusted max concurrent requests to {}", newMax);
+        int unsettled = permitDebt.get();
+        if (unsettled > 0) {
+            LOGGER.info("Adjusted max concurrent requests to {}; {} permit(s) of the reduction are " +
+                "still held by in-flight requests and will be retired as those complete", newMax, unsettled);
+        } else {
+            LOGGER.info("Adjusted max concurrent requests to {}", newMax);
+        }
     }
 
     public int getAvailablePermits() {
@@ -158,8 +198,17 @@ public class RequestThrottle {
         return maxConcurrentRequests;
     }
 
+    /**
+     * Requests holding a permit right now. Directly after a reduction this may exceed
+     * {@link #getMaxConcurrentRequests()} until the running requests return their permits.
+     */
     public int getInFlightRequests() {
-        return maxConcurrentRequests - semaphore.availablePermits();
+        return inFlight.get();
+    }
+
+    /** Visible for testing. */
+    int getPermitDebt() {
+        return permitDebt.get();
     }
 
 }

--- a/plc4j/spi/drivers/src/test/java/org/apache/plc4x/java/spi/drivers/throttle/RequestThrottleTest.java
+++ b/plc4j/spi/drivers/src/test/java/org/apache/plc4x/java/spi/drivers/throttle/RequestThrottleTest.java
@@ -318,4 +318,306 @@ class RequestThrottleTest {
 
         assertEquals("ok", queued.get(5, TimeUnit.SECONDS));
     }
+
+    /**
+     * A reduction that cannot take permits back right away still has to take effect once the
+     * running requests return theirs.
+     */
+    @Test
+    void shrinkingWhileAllPermitsAreInFlightStillTakesEffect() {
+        RequestThrottle throttle = new RequestThrottle(2);
+        CompletableFuture<Void> first = new CompletableFuture<>();
+        CompletableFuture<Void> second = new CompletableFuture<>();
+        throttle.execute(() -> first);
+        throttle.execute(() -> second);
+        assertEquals(0, throttle.getAvailablePermits());
+
+        throttle.adjustMaxConcurrentRequests(1);
+
+        first.complete(null);
+        second.complete(null);
+
+        assertEquals(1, throttle.getMaxConcurrentRequests());
+        assertEquals(1, throttle.getAvailablePermits());
+        assertEquals(0, throttle.getInFlightRequests());
+    }
+
+    /**
+     * A limit reduced under load has to be enforced afterwards, not just reported.
+     */
+    @Test
+    void limitStaysEnforcedAfterShrinkingUnderLoad() {
+        RequestThrottle throttle = new RequestThrottle(2);
+        CompletableFuture<Void> first = new CompletableFuture<>();
+        CompletableFuture<Void> second = new CompletableFuture<>();
+        throttle.execute(() -> first);
+        throttle.execute(() -> second);
+
+        throttle.adjustMaxConcurrentRequests(1);
+        first.complete(null);
+        second.complete(null);
+
+        AtomicInteger started = new AtomicInteger();
+        for (int i = 0; i < 3; i++) {
+            throttle.execute(() -> {
+                started.incrementAndGet();
+                return new CompletableFuture<Void>();
+            });
+        }
+
+        assertEquals(1, started.get(), "only one request may run while the limit is 1");
+    }
+
+    /**
+     * In-flight tracking must not report a negative number of requests.
+     */
+    @Test
+    void inFlightCountNeverGoesNegative() {
+        RequestThrottle throttle = new RequestThrottle(2);
+        CompletableFuture<Void> first = new CompletableFuture<>();
+        CompletableFuture<Void> second = new CompletableFuture<>();
+        throttle.execute(() -> first);
+        throttle.execute(() -> second);
+
+        throttle.adjustMaxConcurrentRequests(1);
+        assertEquals(2, throttle.getInFlightRequests());
+
+        first.complete(null);
+        assertEquals(1, throttle.getInFlightRequests());
+
+        second.complete(null);
+        assertEquals(0, throttle.getInFlightRequests());
+    }
+
+    /**
+     * Shrinking under load and raising the limit again must not leave the pool over budget.
+     */
+    @Test
+    void shrinkingUnderLoadThenRaisingDoesNotInflateThePool() {
+        RequestThrottle throttle = new RequestThrottle(2);
+        CompletableFuture<Void> first = new CompletableFuture<>();
+        CompletableFuture<Void> second = new CompletableFuture<>();
+        throttle.execute(() -> first);
+        throttle.execute(() -> second);
+
+        throttle.adjustMaxConcurrentRequests(1);
+        throttle.adjustMaxConcurrentRequests(2);
+
+        first.complete(null);
+        second.complete(null);
+
+        assertEquals(2, throttle.getAvailablePermits());
+        assertEquals(0, throttle.getInFlightRequests());
+    }
+
+    /**
+     * Reducing runs under the instance monitor, so it cannot wait for in-flight permits. It has
+     * to hand the whole reduction over as debt and let the running requests settle it.
+     */
+    @Test
+    void shrinkingFromAnotherThreadWhileBusyAppliesTheWholeReduction() throws Exception {
+        RequestThrottle throttle = new RequestThrottle(4);
+        List<CompletableFuture<Void>> running = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            CompletableFuture<Void> blocker = new CompletableFuture<>();
+            running.add(blocker);
+            throttle.execute(() -> blocker);
+        }
+
+        CompletableFuture<Void> shrink = CompletableFuture.runAsync(() -> throttle.adjustMaxConcurrentRequests(1));
+        assertDoesNotThrow(() -> shrink.get(5, TimeUnit.SECONDS));
+
+        running.forEach(blocker -> blocker.complete(null));
+        assertEquals(1, throttle.getAvailablePermits());
+    }
+
+    /**
+     * Truncation is not limited to having no free permit: with 2 of 3 in flight and the limit
+     * dropping to 1, one permit is free and the second has to come out of a running request.
+     */
+    @Test
+    void partiallyApplicableReductionIsNotTruncated() {
+        RequestThrottle throttle = new RequestThrottle(3);
+        CompletableFuture<Void> first = new CompletableFuture<>();
+        CompletableFuture<Void> second = new CompletableFuture<>();
+        throttle.execute(() -> first);
+        throttle.execute(() -> second);
+        assertEquals(1, throttle.getAvailablePermits());
+
+        throttle.adjustMaxConcurrentRequests(1);
+        assertEquals(0, throttle.getAvailablePermits());
+        assertEquals(2, throttle.getInFlightRequests());
+
+        first.complete(null);
+        second.complete(null);
+
+        assertEquals(1, throttle.getMaxConcurrentRequests());
+        assertEquals(1, throttle.getAvailablePermits(), "the whole reduction has to be applied");
+        assertEquals(0, throttle.getInFlightRequests());
+    }
+
+    /**
+     * A queued request started from inside the adjustment must not observe a negative count.
+     */
+    @Test
+    void raisingTheLimitNeverReportsNegativeInFlight() {
+        RequestThrottle throttle = new RequestThrottle(1);
+        throttle.execute(() -> new CompletableFuture<>());
+
+        AtomicInteger observed = new AtomicInteger(Integer.MIN_VALUE);
+        throttle.execute(() -> {
+            observed.set(throttle.getInFlightRequests());
+            return new CompletableFuture<Void>();
+        });
+
+        throttle.adjustMaxConcurrentRequests(4);
+
+        assertTrue(observed.get() >= 0,
+            "in-flight count observed during the adjustment was " + observed.get());
+        assertTrue(throttle.getInFlightRequests() >= 0);
+    }
+
+    /**
+     * No sequence of adjustments may drive the reported in-flight count below zero.
+     */
+    @Test
+    void inFlightCountStaysNonNegativeAcrossAdjustments() {
+        RequestThrottle throttle = new RequestThrottle(4);
+        List<CompletableFuture<Void>> running = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            CompletableFuture<Void> blocker = new CompletableFuture<>();
+            running.add(blocker);
+            throttle.execute(() -> blocker);
+        }
+
+        for (int newMax : new int[]{1, 3, 2, 5, 1}) {
+            throttle.adjustMaxConcurrentRequests(newMax);
+            assertTrue(throttle.getInFlightRequests() >= 0,
+                "negative in-flight count after adjusting to " + newMax);
+        }
+        for (CompletableFuture<Void> blocker : running) {
+            blocker.complete(null);
+            assertTrue(throttle.getInFlightRequests() >= 0, "negative in-flight count while draining");
+        }
+
+        assertEquals(1, throttle.getMaxConcurrentRequests());
+        assertEquals(1, throttle.getAvailablePermits());
+        assertEquals(0, throttle.getInFlightRequests());
+    }
+
+    /**
+     * Every permit is either free, held by an in-flight request, or retired to settle a reduction.
+     */
+    private static void assertPermitsAccountedFor(RequestThrottle throttle) {
+        assertEquals(throttle.getMaxConcurrentRequests() + throttle.getPermitDebt(),
+            throttle.getAvailablePermits() + throttle.getInFlightRequests(),
+            "available + in-flight must equal max + outstanding reduction");
+        assertTrue(throttle.getInFlightRequests() >= 0, "in-flight count went negative");
+        assertTrue(throttle.getPermitDebt() >= 0, "permit debt went negative");
+    }
+
+    @Test
+    void permitsStayAccountedForWhileShrinkingUnderLoad() {
+        RequestThrottle throttle = new RequestThrottle(3);
+        assertPermitsAccountedFor(throttle);
+
+        List<CompletableFuture<Void>> running = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            CompletableFuture<Void> blocker = new CompletableFuture<>();
+            running.add(blocker);
+            throttle.execute(() -> blocker);
+            assertPermitsAccountedFor(throttle);
+        }
+
+        throttle.adjustMaxConcurrentRequests(1);
+        assertEquals(2, throttle.getPermitDebt());
+        assertPermitsAccountedFor(throttle);
+
+        for (CompletableFuture<Void> blocker : running) {
+            blocker.complete(null);
+            assertPermitsAccountedFor(throttle);
+        }
+
+        assertEquals(0, throttle.getPermitDebt());
+        assertEquals(1, throttle.getAvailablePermits());
+    }
+
+    /**
+     * Raising by less than the outstanding reduction only cancels part of it.
+     */
+    @Test
+    void raisingByLessThanTheOutstandingReductionOnlyCancelsPartOfIt() {
+        RequestThrottle throttle = new RequestThrottle(4);
+        List<CompletableFuture<Void>> running = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            CompletableFuture<Void> blocker = new CompletableFuture<>();
+            running.add(blocker);
+            throttle.execute(() -> blocker);
+        }
+
+        throttle.adjustMaxConcurrentRequests(1);
+        assertEquals(3, throttle.getPermitDebt());
+
+        throttle.adjustMaxConcurrentRequests(2);
+
+        assertEquals(2, throttle.getPermitDebt(), "one unit of the reduction is cancelled");
+        assertEquals(0, throttle.getAvailablePermits(), "nothing may be handed out yet");
+        assertPermitsAccountedFor(throttle);
+
+        running.forEach(blocker -> blocker.complete(null));
+        assertPermitsAccountedFor(throttle);
+        assertEquals(0, throttle.getPermitDebt());
+        assertEquals(2, throttle.getAvailablePermits());
+    }
+
+    /**
+     * Raising by more than the outstanding reduction cancels it and hands out the remainder.
+     */
+    @Test
+    void raisingByMoreThanTheOutstandingReductionHandsOutTheRemainder() {
+        RequestThrottle throttle = new RequestThrottle(2);
+        CompletableFuture<Void> first = new CompletableFuture<>();
+        CompletableFuture<Void> second = new CompletableFuture<>();
+        throttle.execute(() -> first);
+        throttle.execute(() -> second);
+
+        throttle.adjustMaxConcurrentRequests(1);
+        assertEquals(1, throttle.getPermitDebt());
+
+        throttle.adjustMaxConcurrentRequests(4);
+
+        assertEquals(0, throttle.getPermitDebt(), "the reduction is fully cancelled");
+        assertEquals(2, throttle.getAvailablePermits(), "only the remainder is handed out");
+        assertPermitsAccountedFor(throttle);
+
+        first.complete(null);
+        second.complete(null);
+        assertPermitsAccountedFor(throttle);
+        assertEquals(4, throttle.getAvailablePermits());
+        assertEquals(0, throttle.getInFlightRequests());
+    }
+
+    @Test
+    void permitsStayAccountedForAcrossAnAdjustmentSequence() {
+        RequestThrottle throttle = new RequestThrottle(4);
+        List<CompletableFuture<Void>> running = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            CompletableFuture<Void> blocker = new CompletableFuture<>();
+            running.add(blocker);
+            throttle.execute(() -> blocker);
+        }
+
+        for (int newMax : new int[]{1, 3, 2, 5, 1, 4}) {
+            throttle.adjustMaxConcurrentRequests(newMax);
+            assertPermitsAccountedFor(throttle);
+        }
+        for (CompletableFuture<Void> blocker : running) {
+            blocker.complete(null);
+            assertPermitsAccountedFor(throttle);
+        }
+
+        assertEquals(4, throttle.getMaxConcurrentRequests());
+        assertEquals(4, throttle.getAvailablePermits());
+        assertEquals(0, throttle.getInFlightRequests());
+    }
 }


### PR DESCRIPTION
`RequestThrottle.adjustMaxConcurrentRequests()` loses the part of a reduction it cannot apply while requests are in flight, leaving the throttle permanently above its configured limit. This change defers that part as a permit debt that is settled as the running requests complete.

## Problem

`adjustMaxConcurrentRequests()` took permits away with

    int toDrain = Math.min(-difference, semaphore.availablePermits());

and then updated `maxConcurrentRequests` unconditionally. A permit that is in flight cannot be taken back, so whenever more requests were running than the new limit allows, the clamped-away part of the reduction was silently discarded while the field claimed it had been applied. As the running requests returned their permits, the semaphore climbed back to the old count and stayed there: the throttle permanently allowed more concurrent requests than it was configured for, which is the one thing the class exists to prevent. Repeated adjustments compound it - shrinking under load and raising the limit again leaves the pool over budget for good.

This is not limited to the case where no permit is free. With 3 permits and 2 in flight, reducing to 1 takes the single free permit and drops the second; `getInFlightRequests()` then reports 1 while 2 requests are running, and -1 once they finish.

## Fix

The part of a reduction that cannot be applied immediately is remembered as a permit debt and settled out of the permits the running requests return, so the reduction takes effect as soon as it can instead of being lost. Raising the limit cancels outstanding debt before handing out new permits. The adjustment log line reports how much of a reduction is still outstanding.

Reducing no longer blocks. The old `acquireUninterruptibly()` could wait, under the instance monitor, for permits that only the in-flight requests could hand back, because `availablePermits()` may drop between the check and the call. Free permits are now taken with non-blocking `tryAcquire()`, and whatever is left becomes debt.

`getInFlightRequests()` now counts the permits handed out directly instead of deriving the number from the ceiling and the free permits. The derived value could read negative not only after a lost reduction but also while the limit was being raised, because the permits were released before the ceiling was updated. While a debt is outstanding the counter may temporarily exceed `getMaxConcurrentRequests()`; that is the number of requests actually running, and it settles as they complete.

## Tests

The 15 existing tests are unchanged and keep passing. The 8 added tests all fail without this change. A package-private `getPermitDebt()` exposes the outstanding debt to the tests.

## Reachability

`RequestThrottle` is a `final` field on `ConnectionBase`, so it outlives any number of `connect()` calls, and `connect()` has no re-entry guard: an application-driven reconnect re-runs S7's `SetupCommunication` and adjusts a throttle that is already serving traffic. No driver triggers this on its own today, so this is a latent defect rather than an observed production failure.

## Alternative considered

A larger change would drop the semaphore from the `execute()` path in favour of an `AtomicInteger` in-flight counter checked against a `volatile` maximum, which would make a reduction a plain assignment. That touches the public `acquire()`/`release()` pair - unused elsewhere in the tree, but public API - so it is left out of this change.